### PR TITLE
Add wasm support for both web and node environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { version = "1.0.108", optional = true, features = [
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
+serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2.95"
 
 [dependencies.webpki]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ futures = { version = "0.3", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2.95"
+serde_bytes = "0.11"
 
 [dependencies.webpki]
 version = "0.102.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures = { version = "0.3", optional = true }
 getrandom = { version = "0.2", optional = true, features = ["js"] }
 serde-wasm-bindgen = { version = "0.4", optional = true}
 wasm-bindgen = { version = "0.2.95", optional = true }
-serde_bytes = { version = "0.11", optional = true }
+serde_bytes = { version = "0.11" }
 
 [dependencies.webpki]
 version = "0.102.8"
@@ -81,4 +81,4 @@ std = [
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
-js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen", "serde_bytes"]
+js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ serde_json = { version = "1.0.108", optional = true, features = [
 ] }
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
-getrandom = { version = "0.2", features = ["js"] }
-serde-wasm-bindgen = "0.4"
-wasm-bindgen = "0.2.95"
-serde_bytes = "0.11"
+getrandom = { version = "0.2", optional = true, features = ["js"] }
+serde-wasm-bindgen = { version = "0.4", optional = true}
+wasm-bindgen = { version = "0.2.95", optional = true }
+serde_bytes = { version = "0.11", optional = true }
 
 [dependencies.webpki]
 version = "0.102.8"
@@ -81,4 +81,4 @@ std = [
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
-js = ["ring/wasm32_unknown_unknown_js"]
+js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen", "serde_bytes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = { version = "1.0.108", optional = true, features = [
 ] }
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
+getrandom = { version = "0.2", features = ["js"] }
 
 [dependencies.webpki]
 version = "0.102.7"
@@ -55,6 +56,9 @@ features = ["alloc", "ring"]
 [dev-dependencies]
 insta = "1"
 tokio = { version = "1", features = ["full"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["std", "report"]
@@ -74,3 +78,4 @@ std = [
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
+js = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { version = "1.0.108", optional = true, features = [
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "0.2.95"
 
 [dependencies.webpki]
 version = "0.102.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = { version = "0.4.20", default-features = false }
 
 anyhow = { version = "1", optional = true }
 
-ring = { version = "0.16.20", default-features = false, features = [
+ring = { version = "0.17", default-features = false, features = [
     "alloc",
 ] }
 reqwest = { version = "0.11.27", optional = true, default-features = false, features = [
@@ -80,4 +80,4 @@ std = [
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
-js = []
+js = ["ring/wasm32_unknown_unknown_js"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+WASM_PACK = wasm-pack
+INSTALL_TOOL = cargo install wasm-pack
+BUILD_WEB = $(WASM_PACK) build --release --target web --out-dir pkg/web --out-name dcap-qvl-web -- --features=js
+BUILD_NODE = $(WASM_PACK) build --release --target nodejs --out-dir pkg/node --out-name dcap-qvl-node -- --features=js
+
+all: install_wasm_tool build_web_js_api build_node_js_api
+
+install_wasm_tool:
+	@echo "Installing wasm-pack if not already installed..."
+	@if ! command -v $(WASM_PACK) &> /dev/null; then \
+		echo "wasm-pack not found, installing..."; \
+		$(INSTALL_TOOL); \
+	else \
+		echo "wasm-pack is already installed."; \
+	fi
+
+build_web_pkg: install_wasm_tool
+	@echo "Building for web browsers..."
+	$(BUILD_WEB)
+
+build_node_pkg: install_wasm_tool
+	@echo "Building for Node.js..."
+	$(BUILD_NODE)
+
+clean:
+	@echo "Cleaning up..."
+	rm -rf pkg
+
+.PHONY: all install_wasm_tool build_web_js_api build_node_js_api clean

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INSTALL_TOOL = cargo install wasm-pack
 BUILD_WEB = $(WASM_PACK) build --release --target web --out-dir pkg/web --out-name dcap-qvl-web -- --features=js
 BUILD_NODE = $(WASM_PACK) build --release --target nodejs --out-dir pkg/node --out-name dcap-qvl-node -- --features=js
 
-all: install_wasm_tool build_web_js_api build_node_js_api
+all: install_wasm_tool build_web_pkg build_node_pkg
 
 install_wasm_tool:
 	@echo "Installing wasm-pack if not already installed..."
@@ -26,4 +26,4 @@ clean:
 	@echo "Cleaning up..."
 	rm -rf pkg
 
-.PHONY: all install_wasm_tool build_web_js_api build_node_js_api clean
+.PHONY: all install_wasm_tool build_web_pkg build_node_pkg clean

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -29,6 +29,7 @@ fn get_header(resposne: &reqwest::Response, name: &str) -> Result<String> {
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
+#[cfg(not(feature = "js"))]
 pub async fn get_collateral(
     pccs_url: &str,
     mut quote: &[u8],

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -73,7 +73,6 @@ pub const ATTESTATION_KEY_LEN: usize = 64;
 pub const AUTHENTICATION_DATA_LEN: usize = 32;
 pub const QE_HASH_DATA_BYTE_LEN: usize = ATTESTATION_KEY_LEN + AUTHENTICATION_DATA_LEN;
 
-
 pub const PCK_ID_PLAIN: u16 = 1;
 pub const PCK_ID_RSA_2048_OAEP: u16 = 2;
 pub const PCK_ID_RSA_3072_OAEP: u16 = 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,10 @@ extern crate alloc;
 
 use scale::{Decode, Encode};
 use scale_info::TypeInfo;
+use wasm_bindgen::prelude::*;
 
 #[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq, Eq)]
+#[wasm_bindgen]
 pub enum Error {
     InvalidCertificate,
     InvalidSignature,
@@ -76,6 +78,7 @@ pub enum Error {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+#[wasm_bindgen]
 pub struct QuoteCollateralV3 {
     pub pck_crl_issuer_chain: String,
     pub root_ca_crl: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,9 @@ extern crate alloc;
 
 use scale::{Decode, Encode};
 use scale_info::TypeInfo;
-use wasm_bindgen::prelude::*;
+use serde::{Deserialize, Serialize};
 
-#[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq, Eq)]
-#[wasm_bindgen]
+#[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Error {
     InvalidCertificate,
     InvalidSignature,
@@ -77,8 +76,7 @@ pub enum Error {
     OidIsMissing,
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
-#[wasm_bindgen]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct QuoteCollateralV3 {
     pub pck_crl_issuer_chain: String,
     pub root_ca_crl: String,

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -44,44 +44,70 @@ pub struct Body {
 
 #[derive(Serialize, Deserialize, Decode, Debug, Clone)]
 pub struct EnclaveReport {
+    #[serde(with = "serde_bytes")]
     pub cpu_svn: [u8; 16],
     pub misc_select: u32,
+    #[serde(with = "serde_bytes")]
     pub reserved1: [u8; 28],
+    #[serde(with = "serde_bytes")]
     pub attributes: [u8; 16],
+    #[serde(with = "serde_bytes")]
     pub mr_enclave: [u8; 32],
+    #[serde(with = "serde_bytes")]
     pub reserved2: [u8; 32],
+    #[serde(with = "serde_bytes")]
     pub mr_signer: [u8; 32],
-    pub reserved3: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub reserved3: [u8; 96],
     pub isv_prod_id: u16,
     pub isv_svn: u16,
-    pub reserved4: [u8; 32],
-    pub report_data: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub reserved4: [u8; 60],
+    #[serde(with = "serde_bytes")]
+    pub report_data: [u8; 64],
 }
 
 #[derive(Decode, Debug, Clone, Serialize, Deserialize)]
 pub struct TDReport10 {
+    #[serde(with = "serde_bytes")]
     pub tee_tcb_svn: [u8; 16],
-    pub mr_seam: [u8; 32],
-    pub mr_signer_seam: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub mr_seam: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub mr_signer_seam: [u8; 48],
+    #[serde(with = "serde_bytes")]
     pub seam_attributes: [u8; 8],
+    #[serde(with = "serde_bytes")]
     pub td_attributes: [u8; 8],
+    #[serde(with = "serde_bytes")]
     pub xfam: [u8; 8],
-    pub mr_td: [u8; 32],
-    pub mr_config_id: [u8; 32],
-    pub mr_owner: [u8; 32],
-    pub mr_owner_config: [u8; 32],
-    pub rt_mr0: [u8; 32],
-    pub rt_mr1: [u8; 32],
-    pub rt_mr2: [u8; 32],
-    pub rt_mr3: [u8; 32],
-    pub report_data: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub mr_td: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub mr_config_id: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub mr_owner: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub mr_owner_config: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub rt_mr0: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub rt_mr1: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub rt_mr2: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub rt_mr3: [u8; 48],
+    #[serde(with = "serde_bytes")]
+    pub report_data: [u8; 64],
 }
 
 #[derive(Decode, Debug, Clone, Serialize, Deserialize)]
 pub struct TDReport15 {
     pub base: TDReport10,
+    #[serde(with = "serde_bytes")]
     pub tee_tcb_svn2: [u8; 16],
-    pub mr_service_td: [u8; 32],
+    #[serde(with = "serde_bytes")]
+    pub mr_service_td: [u8; 48],
 }
 
 #[derive(Decode)]

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use anyhow::Result;
 use scale::{Decode, Input};
-use wasm_bindgen::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{constants::*, utils, Error};
 
@@ -42,8 +42,7 @@ pub struct Body {
     pub size: u32,
 }
 
-#[wasm_bindgen]
-#[derive(Decode, Debug, Clone)]
+#[derive(Serialize, Deserialize, Decode, Debug, Clone)]
 pub struct EnclaveReport {
     pub cpu_svn: [u8; 16],
     pub misc_select: u32,
@@ -52,37 +51,37 @@ pub struct EnclaveReport {
     pub mr_enclave: [u8; 32],
     pub reserved2: [u8; 32],
     pub mr_signer: [u8; 32],
-    pub reserved3: [u8; 96],
+    pub reserved3: [u8; 32],
     pub isv_prod_id: u16,
     pub isv_svn: u16,
-    pub reserved4: [u8; 60],
-    pub report_data: [u8; 64],
+    pub reserved4: [u8; 32],
+    pub report_data: [u8; 32],
 }
 
-#[derive(Decode, Debug, Clone)]
+#[derive(Decode, Debug, Clone, Serialize, Deserialize)]
 pub struct TDReport10 {
     pub tee_tcb_svn: [u8; 16],
-    pub mr_seam: [u8; 48],
-    pub mr_signer_seam: [u8; 48],
+    pub mr_seam: [u8; 32],
+    pub mr_signer_seam: [u8; 32],
     pub seam_attributes: [u8; 8],
     pub td_attributes: [u8; 8],
     pub xfam: [u8; 8],
-    pub mr_td: [u8; 48],
-    pub mr_config_id: [u8; 48],
-    pub mr_owner: [u8; 48],
-    pub mr_owner_config: [u8; 48],
-    pub rt_mr0: [u8; 48],
-    pub rt_mr1: [u8; 48],
-    pub rt_mr2: [u8; 48],
-    pub rt_mr3: [u8; 48],
-    pub report_data: [u8; 64],
+    pub mr_td: [u8; 32],
+    pub mr_config_id: [u8; 32],
+    pub mr_owner: [u8; 32],
+    pub mr_owner_config: [u8; 32],
+    pub rt_mr0: [u8; 32],
+    pub rt_mr1: [u8; 32],
+    pub rt_mr2: [u8; 32],
+    pub rt_mr3: [u8; 32],
+    pub report_data: [u8; 32],
 }
 
-#[derive(Decode, Debug, Clone)]
+#[derive(Decode, Debug, Clone, Serialize, Deserialize)]
 pub struct TDReport15 {
     pub base: TDReport10,
     pub tee_tcb_svn2: [u8; 16],
-    pub mr_service_td: [u8; 48],
+    pub mr_service_td: [u8; 32],
 }
 
 #[derive(Decode)]
@@ -185,8 +184,7 @@ fn decode_auth_data(ver: u16, input: &mut &[u8]) -> Result<AuthData, scale::Erro
     }
 }
 
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Report {
     SgxEnclave(EnclaveReport),
     TD10(TDReport10),

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use anyhow::Result;
 use scale::{Decode, Input};
+use wasm_bindgen::prelude::*;
 
 use crate::{constants::*, utils, Error};
 
@@ -41,6 +42,7 @@ pub struct Body {
     pub size: u32,
 }
 
+#[wasm_bindgen]
 #[derive(Decode, Debug, Clone)]
 pub struct EnclaveReport {
     pub cpu_svn: [u8; 16],
@@ -183,6 +185,7 @@ fn decode_auth_data(ver: u16, input: &mut &[u8]) -> Result<AuthData, scale::Erro
     }
 }
 
+#[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub enum Report {
     SgxEnclave(EnclaveReport),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -21,6 +21,7 @@ pub struct VerifiedReport {
     pub report: Report,
 }
 
+#[cfg(feature = "js")]
 #[wasm_bindgen]
 pub fn js_verify(
     raw_quote: JsValue,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -11,10 +11,10 @@ use crate::{
     utils::{self, encode_as_der, extract_certs, verify_certificate_chain},
 };
 use crate::{Error, QuoteCollateralV3};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-#[derive(Debug, Clone)]
-#[wasm_bindgen(getter_with_clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VerifiedReport {
     pub status: String,
     pub advisory_ids: Vec<String>,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -12,6 +12,8 @@ use crate::{
 };
 use crate::{Error, QuoteCollateralV3};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -11,8 +11,10 @@ use crate::{
     utils::{self, encode_as_der, extract_certs, verify_certificate_chain},
 };
 use crate::{Error, QuoteCollateralV3};
+use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone)]
+#[wasm_bindgen(getter_with_clone)]
 pub struct VerifiedReport {
     pub status: String,
     pub advisory_ids: Vec<String>,
@@ -31,6 +33,7 @@ pub struct VerifiedReport {
 ///
 /// * `Ok(VerifiedReport)` - The verified report
 /// * `Err(Error)` - The error
+#[wasm_bindgen]
 pub fn verify(
     raw_quote: &[u8],
     quote_collateral: &QuoteCollateralV3,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -29,8 +29,10 @@ pub fn js_verify(
 ) -> Result<JsValue, JsValue> {
     let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
         .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
-    let quote_collateral: QuoteCollateralV3 = serde_wasm_bindgen::from_value(quote_collateral)
+    let quote_collateral_bytes: Vec<u8> = serde_wasm_bindgen::from_value(quote_collateral)
         .map_err(|_| JsValue::from_str("Failed to decode quote_collateral"))?;
+    let quote_collateral = QuoteCollateralV3::decode(&mut quote_collateral_bytes.as_slice())
+        .map_err(|_| JsValue::from_str("Failed to decode quote_collateral_bytes"))?;
 
     let verified_report = verify(&raw_quote, &quote_collateral, now).map_err(|e| {
         serde_wasm_bindgen::to_value(&e)

--- a/tests/js/.gitignore
+++ b/tests/js/.gitignore
@@ -1,0 +1,2 @@
+pkg
+sample

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -4,7 +4,7 @@
 
 ```
 cd tests/js
-node verify_quote.js
+node verify_quote_node.js
 ```
 
 ## Verify Quote with Web

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,0 +1,19 @@
+# Test the JS bindings
+
+## Verify Quote with Node
+
+```
+cd tests/js
+node verify_quote.js
+```
+
+## Verify Quote with Web
+
+```
+cd tests/js
+ln -sf ../../pkg pkg
+ln -sf ../../sample sample
+python3 -m http.server 8000
+```
+
+Open http://localhost:8000/index.html in browser, and check the console for the result.

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verify Quote</title>
+</head>
+<body>
+    <h1>Verify Quote</h1>
+    <script type="module" src="./verify_quote_web.js"></script>
+</body>
+</html>

--- a/tests/js/verify_quote_node.js
+++ b/tests/js/verify_quote_node.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { js_verify } = require('../pkg/node/dcap-qvl-node');
+const { js_verify } = require('../../pkg/node/dcap-qvl-node');
 
 // Function to read a file as a Uint8Array
 function readFileAsUint8Array(filePath) {
@@ -9,12 +9,11 @@ function readFileAsUint8Array(filePath) {
 }
 
 // Paths to your sample files
-const rawQuotePath = path.join(__dirname, '../sample', 'tdx_quote');
-const quoteCollateralPath = path.join(__dirname, '../sample', 'tdx_quote_collateral');
+const rawQuotePath = path.join(__dirname, '../../sample', 'tdx_quote');
+const quoteCollateralPath = path.join(__dirname, '../../sample', 'tdx_quote_collateral');
 
 // Read the files
 const rawQuote = readFileAsUint8Array(rawQuotePath);
-console.log("rawQuote: ", rawQuote);
 const quoteCollateral = readFileAsUint8Array(quoteCollateralPath);
 
 // Current timestamp

--- a/tests/js/verify_quote_web.js
+++ b/tests/js/verify_quote_web.js
@@ -1,0 +1,36 @@
+import init, { js_verify } from '/pkg/web/dcap-qvl-web.js';
+
+// Function to fetch a file as a Uint8Array
+async function fetchFileAsUint8Array(url) {
+    const response = await fetch(url);
+    const data = await response.arrayBuffer();
+    return new Uint8Array(data);
+}
+
+// URLs to your sample files
+const rawQuoteUrl = '/sample/tdx_quote';
+const quoteCollateralUrl = '/sample/tdx_quote_collateral';
+
+// Load the files
+async function loadFilesAndVerify() {
+    try {
+        // Initialize the WASM module
+        await init('/pkg/web/dcap-qvl-web_bg.wasm');
+
+        const rawQuote = await fetchFileAsUint8Array(rawQuoteUrl);
+        const quoteCollateral = await fetchFileAsUint8Array(quoteCollateralUrl);
+
+        // Current timestamp
+        const now = BigInt(1725258675);
+
+        // Call the js_verify function
+        const result = js_verify(rawQuote, quoteCollateral, now);
+        console.log('Verification Result:', result);
+    } catch (error) {
+        console.error('Verification failed:', error);
+    }
+}
+
+// Execute the verification
+loadFilesAndVerify();
+

--- a/tests/verify_quote.js
+++ b/tests/verify_quote.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { js_verify } = require('../pkg/node/dcap-qvl-node');
+
+// Function to read a file as a Uint8Array
+function readFileAsUint8Array(filePath) {
+    const data = fs.readFileSync(filePath);
+    return new Uint8Array(data);
+}
+
+// Paths to your sample files
+const rawQuotePath = path.join(__dirname, '../sample', 'tdx_quote');
+const quoteCollateralPath = path.join(__dirname, '../sample', 'tdx_quote_collateral');
+
+// Read the files
+const rawQuote = readFileAsUint8Array(rawQuotePath);
+console.log("rawQuote: ", rawQuote);
+const quoteCollateral = readFileAsUint8Array(quoteCollateralPath);
+
+// Current timestamp
+// TCBInfoExpired when using current timestamp, pick the time from verify_quote.rs
+// const now = BigInt(Math.floor(Date.now() / 1000));
+const now = BigInt(1725258675);
+
+try {
+    // Call the js_verify function
+    const result = js_verify(rawQuote, quoteCollateral, now);
+    console.log('Verification Result:', result);
+} catch (error) {
+    console.error('Verification failed:', error);
+}


### PR DESCRIPTION
This is PR is going to adding wasm support for both web and node envrionment by compile the library to `wasm-unknow-unknown` target.
Note that `js` feature should be enabled and due to tls not been supportted by WASM, `get_collateral` will be disabled at the time

- [x] Build to specific target JS packages
- [x] Test JS packages in both web and node env