### PR TITLE
Removes the timeout arg

### DIFF
--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -127,29 +127,16 @@ fn extract_crl_url(cert_der: &[u8]) -> Result<Option<String>> {
 ///
 /// * `pccs_url` - The base URL of PCCS server. (e.g. `https://pccs.example.com/sgx/certification/v4`)
 /// * `quote` - The raw quote to verify. Supported SGX and TDX quotes.
-/// * `timeout` - The timeout for the request. (e.g. `Duration::from_secs(10)`)
 ///
 /// # Returns
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
-pub async fn get_collateral(
-    pccs_url: &str,
-    mut quote: &[u8],
-    #[cfg(not(feature = "js"))] timeout: Duration,
-) -> Result<QuoteCollateralV3> {
+pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCollateralV3> {
     let quote = Quote::decode(&mut quote)?;
     let ca = quote.ca().context("Failed to get CA")?;
     let fmspc = hex::encode_upper(quote.fmspc().context("Failed to get FMSPC")?);
-    get_collateral_for_fmspc(
-        pccs_url,
-        fmspc,
-        ca,
-        quote.header.is_sgx(),
-        #[cfg(not(feature = "js"))]
-        timeout,
-    )
-    .await
+    get_collateral_for_fmspc(pccs_url, fmspc, ca, quote.header.is_sgx()).await
 }
 
 pub async fn get_collateral_for_fmspc(
@@ -157,11 +144,12 @@ pub async fn get_collateral_for_fmspc(
     fmspc: String,
     ca: &'static str,
     for_sgx: bool,
-    #[cfg(not(feature = "js"))] timeout: Duration,
 ) -> Result<QuoteCollateralV3> {
     let builder = reqwest::Client::builder();
     #[cfg(not(feature = "js"))]
-    let builder = builder.danger_accept_invalid_certs(true).timeout(timeout);
+    let builder = builder
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(180));
     let client = builder.build()?;
 
     let endpoints = PcsEndpoints::new(pccs_url, for_sgx, fmspc, ca);
@@ -265,23 +253,13 @@ pub async fn get_collateral_for_fmspc(
 /// # Arguments
 ///
 /// * `quote` - The raw quote to verify. Supported SGX and TDX quotes.
-/// * `timeout` - The timeout for the request. (e.g. `Duration::from_secs(10)`)
 ///
 /// # Returns
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
-pub async fn get_collateral_from_pcs(
-    quote: &[u8],
-    #[cfg(not(feature = "js"))] timeout: Duration,
-) -> Result<QuoteCollateralV3> {
-    get_collateral(
-        PCS_URL,
-        quote,
-        #[cfg(not(feature = "js"))]
-        timeout,
-    )
-    .await
+pub async fn get_collateral_from_pcs(quote: &[u8]) -> Result<QuoteCollateralV3> {
+    get_collateral(PCS_URL, quote).await
 }
 
 /// Get collateral and verify the quote.
@@ -295,13 +273,7 @@ pub async fn get_collateral_and_verify(
     } else {
         pccs_url
     };
-    let collateral = get_collateral(
-        pccs_url,
-        quote,
-        #[cfg(not(feature = "js"))]
-        Duration::from_secs(120),
-    )
-    .await?;
+    let collateral = get_collateral(pccs_url, quote).await?;
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .context("Failed to get current time")?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!     // Get PCCS_URL from environment variable. The URL is like "https://localhost:8081/sgx/certification/v4/".
 //!     let pccs_url = std::env::var("PCCS_URL").expect("PCCS_URL is not set");
 //!     let quote = std::fs::read("tdx_quote").expect("tdx_quote is not found");
-//!     let collateral = get_collateral(&pccs_url, &quote, std::time::Duration::from_secs(10)).await.expect("failed to get collateral");
+//!     let collateral = get_collateral(&pccs_url, &quote).await.expect("failed to get collateral");
 //!     let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 //!     let tcb = verify(&quote, &collateral, now).expect("failed to verify quote");
 //!     println!("{:?}", tcb);


### PR DESCRIPTION
Removes the timeout arg to simplify the API. Use hardcoded 3min instead. If caller want a smaller timeout, they can use the `tokio::time::timeout` instead.