### PR TITLE
feat: support quote verification for `wasm32-unknown-unknown` without I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = { version = "1.0.133", optional = true, features = [
 ] }
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
-getrandom = { version = "0.2", optional = true, features = ["js"] }
+getrandom = { version = "0.2", optional = true}
 serde-wasm-bindgen = { version = "0.6.5", optional = true}
 wasm-bindgen = { version = "0.2.95", optional = true }
 serde_bytes = { package = "serde-human-bytes", version = "0.1" }
@@ -65,7 +65,8 @@ tokio = { version = "1.41.1", features = ["full"] }
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "report"]
+default = ["std", "report", "net"]
+net = ["reqwest"]
 std = [
     "serde/std",
     "scale/std",
@@ -78,8 +79,8 @@ std = [
     "der/std",
     "serde_json",
     "anyhow",
-    "reqwest",
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
-js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen"]
+js = ["ring/wasm32_unknown_unknown_js", "getrandom/js", "serde-wasm-bindgen", "wasm-bindgen"]
+contract = ["getrandom"]

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -1,16 +1,25 @@
+#[cfg(feature = "net")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "net")]
 use anyhow::{anyhow, Context, Result};
+#[cfg(feature = "net")]
 use scale::Decode;
-
+#[cfg(feature = "net")]
 use crate::quote::{Header, Quote};
+#[cfg(feature = "net")]
 use crate::verify::VerifiedReport;
+#[cfg(feature = "net")]
 use crate::QuoteCollateralV3;
 
 #[cfg(not(feature = "js"))]
+#[cfg(feature = "net")]
 use core::time::Duration;
+#[cfg(feature = "net")]
 use std::borrow::Cow;
+#[cfg(feature = "net")]
 use std::time::SystemTime;
 
+#[cfg(feature = "net")]
 fn get_header(resposne: &reqwest::Response, name: &str) -> Result<String> {
     let value = resposne
         .headers()
@@ -33,6 +42,7 @@ fn get_header(resposne: &reqwest::Response, name: &str) -> Result<String> {
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
+#[cfg(feature = "net")]
 pub async fn get_collateral(
     pccs_url: &str,
     mut quote: &[u8],
@@ -113,6 +123,7 @@ pub async fn get_collateral(
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
+#[cfg(feature = "net")]
 pub async fn get_collateral_from_pcs(
     quote: &[u8],
     #[cfg(not(feature = "js"))] timeout: Duration,
@@ -128,6 +139,7 @@ pub async fn get_collateral_from_pcs(
 }
 
 /// Get collateral and verify the quote.
+#[cfg(feature = "net")]
 pub async fn get_collateral_and_verify(
     quote: &[u8],
     pccs_url: Option<&str>,
@@ -153,6 +165,7 @@ pub async fn get_collateral_and_verify(
     crate::verify::verify(quote, &collateral, now)
 }
 
+#[cfg(feature = "net")]
 fn pcs_url(is_sgx: bool) -> &'static str {
     if is_sgx {
         "https://api.trustedservices.intel.com/sgx/certification/v4"
@@ -161,6 +174,7 @@ fn pcs_url(is_sgx: bool) -> &'static str {
     }
 }
 
+#[cfg(feature = "net")]
 fn normalize_pccs_url(url: &str, is_sgx: bool) -> Cow<'_, str> {
     let url = url.trim_end_matches('/');
     let path = if is_sgx {


### PR DESCRIPTION
This PR makes the verification library compatible with `wasm32-unknown-unknown` targets where `std` I/O and `wasm-bindgen` are not available.

Changes:
- Move `js` feature of `getrandom` under the existing `js` feature flag of the crate (this was a bug and should have been there initially)
- Introduce a new `net` feature flag which gates all networking-related code. The `reqwest` library (already optional) has been moved from `std` to `net` feature

The `net` feature is part of default features, so this change maintains semver compatibility.

For additional context see https://github.com/near/mpc/issues/815