### PR TITLE
feat: implement borsh serialization for public types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Kevin Wang <wy721@qq.com>"]
 repository = "https://github.com/Phala-Network/dcap-qvl"
 
 [dependencies]
-borsh = { version = "1.5.7", features = ["derive"] }
+borsh = { version = "1.5.7", features = ["derive"], optional = true}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.215", default-features = false, features = ["derive"] }
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
@@ -95,6 +95,7 @@ std = [
     "reqwest",
     "urlencoding",
 ]
+borsh = ["dep:borsh"]
 report = ["std", "tracing", "futures"]
 js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen"]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Kevin Wang <wy721@qq.com>"]
 repository = "https://github.com/Phala-Network/dcap-qvl"
 
 [dependencies]
+borsh = { version = "1.5.7", features = ["derive"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.215", default-features = false, features = ["derive"] }
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,22 +38,14 @@
 #[macro_use]
 extern crate alloc;
 
-use borsh::{BorshDeserialize, BorshSerialize};
 use scale::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Encode,
-    Decode,
-    Clone,
-    PartialEq,
-    Eq,
-    Debug,
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
-)]
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct QuoteCollateralV3 {
     pub pck_crl_issuer_chain: String,
     #[serde(with = "serde_bytes")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,22 @@
 #[macro_use]
 extern crate alloc;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use scale::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(
+    Encode,
+    Decode,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
 pub struct QuoteCollateralV3 {
     pub pck_crl_issuer_chain: String,
     #[serde(with = "serde_bytes")]

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -6,12 +6,16 @@ use scale::{Decode, Input};
 use serde::{Deserialize, Serialize};
 use x509_cert::Certificate;
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use crate::{
     constants::{self, *},
     utils,
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct Data<T> {
     pub data: Vec<u8>,
     _marker: core::marker::PhantomData<T>,
@@ -46,6 +50,7 @@ impl<T: Decode + Into<u64>> Decode for Data<T> {
 }
 
 #[derive(Decode, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct Header {
     pub version: u16,
     pub attestation_key_type: u16,
@@ -71,6 +76,7 @@ pub struct Body {
 }
 
 #[derive(Serialize, Deserialize, Decode, Debug, Clone)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct EnclaveReport {
     #[serde(with = "serde_bytes")]
     pub cpu_svn: [u8; 16],
@@ -185,6 +191,7 @@ impl TDAttributes {
 }
 
 #[derive(Decode, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TDReport10 {
     #[serde(with = "serde_bytes")]
     pub tee_tcb_svn: [u8; 16],
@@ -219,6 +226,7 @@ pub struct TDReport10 {
 }
 
 #[derive(Decode, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TDReport15 {
     pub base: TDReport10,
     #[serde(with = "serde_bytes")]
@@ -228,6 +236,7 @@ pub struct TDReport15 {
 }
 
 #[derive(Decode, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct CertificationData {
     pub cert_type: u16,
     pub body: Data<u32>,
@@ -244,6 +253,7 @@ impl core::fmt::Debug for CertificationData {
 }
 
 #[derive(Decode, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct QEReportCertificationData {
     #[serde(with = "serde_bytes")]
     pub qe_report: [u8; ENCLAVE_REPORT_BYTE_LEN],
@@ -254,6 +264,7 @@ pub struct QEReportCertificationData {
 }
 
 #[derive(Decode, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct AuthDataV3 {
     #[serde(with = "serde_bytes")]
     pub ecdsa_signature: [u8; ECDSA_SIGNATURE_BYTE_LEN],
@@ -268,6 +279,7 @@ pub struct AuthDataV3 {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct AuthDataV4 {
     #[serde(with = "serde_bytes")]
     pub ecdsa_signature: [u8; ECDSA_SIGNATURE_BYTE_LEN],
@@ -307,6 +319,7 @@ impl Decode for AuthDataV4 {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub enum AuthData {
     V3(AuthDataV3),
     V4(AuthDataV4),
@@ -336,6 +349,7 @@ fn decode_auth_data(ver: u16, input: &mut &[u8]) -> Result<AuthData, scale::Erro
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub enum Report {
     SgxEnclave(EnclaveReport),
     TD10(TDReport10),
@@ -371,6 +385,7 @@ impl Report {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct Quote {
     pub header: Header,
     pub report: Report,

--- a/src/tcb_info.rs
+++ b/src/tcb_info.rs
@@ -2,8 +2,12 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TcbInfo {
     pub id: String,
     pub version: u8,
@@ -18,6 +22,7 @@ pub struct TcbInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TcbLevel {
     pub tcb: Tcb,
     pub tcb_date: String,
@@ -28,6 +33,7 @@ pub struct TcbLevel {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct Tcb {
     #[serde(rename = "sgxtcbcomponents")]
     pub sgx_components: Vec<TcbComponents>,
@@ -39,6 +45,7 @@ pub struct Tcb {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TcbComponents {
     pub svn: u8,
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -23,7 +23,11 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct VerifiedReport {
     pub status: String,
     pub advisory_ids: Vec<String>,


### PR DESCRIPTION
This PR adds optional [Borsh](https://borsh.io/) (Binary Object Representation Serializer for Hashing) serialization support to the Rust SDK types, complementing the existing Serde serialization capabilities.

Borsh is a highly efficient serializer and commonly used for smart contract development.