### PR TITLE
feat: support quote verification for `wasm32-unknown-unknown` without I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,7 @@ name = "dcap_qvl"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "report", "net"]
-net = ["reqwest"]
+default = ["std", "report"]
 std = [
     "serde/std",
     "scale/std",
@@ -100,7 +99,7 @@ std = [
     "anyhow",
     "urlencoding",
 ]
-report = ["std", "tracing", "futures"]
+report = ["std", "tracing", "futures", "reqwest"]
 js = [
     "ring/wasm32_unknown_unknown_js",
     "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
     "derive",
 ] }
-scale-info = { version = "2.11.6", default-features = false, features = [
-    "derive",
-] }
+scale-info = { version = "2.11.6", default-features = false, features = ["derive"] }
 chrono = { version = "0.4.31", default-features = false, features = [
     "alloc",
     "serde",
@@ -34,7 +32,9 @@ log = { version = "0.4.20", default-features = false }
 
 anyhow = { version = "1.0.93", optional = true }
 
-ring = { version = "0.17", default-features = false, features = ["alloc"] }
+ring = { version = "0.17", default-features = false, features = [
+    "alloc",
+] }
 reqwest = { version = "0.12.9", optional = true, default-features = false, features = [
     "rustls-tls",
     "blocking",
@@ -47,20 +47,14 @@ serde_json = { version = "1.0.133", optional = true, features = [
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
 getrandom = { version = "0.2", optional = true }
-serde-wasm-bindgen = { version = "0.6.5", optional = true }
+serde-wasm-bindgen = { version = "0.6.5", optional = true}
 wasm-bindgen = { version = "0.2.95", optional = true }
 wasm-bindgen-futures = { version = "0.4.50" }
 serde_bytes = { package = "serde-human-bytes", version = "0.1" }
 
 # Python bindings
-pyo3 = { version = "0.25", optional = true, features = [
-    "extension-module",
-    "abi3-py37",
-    "generate-import-lib",
-] }
-pyo3-async-runtimes = { version = "0.25", optional = true, features = [
-    "tokio-runtime",
-] }
+pyo3 = { version = "0.25", optional = true, features = ["extension-module", "abi3-py37", "generate-import-lib"] }
+pyo3-async-runtimes = { version = "0.25", optional = true, features = ["tokio-runtime"] }
 tokio = { version = "1.41.1", optional = true, features = ["full"] }
 
 [dependencies.dcap-qvl-webpki]
@@ -100,11 +94,6 @@ std = [
     "urlencoding",
 ]
 report = ["std", "tracing", "futures", "reqwest"]
-js = [
-    "ring/wasm32_unknown_unknown_js",
-    "getrandom",
-    "serde-wasm-bindgen",
-    "wasm-bindgen",
-]
+js = ["ring/wasm32_unknown_unknown_js", "getrandom/js", "serde-wasm-bindgen", "wasm-bindgen"]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report"]
 contract = ["getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 scale = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
     "derive",
 ] }
-scale-info = { version = "2.11.6", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.6", default-features = false, features = [
+    "derive",
+] }
 chrono = { version = "0.4.31", default-features = false, features = [
     "alloc",
     "serde",
@@ -32,9 +34,7 @@ log = { version = "0.4.20", default-features = false }
 
 anyhow = { version = "1.0.93", optional = true }
 
-ring = { version = "0.17", default-features = false, features = [
-    "alloc",
-] }
+ring = { version = "0.17", default-features = false, features = ["alloc"] }
 reqwest = { version = "0.12.9", optional = true, default-features = false, features = [
     "rustls-tls",
     "blocking",
@@ -46,15 +46,21 @@ serde_json = { version = "1.0.133", optional = true, features = [
 ] }
 tracing = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
-getrandom = { version = "0.2", optional = true, features = ["js"] }
-serde-wasm-bindgen = { version = "0.6.5", optional = true}
+getrandom = { version = "0.2", optional = true }
+serde-wasm-bindgen = { version = "0.6.5", optional = true }
 wasm-bindgen = { version = "0.2.95", optional = true }
 wasm-bindgen-futures = { version = "0.4.50" }
 serde_bytes = { package = "serde-human-bytes", version = "0.1" }
 
 # Python bindings
-pyo3 = { version = "0.25", optional = true, features = ["extension-module", "abi3-py37", "generate-import-lib"] }
-pyo3-async-runtimes = { version = "0.25", optional = true, features = ["tokio-runtime"] }
+pyo3 = { version = "0.25", optional = true, features = [
+    "extension-module",
+    "abi3-py37",
+    "generate-import-lib",
+] }
+pyo3-async-runtimes = { version = "0.25", optional = true, features = [
+    "tokio-runtime",
+] }
 tokio = { version = "1.41.1", optional = true, features = ["full"] }
 
 [dependencies.dcap-qvl-webpki]
@@ -78,7 +84,8 @@ name = "dcap_qvl"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "report"]
+default = ["std", "report", "net"]
+net = ["reqwest"]
 std = [
     "serde/std",
     "scale/std",
@@ -91,9 +98,14 @@ std = [
     "der/std",
     "serde_json",
     "anyhow",
-    "reqwest",
     "urlencoding",
 ]
 report = ["std", "tracing", "futures"]
-js = ["ring/wasm32_unknown_unknown_js", "getrandom", "serde-wasm-bindgen", "wasm-bindgen"]
+js = [
+    "ring/wasm32_unknown_unknown_js",
+    "getrandom",
+    "serde-wasm-bindgen",
+    "wasm-bindgen",
+]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report"]
+contract = ["getrandom"]

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "net")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "net")]
 use anyhow::{anyhow, bail, Context, Result};
+#[cfg(feature = "net")]
 use der::Decode as DerDecode;
+#[cfg(feature = "net")]
 use scale::Decode;
 use x509_cert::{
     ext::pkix::{
@@ -12,10 +16,12 @@ use x509_cert::{
 
 use crate::quote::Quote;
 use crate::verify::VerifiedReport;
+#[cfg(feature = "net")]
 use crate::QuoteCollateralV3;
 
-#[cfg(not(feature = "js"))]
+#[cfg(all(not(feature = "js"), feature = "net"))]
 use core::time::Duration;
+#[cfg(feature = "net")]
 use std::time::SystemTime;
 
 const PCS_URL: &str = "https://api.trustedservices.intel.com";
@@ -68,6 +74,7 @@ impl PcsEndpoints {
     }
 }
 
+#[cfg(feature = "net")]
 fn get_header(response: &reqwest::Response, name: &str) -> Result<String> {
     let value = response
         .headers()
@@ -132,6 +139,7 @@ fn extract_crl_url(cert_der: &[u8]) -> Result<Option<String>> {
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
+#[cfg(feature = "net")]
 pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCollateralV3> {
     let quote = Quote::decode(&mut quote)?;
     let ca = quote.ca().context("Failed to get CA")?;
@@ -263,6 +271,7 @@ pub async fn get_collateral_from_pcs(quote: &[u8]) -> Result<QuoteCollateralV3> 
 }
 
 /// Get collateral and verify the quote.
+#[cfg(feature = "net")]
 pub async fn get_collateral_and_verify(
     quote: &[u8],
     pccs_url: Option<&str>,

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -1,10 +1,6 @@
-#[cfg(feature = "net")]
 use alloc::string::{String, ToString};
-#[cfg(feature = "net")]
 use anyhow::{anyhow, bail, Context, Result};
-#[cfg(feature = "net")]
 use der::Decode as DerDecode;
-#[cfg(feature = "net")]
 use scale::Decode;
 use x509_cert::{
     ext::pkix::{
@@ -16,12 +12,10 @@ use x509_cert::{
 
 use crate::quote::Quote;
 use crate::verify::VerifiedReport;
-#[cfg(feature = "net")]
 use crate::QuoteCollateralV3;
 
-#[cfg(all(not(feature = "js"), feature = "net"))]
+#[cfg(not(feature = "js"))]
 use core::time::Duration;
-#[cfg(feature = "net")]
 use std::time::SystemTime;
 
 const PCS_URL: &str = "https://api.trustedservices.intel.com";
@@ -74,7 +68,6 @@ impl PcsEndpoints {
     }
 }
 
-#[cfg(feature = "net")]
 fn get_header(response: &reqwest::Response, name: &str) -> Result<String> {
     let value = response
         .headers()
@@ -139,7 +132,6 @@ fn extract_crl_url(cert_der: &[u8]) -> Result<Option<String>> {
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
-#[cfg(feature = "net")]
 pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCollateralV3> {
     let quote = Quote::decode(&mut quote)?;
     let ca = quote.ca().context("Failed to get CA")?;
@@ -271,7 +263,6 @@ pub async fn get_collateral_from_pcs(quote: &[u8]) -> Result<QuoteCollateralV3> 
 }
 
 /// Get collateral and verify the quote.
-#[cfg(feature = "net")]
 pub async fn get_collateral_and_verify(
     quote: &[u8],
     pccs_url: Option<&str>,


### PR DESCRIPTION
This PR makes the verification library compatible with `wasm32-unknown-unknown` targets where `std` I/O and `wasm-bindgen` are not available.

Changes:
- Move `js` feature of `getrandom` under the existing `js` feature flag of the crate (this was a bug and should have been there initially)
- Move the activation of `reqwest` library dependency (already optional) from `std` to `report` feature, as it's only used in the `collateral` module feature gated by `report`. https://github.com/gilcu3/dcap-qvl/blob/b8c85e3efd11c65845f87fcf4a20bad5176925dd/src/lib.rs#L61-L62

These changes maintain semver compatibility.