### PR TITLE
cli: Show root error on failure

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -106,7 +106,6 @@ async fn command_verify_quote(args: VerifyQuoteArgs) -> Result<()> {
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();
     let report = verify(&quote, &collateral, now)
-        .ok()
         .context("Failed to verify quote")?;
     println!("{}", serde_json::to_string(&report).unwrap());
     eprintln!("Quote verified");


### PR DESCRIPTION
```bash
$ cargo run -q --bin dcap-qvl -- verify teefail.bin
Getting collateral from PCS...
Error: Failed to verify quote

Caused by:
    0: Failed to verify quote
    1: Failed to verify certificate chain
    2: CertRevoked
```