### PR TITLE
feat: unify PCCS URL defaults across all language bindings

### DIFF
--- a/dcap-qvl-js/src/collateral.js
+++ b/dcap-qvl-js/src/collateral.js
@@ -10,7 +10,11 @@ const { Quote } = require('./quote');
 const intel = require('./intel');
 const utils = require('./utils');
 
-const PCS_URL = 'https://api.trustedservices.intel.com';
+// Default PCCS URL (Phala Network's PCCS server - recommended)
+const PHALA_PCCS_URL = 'https://pccs.phala.network';
+
+// Intel's official PCS URL
+const INTEL_PCS_URL = 'https://api.trustedservices.intel.com';
 
 class PcsEndpoints {
     constructor(baseUrl, forSgx, fmspc, ca) {
@@ -26,7 +30,7 @@ class PcsEndpoints {
     }
 
     isPcs() {
-        return this.baseUrl.startsWith(PCS_URL);
+        return this.baseUrl.startsWith(INTEL_PCS_URL);
     }
 
     urlPckcrl() {
@@ -172,11 +176,11 @@ async function getCollateralForFmspc(pccsUrl, fmspc, ca, forSgx) {
 }
 
 async function getCollateralFromPcs(quoteBytes) {
-    return getCollateral(PCS_URL, quoteBytes);
+    return getCollateral(INTEL_PCS_URL, quoteBytes);
 }
 
 async function getCollateralAndVerify(quoteBytes, pccsUrl) {
-    const url = (pccsUrl || '').trim() || PCS_URL;
+    const url = (pccsUrl || '').trim() || PHALA_PCCS_URL;
     const collateral = await getCollateral(url, quoteBytes);
     const now = Math.floor(Date.now() / 1000);
 
@@ -189,4 +193,6 @@ module.exports = {
     getCollateralForFmspc,
     getCollateralFromPcs,
     getCollateralAndVerify,
+    PHALA_PCCS_URL,
+    INTEL_PCS_URL,
 };

--- a/dcap-qvl-js/src/index.d.ts
+++ b/dcap-qvl-js/src/index.d.ts
@@ -305,6 +305,18 @@ export const isBrowser: boolean;
 // Collateral
 // ============================================================================
 
+/**
+ * Default PCCS URL (Phala Network's PCCS server - recommended)
+ * Provides better availability and lower rate limits compared to Intel's PCS.
+ */
+export const PHALA_PCCS_URL: string;
+
+/**
+ * Intel's official PCS (Provisioning Certification Service) URL.
+ * Use getCollateralFromPcs() to fetch collateral directly from Intel.
+ */
+export const INTEL_PCS_URL: string;
+
 export interface Collateral {
   pck_crl_issuer_chain: string;
   root_ca_crl: number[] | string;
@@ -350,7 +362,7 @@ export function getCollateralFromPcs(quoteBytes: Buffer | Uint8Array): Promise<C
 /**
  * Get collateral and verify a quote in one call
  * @param quoteBytes - Raw quote bytes
- * @param pccsUrl - Optional PCCS server URL (defaults to Intel PCS)
+ * @param pccsUrl - Optional PCCS server URL (defaults to Phala PCCS)
  */
 export function getCollateralAndVerify(
   quoteBytes: Buffer | Uint8Array,

--- a/dcap-qvl-js/src/index.js
+++ b/dcap-qvl-js/src/index.js
@@ -3,7 +3,7 @@
 
 const { Quote } = require('./quote');
 const { verify, QuoteVerifier, VerifiedReport } = require('./verify');
-const { getCollateral, getCollateralFromPcs, getCollateralAndVerify } = require('./collateral');
+const { getCollateral, getCollateralFromPcs, getCollateralAndVerify, PHALA_PCCS_URL, INTEL_PCS_URL } = require('./collateral');
 const { TcbInfo } = require('./tcb_info');
 const constants = require('./constants');
 const oids = require('./oids');
@@ -27,6 +27,8 @@ module.exports = {
     getCollateral,
     getCollateralFromPcs,
     getCollateralAndVerify,
+    PHALA_PCCS_URL,
+    INTEL_PCS_URL,
 
     // TCB Info
     TcbInfo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,22 +14,24 @@
 //! dcap-qvl = "0.1.0"
 //! ```
 //!
-//! # Example: Get Collateral from PCCS_URL and Verify Quote
+//! # Example
 //!
-//! To get collateral from a PCCS_URL and verify a quote, you can use the following example code:
 //! ```no_run
 //! use dcap_qvl::collateral::get_collateral;
 //! use dcap_qvl::verify::verify;
+//! use dcap_qvl::PHALA_PCCS_URL;
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     // Get PCCS_URL from environment variable. The URL is like "https://localhost:8081/sgx/certification/v4/".
-//!     let pccs_url = std::env::var("PCCS_URL").expect("PCCS_URL is not set");
-//!     let quote = std::fs::read("tdx_quote").expect("tdx_quote is not found");
+//!     let quote = std::fs::read("quote").expect("quote file not found");
+//!
+//!     // Use default Phala PCCS, or override with custom URL
+//!     let pccs_url = std::env::var("PCCS_URL").unwrap_or_else(|_| PHALA_PCCS_URL.to_string());
 //!     let collateral = get_collateral(&pccs_url, &quote).await.expect("failed to get collateral");
+//!
 //!     let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-//!     let tcb = verify(&quote, &collateral, now).expect("failed to verify quote");
-//!     println!("{:?}", tcb);
+//!     let report = verify(&quote, &collateral, now).expect("failed to verify quote");
+//!     println!("{:?}", report);
 //! }
 //! ```
 
@@ -67,6 +69,9 @@ pub struct QuoteCollateralV3 {
 
 #[cfg(feature = "report")]
 pub mod collateral;
+
+#[cfg(feature = "report")]
+pub use collateral::PHALA_PCCS_URL;
 
 pub mod oids;
 


### PR DESCRIPTION
## Summary
- Change default PCCS URL from Intel PCS to Phala PCCS across Rust, Python, JavaScript, and CLI
- Add `PHALA_PCCS_URL` constant (public) and `INTEL_PCS_URL` (private) 
- Update `get_collateral_and_verify()` to default to Phala PCCS
- Keep `get_collateral_from_pcs()` for explicit Intel PCS access
- CLI uses `PHALA_PCCS_URL` by default, overridable via `PCCS_URL` env var
- Python: Add `PCS_URL` alias for backward compatibility
- Update README examples and documentation

## Test plan
- [x] Rust tests pass (`cargo test` - 10/10)
- [x] Python tests pass across 3.8-3.13
- [x] CLI build and verify commands work
- [x] JS library exports constants and functions correctly
- [x] All README examples verified to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)