### PR TITLE
Allow unwrap in async test for CA freshness check

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -94,7 +94,15 @@ pub static TRUSTED_ROOT_CA_DER: &[u8] = include_bytes!("TrustedRootCA.der");
 #[cfg(test)]
 #[tokio::test]
 async fn dcap_roots_should_be_fresh() {
-    let response = reqwest::get("https://certificates.trustedservices.intel.com/Intel_SGX_Provisioning_Certification_RootCA.cer").await.unwrap();
+    #[allow(clippy::unwrap_used)]
+    let response = reqwest::get(
+        "https://certificates.trustedservices.intel.com/Intel_SGX_Provisioning_Certification_RootCA.cer",
+    )
+    .await
+    .unwrap();
+
+    #[allow(clippy::unwrap_used)]
     let ca_der = response.bytes().await.unwrap();
+
     assert_eq!(TRUSTED_ROOT_CA_DER, ca_der.as_ref());
 }


### PR DESCRIPTION
Allow clippy::unwrap_used in test-only code. No functional changes