### PR TITLE
fix: remove duplicate preposition in documentation comment

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -140,7 +140,7 @@ pub fn encode_as_der(data: &[u8]) -> Result<Vec<u8>> {
 }
 
 /// Verifies that the `leaf_cert` in combination with the `intermediate_certs` establishes
-/// a valid certificate chain that is rooted in one of the trust anchors that was compiled into to the pallet
+/// a valid certificate chain that is rooted in one of the trust anchors that was compiled into the pallet
 ///
 /// It will also check that the certificate is not revoked according to the CRL
 pub fn verify_certificate_chain(


### PR DESCRIPTION

Fixed a typo in the documentation comment for `verify_certificate_chain` function where "into to" was used instead of "into".

