### PR TITLE
types: allow Uint8Array for VerifiedReport.ppid

### DIFF
--- a/dcap-qvl-js/src/index.d.ts
+++ b/dcap-qvl-js/src/index.d.ts
@@ -254,9 +254,9 @@ export class VerifiedReport {
   status: TcbStatus;
   advisory_ids: string[];
   report: Report;
-  ppid: Buffer;
+  ppid: Buffer | Uint8Array;
 
-  constructor(status: TcbStatus, advisoryIds: string[], report: Report, ppid: Buffer);
+  constructor(status: TcbStatus, advisoryIds: string[], report: Report, ppid: Buffer | Uint8Array);
 }
 
 export class QuoteVerifier {


### PR DESCRIPTION
Allow Uint8Array for VerifiedReport.ppid to support browser environments where Buffer is not available. Improves type compatibility without runtime changes.