### PR TITLE
Limit quote data length when deserializing

### DIFF
--- a/src/quote.rs
+++ b/src/quote.rs
@@ -51,8 +51,15 @@ impl<'de, T> Deserialize<'de> for Data<T> {
 
 impl<T: Decode + Into<u64>> Decode for Data<T> {
     fn decode<I: Input>(input: &mut I) -> Result<Self, scale::Error> {
+        const MAX_DATA_LEN: u64 = 1_048_576; // 1 MiB upper bound for variable-length fields
+
         let len = T::decode(input)?;
-        let mut data = vec![0u8; len.into() as usize];
+        let len_u64 = len.into();
+        if len_u64 > MAX_DATA_LEN {
+            return Err(scale::Error::from("Data length exceeds maximum"));
+        }
+
+        let mut data = vec![0u8; len_u64 as usize];
         input.read(&mut data)?;
         Ok(Data {
             data,

--- a/tests/quote_parsing.rs
+++ b/tests/quote_parsing.rs
@@ -2,7 +2,7 @@
 
 use dcap_qvl::{
     intel,
-    quote::{Quote, Report},
+    quote::{Data, Quote, Report},
 };
 use scale::Decode as ScaleDecode;
 
@@ -46,4 +46,16 @@ fn sgx_quote_parsing_exports_cert_chain_and_extension() {
 
     assert_eq!(quote.fmspc().unwrap(), ext.fmspc);
     assert!(!ext.ppid.is_empty());
+}
+
+#[test]
+fn data_decode_rejects_overlong_length() {
+    use scale::Encode as ScaleEncode;
+
+    // Length slightly above the 1 MiB bound used in Data::<u32>::decode.
+    let len: u32 = 1_048_576 + 1;
+    let encoded = len.encode();
+
+    let result = Data::<u32>::decode(&mut &encoded[..]);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
This PR fixes an unbounded allocation when deserializing  fields in quotes (issue #129).

### What changed
- Add a 1 MiB upper bound to  so that malformed quotes cannot request arbitrarily large buffers.
- Introduce a regression test that ensures an over-long length is rejected instead of attempting a huge allocation.

The 1 MiB limit is generous relative to real-world quote and certification data sizes, but still prevents DoS via multi‑GB allocations from a tiny malformed input.

### Rationale
The  wrapper is used for variable-length fields in the quote (auth data, QE auth data, certification body). All of these are ultimately derived from network / untrusted input. Bounding the decoded length is sufficient here because a valid quote should be orders of magnitude smaller than the limit, while an attacker-controlled length value should not be allowed to drive allocations without checks.