### PR TITLE
refactor: remove `der` and `x509-cert` deps for non-`report` builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ chrono = { version = "0.4.42", default-features = false, features = [
     "serde",
 ] }
 const-oid = { version = "0.9.5", default-features = false }
-x509-cert = { version = "0.2.4", default-features = false }
+x509-cert = { version = "0.2.4", default-features = false, optional = true }
 byteorder = { version = "1.5.0", default-features = false }
 pem = { version = "3", default-features = false }
 asn1_der = { version = "0.7", default-features = false, features = [
     "native_types",
 ] }
-der = { version = "0.7.8", default-features = false, features = ["alloc"] }
+der = { version = "0.7.8", default-features = false, features = ["alloc"], optional = true }
 
 log = { version = "0.4.29", default-features = false }
 
@@ -97,7 +97,7 @@ std = [
     "const-oid/std",
     "pem/std",
     "asn1_der/std",
-    "der/std",
+    "der?/std",
     "serde_json",
     "anyhow",
     "urlencoding",
@@ -105,7 +105,7 @@ std = [
 ]
 borsh = ["dep:borsh"]
 borsh_schema = ["borsh", "borsh/unstable__schema"]
-report = ["std", "tracing", "futures", "reqwest"]
+report = ["std", "tracing", "futures", "reqwest", "der", "x509-cert"]
 js = ["getrandom/js", "serde-wasm-bindgen", "wasm-bindgen"]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report", "ring"]
 go = ["std", "ring", "serde_json"]

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use anyhow::{anyhow, bail, Context, Result};
 use scale::{Decode, Encode, Input, Output};
 use serde::{Deserialize, Serialize};
-use x509_cert::Certificate;
 
 #[cfg(feature = "borsh_schema")]
 use borsh::BorshSchema;
@@ -640,9 +639,8 @@ impl Quote {
             .context("Failed to get raw cert chain")?;
         let certs = utils::extract_certs(raw_cert_chain).context("Failed to extract certs")?;
         let cert = certs.first().ok_or(anyhow!("Invalid certificate"))?;
-        let cert_der: Certificate =
-            der::Decode::from_der(cert).context("Failed to decode certificate")?;
-        let issuer = cert_der.tbs_certificate.issuer.to_string();
+        let issuer =
+            utils::get_cert_issuer_string(cert).context("Failed to extract certificate issuer")?;
         if issuer.contains(constants::PROCESSOR_ISSUER) {
             return Ok(constants::PROCESSOR_ISSUER_ID);
         } else if issuer.contains(constants::PLATFORM_ISSUER) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,34 +1,105 @@
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use anyhow::{anyhow, bail, Context, Result};
 use asn1_der::{
-    typed::{DerDecodable, Sequence},
-    DerObject,
+    typed::{DerDecodable, Integer, Sequence},
+    DerObject, VecBacking,
 };
 use rustls_pki_types::{CertificateDer, TrustAnchor, UnixTime};
-use webpki::CertRevocationList;
-use webpki::{self, OwnedCertRevocationList};
-use x509_cert::Certificate;
+use webpki::{self, CertRevocationList, OwnedCertRevocationList};
 
 use crate::{constants::*, oids};
 
-pub fn get_intel_extension(der_encoded: &[u8]) -> Result<Vec<u8>> {
-    let cert: Certificate =
-        der::Decode::from_der(der_encoded).context("Failed to decode certificate")?;
-    let mut extension_iter = cert
-        .tbs_certificate
-        .extensions
-        .as_deref()
-        .unwrap_or(&[])
-        .iter()
-        .filter(|e| e.extn_id == oids::SGX_EXTENSION)
-        .map(|e| e.extn_value.clone());
+/// Parse the tbsCertificate SEQUENCE from a DER-encoded X.509 certificate.
+///
+/// X.509 structure:
+///   Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signature }
+fn parse_tbs_certificate(der_encoded: &[u8]) -> Result<Sequence<'_>> {
+    let cert = Sequence::decode(der_encoded).context("Failed to decode certificate")?;
+    cert.get_as::<Sequence>(0)
+        .context("Failed to decode tbsCertificate")
+}
 
-    let extension = extension_iter.next().context("Intel extension not found")?;
-    if extension_iter.next().is_some() {
-        //"There should only be one Intel extension"
-        bail!("Intel extension ambiguity");
+pub fn get_intel_extension(der_encoded: &[u8]) -> Result<Vec<u8>> {
+    let tbs = parse_tbs_certificate(der_encoded)?;
+
+    // Find the extensions field: context-tagged [3] EXPLICIT wrapper
+    let mut extensions_raw = None;
+    for i in 0..tbs.len() {
+        let elem = tbs.get(i).context("Failed to get tbsCertificate element")?;
+        if elem.tag() == 0xA3 {
+            extensions_raw = Some(elem.value());
+            break;
+        }
     }
-    Ok(extension.into_bytes())
+    let extensions_raw = extensions_raw.context("No extensions found in certificate")?;
+
+    // The [3] wrapper contains a SEQUENCE OF Extension
+    // Extension ::= SEQUENCE { extnID OID, critical BOOLEAN OPTIONAL, extnValue OCTET STRING }
+    let ext_seq =
+        Sequence::decode(extensions_raw).context("Failed to decode extensions sequence")?;
+
+    let sgx_oid = oids::SGX_EXTENSION.as_bytes();
+    let mut found: Option<Vec<u8>> = None;
+    for i in 0..ext_seq.len() {
+        let ext: Sequence = ext_seq.get_as(i).context("Failed to decode extension")?;
+
+        let oid_obj = ext.get(0).context("Missing extension OID")?;
+        if oid_obj.value() == sgx_oid {
+            if found.is_some() {
+                bail!("Intel extension ambiguity");
+            }
+            // The value is the last element (index 1 or 2 depending on critical flag)
+            let value_idx = ext
+                .len()
+                .checked_sub(1)
+                .context("Empty extension sequence")?;
+            let value_obj = ext.get(value_idx).context("Missing extension value")?;
+            found = Some(value_obj.value().to_vec());
+        }
+    }
+    found.context("Intel extension not found")
+}
+
+/// Extract the issuer's human-readable name from a DER-encoded X.509 certificate.
+///
+/// Navigates the ASN.1 structure: Certificate -> tbsCertificate -> issuer (4th field),
+/// then concatenates all printable/UTF-8 string values from the RDN sequence.
+pub fn get_cert_issuer_string(der_encoded: &[u8]) -> Result<String> {
+    let tbs = parse_tbs_certificate(der_encoded)?;
+
+    // tbsCertificate fields: version[0], serialNumber, signature, issuer, ...
+    // version is context-tagged [0] EXPLICIT, so if the first element's tag is 0xA0,
+    // issuer is at index 3; otherwise (v1 certs without explicit version) at index 2.
+    let first_tag = tbs.get(0).context("Empty tbsCertificate")?.tag();
+    let issuer_idx = if first_tag == 0xA0 { 3 } else { 2 };
+
+    let issuer: Sequence = tbs.get_as(issuer_idx).context("Failed to decode issuer")?;
+
+    // Issuer is a SEQUENCE OF RelativeDistinguishedName
+    // Each RDN is a SET (tag 0x31) OF AttributeTypeAndValue
+    // Each ATV is a SEQUENCE { OID, value }
+    let mut parts = Vec::new();
+    for i in 0..issuer.len() {
+        let rdn_obj = issuer.get(i).context("Failed to get RDN")?;
+        // RDN is a SET (tag 0x31) - iterate its AttributeTypeAndValue SEQUENCEs
+        let rdn_bytes = rdn_obj.value();
+        let mut pos: usize = 0;
+        while pos < rdn_bytes.len() {
+            let atv = DerObject::decode_at(rdn_bytes, pos).context("Failed to decode ATV")?;
+            pos = pos
+                .checked_add(atv.raw().len())
+                .context("ATV offset overflow")?;
+            let atv_seq = Sequence::load(atv).context("Failed to load ATV as sequence")?;
+            let value = match atv_seq.get(1) {
+                Ok(v) if matches!(v.tag(), 0x13 | 0x0C | 0x16) => v,
+                _ => continue,
+            };
+            if let Ok(s) = core::str::from_utf8(value.value()) {
+                parts.push(s);
+            }
+        }
+    }
+    Ok(parts.join(","))
 }
 
 pub fn find_extension(path: &[&[u8]], raw: &[u8]) -> Result<Vec<u8>> {
@@ -105,38 +176,41 @@ pub(crate) fn extract_raw_certs(cert_chain: &[u8]) -> Result<Vec<Vec<u8>>> {
 }
 
 pub fn extract_certs<'a>(cert_chain: &'a [u8]) -> Result<Vec<CertificateDer<'a>>> {
-    let mut certs = Vec::<CertificateDer<'a>>::new();
-
-    let raw_certs = extract_raw_certs(cert_chain)?;
-    for raw_cert in raw_certs.iter() {
-        let cert = rustls_pki_types::CertificateDer::<'a>::from(raw_cert.to_vec());
-        certs.push(cert);
-    }
-
-    Ok(certs)
+    Ok(extract_raw_certs(cert_chain)?
+        .into_iter()
+        .map(CertificateDer::from)
+        .collect())
 }
 
-/// Encode two 32-byte values in DER format
-/// This is meant for 256 bit ECC signatures or public keys
-/// TODO: We could use `asn1_der` crate to reimplement this, so we can remove `der` which overlaps with `asn1_der`
+/// Encode two 32-byte values as a DER SEQUENCE of two INTEGERs.
+/// This is meant for 256 bit ECC signatures (r, s components).
+///
+/// Uses `asn1_der::typed::Integer::write` for correct DER integer encoding
+/// (leading zero stripping and sign-bit padding).
 pub fn encode_as_der(data: &[u8]) -> Result<Vec<u8>> {
-    let (first, second) = data.split_at_checked(32).context("Invalid key length")?;
-    let mut sequence = der::asn1::SequenceOf::<der::asn1::UintRef, 2>::new();
-    let element0 = der::asn1::UintRef::new(first).context("Failed to add first element")?;
-    sequence
-        .add(element0)
-        .context("Failed to add second element")?;
-    let element1 = der::asn1::UintRef::new(second).context("Failed to add second element")?;
-    sequence
-        .add(element1)
-        .context("Failed to add third element")?;
-    // 72 should be enough in all cases. 2 + 2 x (32 + 3)
-    let mut asn1 = alloc::vec![0u8; 72];
-    let mut writer = der::SliceWriter::new(&mut asn1);
-    writer
-        .encode(&sequence)
-        .context("Failed to encode sequence")?;
-    Ok(writer.finish().context("Failed to finish writer")?.to_vec())
+    if data.len() != 64 {
+        bail!("Expected 64 bytes (two 32-byte values), got {}", data.len());
+    }
+    let (first, second) = data.split_at(32);
+
+    // Encode both integers into a temporary buffer
+    let mut inner = Vec::with_capacity(72);
+    Integer::write(first, false, &mut VecBacking(&mut inner))
+        .context("Failed to encode first integer")?;
+    Integer::write(second, false, &mut VecBacking(&mut inner))
+        .context("Failed to encode second integer")?;
+
+    // Wrap in SEQUENCE
+    let mut result = Vec::with_capacity(72);
+    DerObject::write(
+        0x30,
+        inner.len(),
+        &mut inner.iter(),
+        &mut VecBacking(&mut result),
+    )
+    .context("Failed to encode DER sequence")?;
+
+    Ok(result)
 }
 
 /// Parse CRL DER bytes into CertRevocationList objects.


### PR DESCRIPTION
## Summary

- Replace `der` crate encoding/decoding and `x509-cert` certificate parsing with `asn1_der`-based implementations
- Make `der` and `x509-cert` optional, gated behind the `report` feature
- Addresses the TODO at `utils.rs:121`: *"We could use `asn1_der` crate to reimplement this, so we can remove `der` which overlaps with `asn1_der`"*

## Changes

- **`encode_as_der()`**: rewritten with manual DER byte encoding instead of `der::asn1::SequenceOf`/`UintRef`/`SliceWriter`
- **`get_intel_extension()`**: rewritten to parse X.509 extensions via `asn1_der` instead of `x509_cert::Certificate`
- **`get_cert_issuer_string()`** (new): extracts certificate issuer using `asn1_der` ASN.1 navigation
- **`Quote::ca()`**: uses `get_cert_issuer_string()` instead of `der::Decode` + `x509_cert::Certificate`
- **`Cargo.toml`**: `der` and `x509-cert` made optional behind `report` feature (only `collateral.rs` still needs them)

## Motivation

The `der` and `x509-cert` crates add ~37KB to WASM contract binaries (measured with `lto="fat"` + `wasm-opt -O`). For users that don't enable the `report` feature (e.g., NEAR smart contracts using `["std", "ring", "contract"]`), these crates are no longer compiled.

The `asn1_der` crate was already a dependency, so no new dependencies are introduced.

## Test plan

- [x] `cargo test --test quote_parsing --test verify_quote` passes (5 tests)
- [x] `cargo check --features "std,ring" --no-default-features` compiles without `der`/`x509-cert`
- [x] `cargo check --features "std,ring,report" --no-default-features` compiles with `der`/`x509-cert`
- [ ] Verify WASM binary size reduction in downstream NEAR contract