### PR TITLE
feat: introduce Config trait for pluggable X.509/DER backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,15 @@ chrono = { version = "0.4.42", default-features = false, features = [
     "serde",
 ] }
 const-oid = { version = "0.9.5", default-features = false }
-x509-cert = { version = "0.2.4", default-features = false }
+x509-cert = { version = "0.2.4", default-features = false, optional = true }
 byteorder = { version = "1.5.0", default-features = false }
 pem = { version = "3", default-features = false }
 asn1_der = { version = "0.7", default-features = false, features = [
     "native_types",
 ] }
-der = { version = "0.7.8", default-features = false, features = ["alloc"] }
+der = { version = "0.7.8", default-features = false, features = [
+    "alloc",
+], optional = true }
 
 log = { version = "0.4.29", default-features = false }
 
@@ -89,7 +91,7 @@ name = "dcap_qvl"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
-default = ["std", "report", "ring", "rustcrypto"]
+default = ["std", "report", "ring", "rustcrypto", "default-x509"]
 std = [
     "serde/std",
     "scale/std",
@@ -97,7 +99,7 @@ std = [
     "const-oid/std",
     "pem/std",
     "asn1_der/std",
-    "der/std",
+    "der?/std",
     "serde_json",
     "anyhow",
     "urlencoding",
@@ -105,10 +107,24 @@ std = [
 ]
 borsh = ["dep:borsh"]
 borsh_schema = ["borsh", "borsh/unstable__schema"]
-report = ["std", "tracing", "futures", "reqwest"]
+# Audited in-tree X.509 / signature backends (`x509::X509CertBackend`,
+# `signature::DerSigEncoder`) and the configs that bundle them
+# (`configs::RingConfig` / `RustCryptoConfig` / `DefaultConfig`), plus the
+# non-generic `verify` / `intel::*` shims that pin `DefaultConfig`.
+#
+# Disabling this drops ~37 KiB on `wasm32-unknown-unknown` (`lto="fat"` +
+# `wasm-opt -O`) by removing `der` and `x509-cert`. Without it, callers
+# must supply their own `Config` impl and use the `_with::<C>` entry
+# points (see `examples/asn1-der-backend/`).
+default-x509 = ["dep:der", "dep:x509-cert"]
+# `report` (PCCS client + collateral fetch) parses CRL distribution
+# points with `x509-cert`, so it pulls in the audited backend bundle too.
+report = ["std", "tracing", "futures", "reqwest", "default-x509"]
 js = ["getrandom/js", "serde-wasm-bindgen", "wasm-bindgen"]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report", "ring"]
-go = ["std", "ring", "serde_json"]
+# The `go` FFI surface concretizes on `DefaultConfig`, so it pulls in the
+# audited backend bundle.
+go = ["std", "ring", "serde_json", "default-x509"]
 ring = ["dep:ring", "dcap-qvl-webpki/ring", "_anycrypto"]
 rustcrypto = ["dep:sha2", "dep:p256", "dep:signature", "dcap-qvl-webpki/rustcrypto", "_anycrypto"]
 _anycrypto = []

--- a/cli/src/bin/test_case.rs
+++ b/cli/src/bin/test_case.rs
@@ -101,22 +101,17 @@ fn run_verify(quote_file: PathBuf, collateral_file: PathBuf, root_ca_file: Optio
         .expect("Invalid system time")
         .as_secs();
 
-    let ring_backend = dcap_qvl::verify::ring::backend();
-    let rustcrypto_backend = dcap_qvl::verify::rustcrypto::backend();
-    let ring_verifier = match root_ca_der.clone() {
-        Some(root_ca_der) => QuoteVerifier::new(root_ca_der, ring_backend),
-        None => QuoteVerifier::new_prod(ring_backend),
-    };
-    let rustcrypto_verifier = match root_ca_der {
-        Some(root_ca_der) => QuoteVerifier::new(root_ca_der, rustcrypto_backend),
-        None => QuoteVerifier::new_prod(rustcrypto_backend),
+    use dcap_qvl::configs::{RingConfig, RustCryptoConfig};
+    let verifier = match root_ca_der {
+        Some(root_ca_der) => QuoteVerifier::new(root_ca_der),
+        None => QuoteVerifier::new_prod(),
     };
 
-    let ring_result = ring_verifier
-        .verify(&quote_bytes, &collateral, now)
+    let ring_result = verifier
+        .verify_with::<RingConfig>(&quote_bytes, &collateral, now)
         .map_err(|e| format!("{e:#}"));
-    let rustcrypto_result = rustcrypto_verifier
-        .verify(&quote_bytes, &collateral, now)
+    let rustcrypto_result = verifier
+        .verify_with::<RustCryptoConfig>(&quote_bytes, &collateral, now)
         .map_err(|e| format!("{e:#}"));
     if ring_result != rustcrypto_result {
         eprintln!("Verification results differ between ring and rustcrypto");
@@ -125,7 +120,7 @@ fn run_verify(quote_file: PathBuf, collateral_file: PathBuf, root_ca_file: Optio
         return 1;
     }
 
-    let ring_result1 = ring_verifier.verify(&quote_bytes, &collateral, now);
+    let ring_result1 = verifier.verify_with::<RingConfig>(&quote_bytes, &collateral, now);
     match ring_result1 {
         Ok(verified_report) => {
             println!("Verification successful");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -82,7 +82,8 @@ fn command_decode_quote(args: DecodeQuoteArgs) -> Result<()> {
     if args.fmspc {
         println!(
             "fmspc={}",
-            hex::encode(decoded_quote.fmspc().context("no fmspc found")?).to_uppercase()
+            hex::encode(intel::quote_fmspc(&decoded_quote).context("no fmspc found")?)
+                .to_uppercase()
         );
     } else {
         let json = serde_json::to_string(&decoded_quote).context("Failed to serialize quote")?;

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -11,6 +11,8 @@ use x509_cert::{
     Certificate,
 };
 
+use crate::config::{Config, ParsedCert, X509Codec};
+use crate::configs::DefaultConfig;
 use crate::constants::{
     PCK_ID_ENCRYPTED_PPID_2048, PCK_ID_ENCRYPTED_PPID_3072, PCK_ID_PCK_CERT_CHAIN,
 };
@@ -214,23 +216,31 @@ async fn fetch_pck_certificate(
 }
 
 /// Extract FMSPC and CA type from a PEM certificate chain.
-fn extract_fmspc_and_ca(pem_chain: &str) -> Result<(String, &'static str)> {
+///
+/// Generic over [`Config`]; the cert parse and issuer DN extraction go
+/// through the configured [`X509Codec`].
+fn extract_fmspc_and_ca_with<C: Config>(pem_chain: &str) -> Result<(String, &'static str)> {
     let certs = crate::utils::extract_certs(pem_chain.as_bytes())
         .context("Failed to extract certificates from PEM chain")?;
     let cert = certs
         .first()
         .ok_or_else(|| anyhow!("Empty certificate chain"))?;
 
+    // Parse cert once; reuse for both extension lookup and issuer DN.
+    let parsed = <C as Config>::X509::from_der(cert).context("Failed to decode certificate")?;
+
     // Extract FMSPC from Intel extension
-    let extension = crate::utils::get_intel_extension(cert)
-        .context("Failed to get Intel extension from certificate")?;
+    let extension = parsed
+        .extension(crate::oids::SGX_EXTENSION.as_bytes())
+        .context("Failed to get Intel extension from certificate")?
+        .ok_or_else(|| anyhow!("Intel extension not found"))?;
     let fmspc = crate::utils::get_fmspc(&extension)?;
     let fmspc_hex = hex::encode_upper(fmspc);
 
-    // Extract CA type from issuer
-    let cert_der: Certificate =
-        der::Decode::from_der(cert).context("Failed to decode certificate")?;
-    let issuer = cert_der.tbs_certificate.issuer.to_string();
+    // Extract CA type from issuer (reuses parsed cert above)
+    let issuer = parsed
+        .issuer_dn()
+        .context("Failed to extract certificate issuer")?;
     let ca = if issuer.contains(crate::constants::PROCESSOR_ISSUER) {
         crate::constants::PROCESSOR_ISSUER_ID
     } else if issuer.contains(crate::constants::PLATFORM_ISSUER) {
@@ -275,7 +285,17 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
-pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCollateralV3> {
+pub async fn get_collateral(pccs_url: &str, quote: &[u8]) -> Result<QuoteCollateralV3> {
+    get_collateral_with::<DefaultConfig>(pccs_url, quote).await
+}
+
+/// Variant of [`get_collateral`] with an explicit [`Config`] for the cert
+/// parsing performed during FMSPC/CA extraction. Use this to plug in a custom
+/// backend.
+pub async fn get_collateral_with<C: Config>(
+    pccs_url: &str,
+    mut quote: &[u8],
+) -> Result<QuoteCollateralV3> {
     let parsed_quote = Quote::decode(&mut quote)?;
     let client = build_http_client()?;
 
@@ -285,7 +305,7 @@ pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCol
         .context("Failed to get PCK certificate chain")?;
 
     // Extract FMSPC and CA from the certificate
-    let (fmspc, ca) = extract_fmspc_and_ca(&pck_chain)?;
+    let (fmspc, ca) = extract_fmspc_and_ca_with::<C>(&pck_chain)?;
 
     // Fetch the rest of the collateral
     let mut collateral =
@@ -420,7 +440,12 @@ async fn get_collateral_for_fmspc_impl(
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
 pub async fn get_collateral_from_pcs(quote: &[u8]) -> Result<QuoteCollateralV3> {
-    get_collateral(INTEL_PCS_URL, quote).await
+    get_collateral_from_pcs_with::<DefaultConfig>(quote).await
+}
+
+/// Variant of [`get_collateral_from_pcs`] with an explicit [`Config`].
+pub async fn get_collateral_from_pcs_with<C: Config>(quote: &[u8]) -> Result<QuoteCollateralV3> {
+    get_collateral_with::<C>(INTEL_PCS_URL, quote).await
 }
 
 /// Get collateral and verify the quote (uses ring backend).
@@ -434,18 +459,28 @@ pub async fn get_collateral_and_verify(
     quote: &[u8],
     pccs_url: Option<&str>,
 ) -> Result<crate::verify::VerifiedReport> {
+    get_collateral_and_verify_with::<DefaultConfig>(quote, pccs_url).await
+}
+
+/// Variant of [`get_collateral_and_verify`] with an explicit [`Config`] used
+/// for both the collateral fetch and the verification.
+#[cfg(feature = "_anycrypto")]
+pub async fn get_collateral_and_verify_with<C: Config>(
+    quote: &[u8],
+    pccs_url: Option<&str>,
+) -> Result<crate::verify::VerifiedReport> {
     use std::time::SystemTime;
 
     let pccs_url = pccs_url
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .unwrap_or(PHALA_PCCS_URL);
-    let collateral = get_collateral(pccs_url, quote).await?;
+    let collateral = get_collateral_with::<C>(pccs_url, quote).await?;
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .context("Failed to get current time")?
         .as_secs();
-    crate::verify::verify(quote, &collateral, now)
+    crate::verify::verify_with::<C>(quote, &collateral, now)
 }
 
 #[cfg(test)]
@@ -519,7 +554,8 @@ AiEA4J0lrHoMs+Xo5o/sX6O9QWxHRAvZUGOdRQ7cvqRXaqI=
 
     #[test]
     fn test_extract_fmspc_and_ca_processor() {
-        let (fmspc, ca) = extract_fmspc_and_ca(TEST_PCK_CHAIN_PROCESSOR).unwrap();
+        let (fmspc, ca) =
+            extract_fmspc_and_ca_with::<DefaultConfig>(TEST_PCK_CHAIN_PROCESSOR).unwrap();
         assert_eq!(fmspc, "00A067110000");
         assert_eq!(ca, PROCESSOR_ISSUER_ID);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,138 @@
+//! Pluggable configuration trait surface for quote verification.
+//!
+//! Quote verification depends on a small set of operations on certificates,
+//! signatures, and crypto primitives. Each is captured by a small trait so a
+//! downstream consumer (e.g. a smart contract building for WASM) can supply a
+//! smaller-footprint implementation without forking this crate. The audited
+//! in-tree implementations live in [`crate::x509`], [`crate::signature`], and
+//! [`crate::crypto`]; the bundles in [`crate::configs`] (incl.
+//! [`DefaultConfig`](crate::configs::DefaultConfig)) pair them into ready-to-use
+//! [`Config`]s.
+//!
+//! ## Config trait
+//!
+//! [`Config`] bundles the pluggable components as associated types so they can
+//! be swapped independently — e.g. keep the audited cert parser but bring your
+//! own micro-encoder. A custom config is just a marker type implementing
+//! [`Config`]:
+//!
+//! ```ignore
+//! struct MyConfig;
+//! impl dcap_qvl::config::Config for MyConfig {
+//!     type X509       = dcap_qvl::x509::X509CertBackend; // keep audited
+//!     type SigEncoder = MyMicroEncoder;                  // custom
+//!     type Crypto     = dcap_qvl::crypto::RingCrypto;
+//! }
+//!
+//! dcap_qvl::verify::verify_with::<MyConfig>(quote, &collateral, now)?;
+//! ```
+//!
+//! ## Auditing
+//!
+//! Only the in-tree backends ([`crate::x509::X509CertBackend`],
+//! [`crate::signature::DerSigEncoder`], [`crate::crypto::RingCrypto`] /
+//! [`crate::crypto::RustCryptoCrypto`]) and the bundles in [`crate::configs`]
+//! are audited as part of `dcap-qvl`. Custom implementations of [`X509Codec`]
+//! / [`ParsedCert`] / [`EcdsaSigEncoder`] / [`CryptoProvider`] are the
+//! implementer's responsibility; they SHOULD be checked for byte-for-byte
+//! equivalence against [`DefaultConfig`](crate::configs::DefaultConfig) on a
+//! representative corpus (see `tests/config_conformance.rs`).
+//!
+//! ## Trait shape
+//!
+//! Sub-trait methods (other than [`X509Codec::from_der`]) are associated
+//! functions, not `&self` methods, so backends are expected to be zero-sized
+//! marker types. [`X509Codec`] is the exception: it produces a [`ParsedCert`]
+//! that owns or borrows the parsed data, so multiple field accesses share a
+//! single parse.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use anyhow::Result;
+
+/// X.509 certificate parser factory.
+///
+/// Implementations MUST conform to RFC 5280 and X.690 (DER). A backend
+/// parses a certificate once via [`X509Codec::from_der`], returning a
+/// [`ParsedCert`] that exposes the fields needed by quote verification as
+/// `&self` accessors — so a caller that touches multiple fields of the same
+/// certificate pays the parsing cost only once.
+///
+/// The associated type [`X509Codec::Parsed`] is generic over the input
+/// lifetime, allowing implementations to choose whether to own their parsed
+/// representation or borrow zero-copy from the input DER bytes.
+pub trait X509Codec {
+    /// Parsed representation. May own its data, or may borrow from the input
+    /// `cert_der` slice (zero-copy backends).
+    type Parsed<'a>: ParsedCert
+    where
+        Self: 'a;
+
+    /// Parse a DER-encoded X.509 certificate.
+    fn from_der<'a>(cert_der: &'a [u8]) -> Result<Self::Parsed<'a>>;
+}
+
+/// Read-only accessors over a parsed X.509 certificate.
+pub trait ParsedCert {
+    /// Returns the issuer Distinguished Name as a human-readable string in
+    /// RFC 4514 form (e.g. `"CN=Foo,O=Bar"`).
+    ///
+    /// The string is consumed by `intel::quote_ca` for substring matching, so
+    /// a stable, conventional representation is required.
+    fn issuer_dn(&self) -> Result<String>;
+
+    /// Returns the OCTET STRING contents of the unique extension whose
+    /// `extnID` equals `oid`, where `oid` is the DER-encoded OID body
+    /// (no tag/length).
+    ///
+    /// * `Ok(Some(value))` — exactly one matching extension was found.
+    /// * `Ok(None)` — no matching extension.
+    /// * `Err(_)` — the extension was found more than once, or the certificate
+    ///   is malformed.
+    fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>>;
+}
+
+/// DER encoding of ECDSA signatures.
+///
+/// DCAP quotes carry signatures as raw `r ‖ s` byte strings, but webpki's
+/// signature verifier expects them encoded as `Ecdsa-Sig-Value` (RFC 5480):
+/// `SEQUENCE { r INTEGER, s INTEGER }`. This trait performs that conversion.
+pub trait EcdsaSigEncoder {
+    /// Encodes `(r, s)` as DER `SEQUENCE { INTEGER r, INTEGER s }`.
+    ///
+    /// Each component is treated as an unsigned big-endian magnitude:
+    /// implementations MUST strip leading zero bytes and prepend a single
+    /// `0x00` when the high bit of the leading byte would otherwise make the
+    /// integer negative under DER's signed-integer rules.
+    fn encode_ecdsa_sig(r: &[u8], s: &[u8]) -> Result<Vec<u8>>;
+}
+
+/// Cryptographic primitives required by quote verification: the ECDSA
+/// signature verification algorithm passed to webpki, plus a SHA-256 hash.
+///
+/// Implementations are typically zero-sized marker types whose methods are
+/// associated functions delegating to a chosen crypto crate (ring, RustCrypto,
+/// hardware accelerator, etc.).
+pub trait CryptoProvider {
+    /// ECDSA P-256 SHA-256 algorithm passed to webpki's signature verifier.
+    fn sig_algo() -> &'static dyn rustls_pki_types::SignatureVerificationAlgorithm;
+    /// SHA-256 of `data`.
+    fn sha256(data: &[u8]) -> [u8; 32];
+}
+
+/// Configuration bundle selecting an implementation for each pluggable
+/// component.
+///
+/// Implementations are typically zero-sized marker types. Adding a new
+/// pluggable component in the future means adding a new associated type here,
+/// which is backwards-compatible (existing custom configs continue to work as
+/// long as they implement the new associated type — defaulted with a `where`
+/// clause if needed).
+pub trait Config {
+    /// X.509 certificate parser.
+    type X509: X509Codec;
+    /// ECDSA `r ‖ s` → DER `Ecdsa-Sig-Value` encoder.
+    type SigEncoder: EcdsaSigEncoder;
+    /// Cryptographic primitives (ECDSA signature verification + SHA-256).
+    type Crypto: CryptoProvider;
+}

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,0 +1,49 @@
+//! Preset [`Config`] bundles built from the audited in-tree backends.
+//!
+//! Each bundle pairs the audited X.509 parser ([`X509CertBackend`]) and
+//! signature encoder ([`DerSigEncoder`]) with one of the available
+//! [`CryptoProvider`](crate::config::CryptoProvider) implementations.
+//! [`DefaultConfig`] is a feature-selected type alias picking the right
+//! preset based on which crypto feature is enabled.
+
+use crate::config::Config;
+use crate::signature::DerSigEncoder;
+use crate::x509::X509CertBackend;
+
+#[cfg(feature = "ring")]
+use crate::crypto::RingCrypto;
+#[cfg(feature = "rustcrypto")]
+use crate::crypto::RustCryptoCrypto;
+
+/// Audited config pairing the `der` / `x509-cert` parser with the `ring`
+/// crypto provider. Selected as [`DefaultConfig`] when the `ring` feature is
+/// enabled.
+#[cfg(feature = "ring")]
+pub struct RingConfig;
+
+#[cfg(feature = "ring")]
+impl Config for RingConfig {
+    type X509 = X509CertBackend;
+    type SigEncoder = DerSigEncoder;
+    type Crypto = RingCrypto;
+}
+
+/// Audited config pairing the `der` / `x509-cert` parser with the RustCrypto
+/// crypto provider.
+#[cfg(feature = "rustcrypto")]
+pub struct RustCryptoConfig;
+
+#[cfg(feature = "rustcrypto")]
+impl Config for RustCryptoConfig {
+    type X509 = X509CertBackend;
+    type SigEncoder = DerSigEncoder;
+    type Crypto = RustCryptoCrypto;
+}
+
+/// Audited default config: prefers [`RingConfig`] if the `ring` feature is on,
+/// otherwise [`RustCryptoConfig`].
+#[cfg(feature = "ring")]
+pub type DefaultConfig = RingConfig;
+
+#[cfg(all(not(feature = "ring"), feature = "rustcrypto"))]
+pub type DefaultConfig = RustCryptoConfig;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,44 @@
+//! Audited [`CryptoProvider`] implementations.
+//!
+//! [`RingCrypto`] (gated by `ring`) and [`RustCryptoCrypto`] (gated by
+//! `rustcrypto`) are selected by [`crate::configs::RingConfig`] /
+//! [`crate::configs::RustCryptoConfig`] respectively.
+
+use crate::config::CryptoProvider;
+
+/// Audited [`CryptoProvider`] backed by the `ring` crate (gated by the `ring`
+/// feature). Selected by [`crate::configs::RingConfig`] /
+/// [`crate::configs::DefaultConfig`].
+#[cfg(feature = "ring")]
+pub struct RingCrypto;
+
+#[cfg(feature = "ring")]
+impl CryptoProvider for RingCrypto {
+    fn sig_algo() -> &'static dyn rustls_pki_types::SignatureVerificationAlgorithm {
+        webpki::ring::ECDSA_P256_SHA256
+    }
+
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        let digest = ::ring::digest::digest(&::ring::digest::SHA256, data);
+        let mut out = [0u8; 32];
+        out.copy_from_slice(digest.as_ref());
+        out
+    }
+}
+
+/// Audited [`CryptoProvider`] backed by RustCrypto (`sha2` + `p256`, gated by
+/// the `rustcrypto` feature). Selected by [`crate::configs::RustCryptoConfig`].
+#[cfg(feature = "rustcrypto")]
+pub struct RustCryptoCrypto;
+
+#[cfg(feature = "rustcrypto")]
+impl CryptoProvider for RustCryptoCrypto {
+    fn sig_algo() -> &'static dyn rustls_pki_types::SignatureVerificationAlgorithm {
+        webpki::rustcrypto::ECDSA_P256_SHA256
+    }
+
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        use sha2::Digest;
+        sha2::Sha256::digest(data).into()
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -305,11 +305,11 @@ pub unsafe extern "C" fn dcap_parse_quote_cb(
     // For cert_type 5: extract fmspc/ca from embedded cert chain
     // For cert_type 2/3: these are unavailable until PCK cert is fetched
     let (fmspc, ca) = if cert_chain_pem.is_some() {
-        let fmspc = match parsed.fmspc() {
+        let fmspc = match crate::intel::quote_fmspc(&parsed) {
             Ok(f) => Some(hex::encode_upper(f)),
             Err(e) => return emit_error(format_error(&e), cb, user_data),
         };
-        let ca = match parsed.ca() {
+        let ca = match crate::intel::quote_ca(&parsed) {
             Ok(c) => Some(c.to_string()),
             Err(e) => return emit_error(format_error(&e), cb, user_data),
         };
@@ -420,7 +420,7 @@ pub unsafe extern "C" fn dcap_verify_with_root_ca_cb(
         }
     };
 
-    let verifier = verify::QuoteVerifier::new(root_ca.to_vec(), verify::default_crypto::backend());
+    let verifier = verify::QuoteVerifier::new(root_ca.to_vec());
 
     let report = match verifier.verify(quote_slice, &collateral, now_secs) {
         Ok(r) => r,

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -4,9 +4,10 @@ use asn1_der::{
     DerObject,
 };
 
+#[cfg(feature = "default-x509")]
+use crate::configs::DefaultConfig;
 use crate::{
     config::{Config, ParsedCert, X509Codec},
-    configs::DefaultConfig,
     constants::{self, CpuSvn, Fmspc, Svn},
     oids,
     quote::{AuthData, Quote},
@@ -94,6 +95,7 @@ pub fn parse_pck_extension_with<C: Config>(cert_der: &[u8]) -> Result<PckExtensi
 ///
 /// Uses the audited [`DefaultConfig`]. For a custom backend, use
 /// [`parse_pck_extension_with`].
+#[cfg(feature = "default-x509")]
 pub fn parse_pck_extension(cert_der: &[u8]) -> Result<PckExtension> {
     parse_pck_extension_with::<DefaultConfig>(cert_der)
 }
@@ -112,6 +114,7 @@ pub fn parse_pck_extension_from_pem_with<C: Config>(pem_data: &[u8]) -> Result<P
 /// The first (leaf) certificate in the chain is used. Uses the audited
 /// [`DefaultConfig`]. For a custom backend, use
 /// [`parse_pck_extension_from_pem_with`].
+#[cfg(feature = "default-x509")]
 pub fn parse_pck_extension_from_pem(pem_data: &[u8]) -> Result<PckExtension> {
     parse_pck_extension_from_pem_with::<DefaultConfig>(pem_data)
 }
@@ -138,6 +141,7 @@ pub fn pck_ca_with<C: Config>(cert_der: &[u8]) -> Result<&'static str> {
 }
 
 /// [`pck_ca_with`] under the audited [`DefaultConfig`].
+#[cfg(feature = "default-x509")]
 pub fn pck_ca(cert_der: &[u8]) -> Result<&'static str> {
     pck_ca_with::<DefaultConfig>(cert_der)
 }
@@ -153,6 +157,7 @@ pub fn quote_fmspc_with<C: Config>(quote: &Quote) -> Result<Fmspc> {
 }
 
 /// [`quote_fmspc_with`] under the audited [`DefaultConfig`].
+#[cfg(feature = "default-x509")]
 pub fn quote_fmspc(quote: &Quote) -> Result<Fmspc> {
     quote_fmspc_with::<DefaultConfig>(quote)
 }
@@ -167,6 +172,7 @@ pub fn quote_ca_with<C: Config>(quote: &Quote) -> Result<&'static str> {
 }
 
 /// [`quote_ca_with`] under the audited [`DefaultConfig`].
+#[cfg(feature = "default-x509")]
 pub fn quote_ca(quote: &Quote) -> Result<&'static str> {
     quote_ca_with::<DefaultConfig>(quote)
 }

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -5,6 +5,8 @@ use asn1_der::{
 };
 
 use crate::{
+    config::{Config, ParsedCert, X509Codec},
+    configs::DefaultConfig,
     constants::{self, CpuSvn, Fmspc, Svn},
     oids,
     quote::{AuthData, Quote},
@@ -64,9 +66,9 @@ pub fn extract_cert_chain(quote: &Quote) -> Result<Vec<Vec<u8>>> {
     );
 }
 
-/// Parse the Intel SGX extension values from a DER-encoded PCK certificate.
-pub fn parse_pck_extension(cert_der: &[u8]) -> Result<PckExtension> {
-    let extension = utils::get_intel_extension(cert_der)?;
+/// Generic version of [`parse_pck_extension`] using a custom [`Config`].
+pub fn parse_pck_extension_with<C: Config>(cert_der: &[u8]) -> Result<PckExtension> {
+    let extension = utils::get_intel_extension_with::<C>(cert_der)?;
 
     let ppid = find_extension_required(&[oids::PPID], &extension)?;
     let cpu_svn = utils::get_cpu_svn(&extension)?;
@@ -88,15 +90,85 @@ pub fn parse_pck_extension(cert_der: &[u8]) -> Result<PckExtension> {
     })
 }
 
-/// Parse the Intel SGX extension from a PEM-encoded certificate chain.
+/// Parse the Intel SGX extension values from a DER-encoded PCK certificate.
 ///
-/// The first (leaf) certificate in the chain is used.
-pub fn parse_pck_extension_from_pem(pem_data: &[u8]) -> Result<PckExtension> {
+/// Uses the audited [`DefaultConfig`]. For a custom backend, use
+/// [`parse_pck_extension_with`].
+pub fn parse_pck_extension(cert_der: &[u8]) -> Result<PckExtension> {
+    parse_pck_extension_with::<DefaultConfig>(cert_der)
+}
+
+/// Generic version of [`parse_pck_extension_from_pem`] using a custom [`Config`].
+pub fn parse_pck_extension_from_pem_with<C: Config>(pem_data: &[u8]) -> Result<PckExtension> {
     let certs = utils::extract_certs(pem_data)?;
     let leaf = certs
         .first()
         .ok_or_else(|| anyhow!("No certificates found in PEM chain"))?;
-    parse_pck_extension(leaf)
+    parse_pck_extension_with::<C>(leaf)
+}
+
+/// Parse the Intel SGX extension from a PEM-encoded certificate chain.
+///
+/// The first (leaf) certificate in the chain is used. Uses the audited
+/// [`DefaultConfig`]. For a custom backend, use
+/// [`parse_pck_extension_from_pem_with`].
+pub fn parse_pck_extension_from_pem(pem_data: &[u8]) -> Result<PckExtension> {
+    parse_pck_extension_from_pem_with::<DefaultConfig>(pem_data)
+}
+
+/// Classify the PCK certificate authority of a leaf cert as
+/// [`crate::constants::PROCESSOR_ISSUER_ID`] or
+/// [`crate::constants::PLATFORM_ISSUER_ID`] by inspecting the issuer DN.
+///
+/// Generic over [`Config`]; the issuer DN extraction goes through the
+/// configured [`X509Codec`].
+pub fn pck_ca_with<C: Config>(cert_der: &[u8]) -> Result<&'static str> {
+    let issuer = C::X509::from_der(cert_der)
+        .context("Failed to decode certificate")?
+        .issuer_dn()
+        .context("Failed to extract certificate issuer")?;
+    if issuer.contains(constants::PROCESSOR_ISSUER) {
+        Ok(constants::PROCESSOR_ISSUER_ID)
+    } else if issuer.contains(constants::PLATFORM_ISSUER) {
+        Ok(constants::PLATFORM_ISSUER_ID)
+    } else {
+        // Preserve legacy fallback behavior: unknown issuer is treated as processor.
+        Ok(constants::PROCESSOR_ISSUER_ID)
+    }
+}
+
+/// [`pck_ca_with`] under the audited [`DefaultConfig`].
+pub fn pck_ca(cert_der: &[u8]) -> Result<&'static str> {
+    pck_ca_with::<DefaultConfig>(cert_der)
+}
+
+/// Return the FMSPC of a quote's PCK leaf certificate.
+///
+/// Convenience over [`extract_cert_chain`] + [`parse_pck_extension_with`];
+/// generic over [`Config`].
+pub fn quote_fmspc_with<C: Config>(quote: &Quote) -> Result<Fmspc> {
+    let chain = extract_cert_chain(quote)?;
+    let leaf = chain.first().context("Empty PCK certificate chain")?;
+    Ok(parse_pck_extension_with::<C>(leaf)?.fmspc)
+}
+
+/// [`quote_fmspc_with`] under the audited [`DefaultConfig`].
+pub fn quote_fmspc(quote: &Quote) -> Result<Fmspc> {
+    quote_fmspc_with::<DefaultConfig>(quote)
+}
+
+/// Return the PCK CA classification of a quote's PCK leaf certificate.
+///
+/// Generic over [`Config`].
+pub fn quote_ca_with<C: Config>(quote: &Quote) -> Result<&'static str> {
+    let chain = extract_cert_chain(quote)?;
+    let leaf = chain.first().context("Empty PCK certificate chain")?;
+    pck_ca_with::<C>(leaf)
+}
+
+/// [`quote_ca_with`] under the audited [`DefaultConfig`].
+pub fn quote_ca(quote: &Quote) -> Result<&'static str> {
+    quote_ca_with::<DefaultConfig>(quote)
 }
 
 fn find_extension_required(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,13 @@ pub mod collateral;
 pub use collateral::PHALA_PCCS_URL;
 
 pub mod config;
+#[cfg(feature = "default-x509")]
 pub mod configs;
 pub mod crypto;
 pub mod oids;
+#[cfg(feature = "default-x509")]
 pub mod signature;
+#[cfg(feature = "default-x509")]
 pub mod x509;
 
 mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,12 @@ pub mod collateral;
 #[cfg(feature = "report")]
 pub use collateral::PHALA_PCCS_URL;
 
+pub mod config;
+pub mod configs;
+pub mod crypto;
 pub mod oids;
+pub mod signature;
+pub mod x509;
 
 mod constants;
 pub mod intel;

--- a/src/python.rs
+++ b/src/python.rs
@@ -474,14 +474,14 @@ impl PyQuote {
     }
 
     fn fmspc(&self) -> PyResult<String> {
-        match self.inner.fmspc() {
+        match intel::quote_fmspc(&self.inner) {
             Ok(fmspc) => Ok(hex::encode_upper(fmspc)),
             Err(e) => Err(PyValueError::new_err(format!("Failed to get FMSPC: {}", e))),
         }
     }
 
     fn ca(&self) -> PyResult<String> {
-        match self.inner.ca() {
+        match intel::quote_ca(&self.inner) {
             Ok(ca) => Ok(ca.to_string()),
             Err(e) => Err(PyValueError::new_err(format!("Failed to get CA: {}", e))),
         }
@@ -563,10 +563,7 @@ fn py_verify_with_root_ca(
     let quote_bytes = raw_quote.as_bytes();
     let root_ca = root_ca_der.as_bytes();
 
-    let verifier = crate::verify::QuoteVerifier::new(
-        root_ca.to_vec(),
-        crate::verify::default_crypto::backend(),
-    );
+    let verifier = crate::verify::QuoteVerifier::new(root_ca.to_vec());
     match verifier.verify(quote_bytes, &collateral.inner, now_secs) {
         Ok(verified_report) => Ok(PyVerifiedReport {
             inner: verified_report,

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -1,20 +1,16 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use scale::{Decode, Encode, Input, Output};
 use serde::{Deserialize, Serialize};
-use x509_cert::Certificate;
 
 #[cfg(feature = "borsh_schema")]
 use borsh::BorshSchema;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::{
-    constants::{self, *},
-    utils,
-};
+use crate::constants::*;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
@@ -618,37 +614,6 @@ impl Quote {
             bail!("Unsupported cert type: {}", cert_data.cert_type);
         }
         Ok(&cert_data.body.data)
-    }
-
-    /// Get the FMSPC from the quote.
-    pub fn fmspc(&self) -> Result<Fmspc> {
-        let raw_cert_chain = self
-            .raw_cert_chain()
-            .context("Failed to get raw cert chain")?;
-        let certs = utils::extract_certs(raw_cert_chain).context("Failed to extract certs")?;
-        let cert = certs.first().ok_or(anyhow!("Invalid certificate"))?;
-        let extension_section =
-            utils::get_intel_extension(cert).context("Failed to get Intel extension")?;
-        utils::get_fmspc(&extension_section)
-    }
-
-    /// Get the Certificate Authority (CA) type from the quote.
-    /// Returns "processor" or "platform" based on the issuer of the PCK certificate.
-    pub fn ca(&self) -> Result<&'static str> {
-        let raw_cert_chain = self
-            .raw_cert_chain()
-            .context("Failed to get raw cert chain")?;
-        let certs = utils::extract_certs(raw_cert_chain).context("Failed to extract certs")?;
-        let cert = certs.first().ok_or(anyhow!("Invalid certificate"))?;
-        let cert_der: Certificate =
-            der::Decode::from_der(cert).context("Failed to decode certificate")?;
-        let issuer = cert_der.tbs_certificate.issuer.to_string();
-        if issuer.contains(constants::PROCESSOR_ISSUER) {
-            return Ok(constants::PROCESSOR_ISSUER_ID);
-        } else if issuer.contains(constants::PLATFORM_ISSUER) {
-            return Ok(constants::PLATFORM_ISSUER_ID);
-        }
-        Ok(constants::PROCESSOR_ISSUER_ID)
     }
 
     /// Get the length of signed data in the quote.

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,39 @@
+//! Audited [`EcdsaSigEncoder`] implementation backed by `der`.
+//!
+//! Selected by [`crate::configs::RingConfig`] / [`crate::configs::RustCryptoConfig`]
+//! / [`crate::configs::DefaultConfig`].
+
+use alloc::vec::Vec;
+use anyhow::{Context, Result};
+
+use crate::config::EcdsaSigEncoder;
+
+/// Audited default [`EcdsaSigEncoder`] implementation, built on `der`.
+///
+/// Stateless zero-sized marker type.
+pub struct DerSigEncoder;
+
+impl EcdsaSigEncoder for DerSigEncoder {
+    fn encode_ecdsa_sig(r: &[u8], s: &[u8]) -> Result<Vec<u8>> {
+        let mut sequence = der::asn1::SequenceOf::<der::asn1::UintRef, 2>::new();
+        let r_int = der::asn1::UintRef::new(r).context("Failed to create r INTEGER")?;
+        sequence.add(r_int).context("Failed to add r INTEGER")?;
+        let s_int = der::asn1::UintRef::new(s).context("Failed to create s INTEGER")?;
+        sequence.add(s_int).context("Failed to add s INTEGER")?;
+        // Capacity: SEQUENCE header (≤4) + 2 × (INTEGER header (≤4) + payload + 1 sign byte)
+        let cap = 8usize
+            .checked_add(r.len())
+            .and_then(|n| n.checked_add(s.len()))
+            .and_then(|n| n.checked_add(2))
+            .context("encode_ecdsa_sig capacity overflow")?;
+        let mut buf = alloc::vec![0u8; cap];
+        let mut writer = der::SliceWriter::new(&mut buf);
+        writer
+            .encode(&sequence)
+            .context("Failed to encode ECDSA signature sequence")?;
+        Ok(writer
+            .finish()
+            .context("Failed to finalize ECDSA signature sequence")?
+            .to_vec())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,28 +7,19 @@ use asn1_der::{
 use rustls_pki_types::{CertificateDer, TrustAnchor, UnixTime};
 use webpki::CertRevocationList;
 use webpki::{self, OwnedCertRevocationList};
-use x509_cert::Certificate;
 
-use crate::{constants::*, oids};
+use crate::{
+    config::{Config, ParsedCert, X509Codec},
+    constants::*,
+    oids,
+};
 
-pub fn get_intel_extension(der_encoded: &[u8]) -> Result<Vec<u8>> {
-    let cert: Certificate =
-        der::Decode::from_der(der_encoded).context("Failed to decode certificate")?;
-    let mut extension_iter = cert
-        .tbs_certificate
-        .extensions
-        .as_deref()
-        .unwrap_or(&[])
-        .iter()
-        .filter(|e| e.extn_id == oids::SGX_EXTENSION)
-        .map(|e| e.extn_value.clone());
-
-    let extension = extension_iter.next().context("Intel extension not found")?;
-    if extension_iter.next().is_some() {
-        //"There should only be one Intel extension"
-        bail!("Intel extension ambiguity");
-    }
-    Ok(extension.into_bytes())
+/// Look up the Intel SGX OID extension's OCTET STRING contents in a PCK
+/// certificate. Generic over [`Config`].
+pub fn get_intel_extension_with<C: Config>(der_encoded: &[u8]) -> Result<Vec<u8>> {
+    C::X509::from_der(der_encoded)?
+        .extension(oids::SGX_EXTENSION.as_bytes())?
+        .context("Intel extension not found")
 }
 
 pub fn find_extension(path: &[&[u8]], raw: &[u8]) -> Result<Vec<u8>> {
@@ -116,27 +107,12 @@ pub fn extract_certs<'a>(cert_chain: &'a [u8]) -> Result<Vec<CertificateDer<'a>>
     Ok(certs)
 }
 
-/// Encode two 32-byte values in DER format
-/// This is meant for 256 bit ECC signatures or public keys
-/// TODO: We could use `asn1_der` crate to reimplement this, so we can remove `der` which overlaps with `asn1_der`
-pub fn encode_as_der(data: &[u8]) -> Result<Vec<u8>> {
+/// Split a 64-byte raw `r ‖ s` payload at byte 32 and DER-encode it as
+/// `Ecdsa-Sig-Value` (RFC 5480) using the [`Config::SigEncoder`] of `C`.
+pub fn encode_as_der_with<C: Config>(data: &[u8]) -> Result<Vec<u8>> {
+    use crate::config::EcdsaSigEncoder;
     let (first, second) = data.split_at_checked(32).context("Invalid key length")?;
-    let mut sequence = der::asn1::SequenceOf::<der::asn1::UintRef, 2>::new();
-    let element0 = der::asn1::UintRef::new(first).context("Failed to add first element")?;
-    sequence
-        .add(element0)
-        .context("Failed to add second element")?;
-    let element1 = der::asn1::UintRef::new(second).context("Failed to add second element")?;
-    sequence
-        .add(element1)
-        .context("Failed to add third element")?;
-    // 72 should be enough in all cases. 2 + 2 x (32 + 3)
-    let mut asn1 = alloc::vec![0u8; 72];
-    let mut writer = der::SliceWriter::new(&mut asn1);
-    writer
-        .encode(&sequence)
-        .context("Failed to encode sequence")?;
-    Ok(writer.finish().context("Failed to finish writer")?.to_vec())
+    C::SigEncoder::encode_ecdsa_sig(first, second)
 }
 
 /// Parse CRL DER bytes into CertRevocationList objects.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -13,10 +13,11 @@ use {
     alloc::vec::Vec,
 };
 
+#[cfg(feature = "default-x509")]
+use crate::configs::DefaultConfig;
 pub use crate::quote::{AuthData, EnclaveReport, Quote};
 use crate::{
     config::{Config, CryptoProvider},
-    configs::DefaultConfig,
     quote::{Report, TDAttributes},
     utils::{encode_as_der_with, extract_certs, parse_crls, verify_certificate_chain},
 };
@@ -104,6 +105,7 @@ impl QuoteVerifier {
 
     /// Verify a quote with the configured root certificate, using
     /// [`DefaultConfig`].
+    #[cfg(feature = "default-x509")]
     pub fn verify(
         &self,
         raw_quote: &[u8],
@@ -133,7 +135,7 @@ impl QuoteVerifier {
 
     /// Like [`Self::verify`], but takes a closure to mutate TCB info after the
     /// signature check passes. Uses [`DefaultConfig`].
-    #[cfg(feature = "danger-allow-tcb-override")]
+    #[cfg(all(feature = "default-x509", feature = "danger-allow-tcb-override"))]
     pub fn dangerous_verify_with_tcb_override(
         &self,
         raw_quote: &[u8],
@@ -169,7 +171,7 @@ impl QuoteVerifier {
     }
 }
 
-#[cfg(all(feature = "js", feature = "_anycrypto"))]
+#[cfg(all(feature = "js", feature = "_anycrypto", feature = "default-x509"))]
 #[wasm_bindgen]
 pub fn js_verify(
     raw_quote: JsValue,
@@ -190,7 +192,7 @@ pub fn js_verify(
         .map_err(|_| JsValue::from_str("Failed to encode verified_report"))
 }
 
-#[cfg(all(feature = "js", feature = "_anycrypto"))]
+#[cfg(all(feature = "js", feature = "_anycrypto", feature = "default-x509"))]
 #[wasm_bindgen]
 pub fn js_verify_with_root_ca(
     raw_quote: JsValue,
@@ -919,7 +921,7 @@ fn validate_attrs(report: &Report) -> Result<()> {
 /// Convenience entry points pinning the [`crate::configs::RingConfig`]
 /// (audited cert parser + sig encoder + ring crypto). Equivalent to calling
 /// `verify_with::<RingConfig>(...)` on a default `QuoteVerifier`.
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "ring", feature = "default-x509"))]
 pub mod ring {
     use super::*;
     pub use crate::configs::RingConfig;
@@ -956,7 +958,7 @@ pub mod ring {
 /// [`crate::configs::RustCryptoConfig`] (audited cert parser + sig
 /// encoder + RustCrypto crypto). Equivalent to calling
 /// `verify_with::<RustCryptoConfig>(...)` on a default `QuoteVerifier`.
-#[cfg(feature = "rustcrypto")]
+#[cfg(all(feature = "rustcrypto", feature = "default-x509"))]
 pub mod rustcrypto {
     use super::*;
     pub use crate::configs::RustCryptoConfig;
@@ -996,7 +998,7 @@ pub mod rustcrypto {
 /// `ring` crypto provider when the `ring` feature is enabled, otherwise
 /// `rustcrypto`. To pin a specific config, use [`verify_with`] or one of the
 /// [`ring::verify`] / [`rustcrypto::verify`] convenience entry points.
-#[cfg(feature = "_anycrypto")]
+#[cfg(all(feature = "_anycrypto", feature = "default-x509"))]
 pub fn verify(
     raw_quote: &[u8],
     collateral: &QuoteCollateralV3,
@@ -1018,7 +1020,11 @@ pub fn verify_with<C: Config>(
 
 /// Like [`verify`], but takes a closure to mutate TCB info after the
 /// signature check. Uses [`DefaultConfig`].
-#[cfg(all(feature = "_anycrypto", feature = "danger-allow-tcb-override"))]
+#[cfg(all(
+    feature = "_anycrypto",
+    feature = "default-x509",
+    feature = "danger-allow-tcb-override"
+))]
 pub fn dangerous_verify_with_tcb_override(
     raw_quote: &[u8],
     collateral: &QuoteCollateralV3,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -15,8 +15,10 @@ use {
 
 pub use crate::quote::{AuthData, EnclaveReport, Quote};
 use crate::{
+    config::{Config, CryptoProvider},
+    configs::DefaultConfig,
     quote::{Report, TDAttributes},
-    utils::{encode_as_der, extract_certs, parse_crls, verify_certificate_chain},
+    utils::{encode_as_der_with, extract_certs, parse_crls, verify_certificate_chain},
 };
 use crate::{
     quote::{TDReport10, TDReport15},
@@ -24,23 +26,6 @@ use crate::{
 };
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "ring")]
-pub(crate) use self::ring as default_crypto;
-#[cfg(all(not(feature = "ring"), feature = "rustcrypto"))]
-pub(crate) use self::rustcrypto as default_crypto;
-
-/// Crypto backend configuration for quote verification.
-///
-/// Holds the signature verification algorithm and SHA-256 implementation
-/// needed by the verification logic. Use [`ring::backend()`] or
-/// [`rustcrypto::backend()`] to obtain a pre-configured instance.
-pub struct CryptoBackend {
-    /// ECDSA P-256 SHA-256 algorithm for certificate and raw signature verification
-    pub sig_algo: &'static dyn rustls_pki_types::SignatureVerificationAlgorithm,
-    /// SHA-256 hash function
-    pub sha256: fn(&[u8]) -> [u8; 32],
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TeeType {
@@ -95,67 +80,59 @@ pub struct VerifiedReport {
     pub platform_status: TcbStatusWithAdvisory,
 }
 
-/// Quote verifier with configurable root certificate and crypto backend.
+/// Quote verifier with a configurable root certificate.
 ///
-/// This allows using custom root certificates for testing or private deployments,
-/// and selecting between different cryptographic backends (ring or rustcrypto).
+/// All other configurable choices (X.509 parser, signature encoder, crypto
+/// primitives) are selected at the call site by passing a [`Config`] type
+/// parameter to [`Self::verify_with`] / [`Self::dangerous_verify_with_tcb_override_with`].
+/// The non-generic [`Self::verify`] / [`Self::dangerous_verify_with_tcb_override`]
+/// methods use [`DefaultConfig`].
 pub struct QuoteVerifier {
     root_ca_der: Vec<u8>,
-    backend: CryptoBackend,
 }
 
 impl QuoteVerifier {
-    /// Create a new verifier with a custom root certificate and crypto backend.
-    pub fn new(root_ca_der: Vec<u8>, backend: CryptoBackend) -> Self {
-        Self {
-            root_ca_der,
-            backend,
-        }
+    /// Create a new verifier with a custom root certificate.
+    pub fn new(root_ca_der: Vec<u8>) -> Self {
+        Self { root_ca_der }
     }
 
-    /// Create a new verifier using Intel's production root certificate with ring backend.
-    pub fn new_prod(backend: CryptoBackend) -> Self {
-        Self::new(TRUSTED_ROOT_CA_DER.to_vec(), backend)
+    /// Create a new verifier using Intel's production root certificate.
+    pub fn new_prod() -> Self {
+        Self::new(TRUSTED_ROOT_CA_DER.to_vec())
     }
 
-    /// Verify a quote with the configured root certificate
-    ///
-    /// # Arguments
-    /// * `raw_quote` - The raw quote bytes
-    /// * `collateral` - The quote collateral
-    /// * `now_secs` - Current time in seconds since UNIX epoch
-    ///
-    /// # Returns
-    /// * `Ok(VerifiedReport)` - The verified report
-    /// * `Err(Error)` - The error
+    /// Verify a quote with the configured root certificate, using
+    /// [`DefaultConfig`].
     pub fn verify(
         &self,
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        verify_impl(
+        self.verify_with::<DefaultConfig>(raw_quote, collateral, now_secs)
+    }
+
+    /// Verify a quote, selecting an explicit [`Config`] for X.509 / DER /
+    /// crypto operations. Use this to plug in a custom backend.
+    pub fn verify_with<C: Config>(
+        &self,
+        raw_quote: &[u8],
+        collateral: &QuoteCollateralV3,
+        now_secs: u64,
+    ) -> Result<VerifiedReport> {
+        verify_impl::<C>(
             raw_quote,
             collateral,
             now_secs,
             &self.root_ca_der,
-            &self.backend,
             #[cfg(feature = "danger-allow-tcb-override")]
             None::<fn(_) -> _>,
         )
     }
 
-    /// Verify a quote with the configured root certificate, passing a TCB info override
-    ///
-    /// # Arguments
-    /// * `raw_quote` - The raw quote bytes
-    /// * `collateral` - The quote collateral
-    /// * `now_secs` - Current time in seconds since UNIX epoch
-    /// * `override_tcb_info` - a function which modifies TCB info after the signature check
-    ///
-    /// # Returns
-    /// * `Ok(VerifiedReport)` - The verified report
-    /// * `Err(Error)` - The error
+    /// Like [`Self::verify`], but takes a closure to mutate TCB info after the
+    /// signature check passes. Uses [`DefaultConfig`].
     #[cfg(feature = "danger-allow-tcb-override")]
     pub fn dangerous_verify_with_tcb_override(
         &self,
@@ -164,12 +141,29 @@ impl QuoteVerifier {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        verify_impl(
+        self.dangerous_verify_with_tcb_override_with::<DefaultConfig, _>(
+            raw_quote,
+            collateral,
+            now_secs,
+            override_tcb_info,
+        )
+    }
+
+    /// Variant of [`Self::dangerous_verify_with_tcb_override`] with an explicit
+    /// [`Config`].
+    #[cfg(feature = "danger-allow-tcb-override")]
+    pub fn dangerous_verify_with_tcb_override_with<C: Config, F: FnOnce(TcbInfo) -> TcbInfo>(
+        &self,
+        raw_quote: &[u8],
+        collateral: &QuoteCollateralV3,
+        now_secs: u64,
+        override_tcb_info: F,
+    ) -> Result<VerifiedReport> {
+        verify_impl::<C>(
             raw_quote,
             collateral,
             now_secs,
             &self.root_ca_der,
-            &self.backend,
             Some(override_tcb_info),
         )
     }
@@ -210,7 +204,7 @@ pub fn js_verify_with_root_ca(
     let root_ca_der: Vec<u8> = serde_wasm_bindgen::from_value(root_ca_der)
         .map_err(|_| JsValue::from_str("Failed to decode root_ca_der"))?;
 
-    let verifier = QuoteVerifier::new(root_ca_der, default_crypto::backend());
+    let verifier = QuoteVerifier::new(root_ca_der);
     let verified_report = verifier
         .verify(&raw_quote, &quote_collateral, now)
         .map_err(|e| {
@@ -243,12 +237,11 @@ pub async fn js_get_collateral(pccs_url: JsValue, raw_quote: JsValue) -> Result<
 // =============================================================================
 
 /// Verify TCB Info collateral: certificate chain, signature, parsing, and expiration check
-fn verify_tcb_info_signature(
+fn verify_tcb_info_signature<C: Config>(
     collateral: &QuoteCollateralV3,
     now: UnixTime,
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
-    backend: &CryptoBackend,
 ) -> Result<TcbInfo> {
     // Parse TCB Info
     let tcb_info = serde_json::from_str::<TcbInfo>(&collateral.tcb_info)
@@ -278,10 +271,10 @@ fn verify_tcb_info_signature(
     verify_certificate_chain(&tcb_leaf_cert, tcb_chain, now, crls, trust_anchor)?;
 
     // Verify signature
-    let asn1_signature = encode_as_der(&collateral.tcb_info_signature)?;
+    let asn1_signature = encode_as_der_with::<C>(&collateral.tcb_info_signature)?;
     if tcb_leaf_cert
         .verify_signature(
-            backend.sig_algo,
+            C::Crypto::sig_algo(),
             collateral.tcb_info.as_bytes(),
             &asn1_signature,
         )
@@ -298,12 +291,11 @@ fn verify_tcb_info_signature(
 // =============================================================================
 
 /// Verify QE Identity collateral: certificate chain, signature, parsing, and expiration check
-fn verify_qe_identity_signature(
+fn verify_qe_identity_signature<C: Config>(
     collateral: &QuoteCollateralV3,
     now: UnixTime,
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
-    backend: &CryptoBackend,
 ) -> Result<QeIdentity> {
     // Parse QE Identity
     let qe_identity = serde_json::from_str::<QeIdentity>(&collateral.qe_identity)
@@ -333,10 +325,10 @@ fn verify_qe_identity_signature(
     verify_certificate_chain(&qe_id_leaf_cert, qe_id_chain, now, crls, trust_anchor)?;
 
     // Verify signature
-    let qe_id_asn1_signature = encode_as_der(&collateral.qe_identity_signature)?;
+    let qe_id_asn1_signature = encode_as_der_with::<C>(&collateral.qe_identity_signature)?;
     if qe_id_leaf_cert
         .verify_signature(
-            backend.sig_algo,
+            C::Crypto::sig_algo(),
             collateral.qe_identity.as_bytes(),
             &qe_id_asn1_signature,
         )
@@ -356,7 +348,7 @@ fn verify_qe_identity_signature(
 ///
 /// Verifies the PCK certificate chain against the trusted root and CRLs.
 /// Extracts cpu_svn, pce_svn, fmspc, and ppid from the certificate.
-fn verify_pck_cert_chain(
+fn verify_pck_cert_chain<C: Config>(
     collateral: &QuoteCollateralV3,
     certification_data: &crate::quote::CertificationData,
     now: UnixTime,
@@ -385,7 +377,7 @@ fn verify_pck_cert_chain(
     verify_certificate_chain(&pck_leaf_cert, pck_chain, now, crls, trust_anchor)?;
 
     // Extract Intel extension data from PCK cert (parsed once)
-    let pck_ext = intel::parse_pck_extension(pck_leaf)?;
+    let pck_ext = intel::parse_pck_extension_with::<C>(pck_leaf)?;
 
     Ok(PckCertChainResult {
         pck_leaf_der: pck_leaf.as_ref().to_vec(),
@@ -410,18 +402,21 @@ struct PckCertChainResult {
 // =============================================================================
 
 /// Verify QE report signature using PCK certificate
-fn verify_qe_report_signature(
+fn verify_qe_report_signature<C: Config>(
     pck_leaf: &CertificateDer,
     auth_data: &crate::quote::AuthDataV3,
-    backend: &CryptoBackend,
 ) -> Result<EnclaveReport> {
     let pck_leaf_cert =
         webpki::EndEntityCert::try_from(pck_leaf).context("Failed to parse PCK certificate")?;
 
     // Verify QE report signature (signed by PCK)
-    let qe_report_signature = encode_as_der(&auth_data.qe_report_signature)?;
+    let qe_report_signature = encode_as_der_with::<C>(&auth_data.qe_report_signature)?;
     if pck_leaf_cert
-        .verify_signature(backend.sig_algo, &auth_data.qe_report, &qe_report_signature)
+        .verify_signature(
+            C::Crypto::sig_algo(),
+            &auth_data.qe_report,
+            &qe_report_signature,
+        )
         .is_err()
     {
         bail!("Signature is invalid for qe_report in quote");
@@ -440,10 +435,9 @@ fn verify_qe_report_signature(
 // =============================================================================
 
 /// Verify QE report hash matches attestation key and auth data (panic-free)
-fn verify_qe_report_data(
+fn verify_qe_report_data<C: Config>(
     qe_report: &EnclaveReport,
     auth_data: &crate::quote::AuthDataV3,
-    backend: &CryptoBackend,
 ) -> Result<()> {
     use crate::constants::{ATTESTATION_KEY_LEN, AUTHENTICATION_DATA_LEN};
 
@@ -455,7 +449,7 @@ fn verify_qe_report_data(
     let mut qe_hash_data = [0u8; ATTESTATION_KEY_LEN + AUTHENTICATION_DATA_LEN];
     qe_hash_data[..ATTESTATION_KEY_LEN].copy_from_slice(&auth_data.ecdsa_attestation_key);
     qe_hash_data[ATTESTATION_KEY_LEN..].copy_from_slice(&auth_data.qe_auth_data.data);
-    let qe_hash = (backend.sha256)(&qe_hash_data);
+    let qe_hash = C::Crypto::sha256(&qe_hash_data);
     if qe_hash[..] != qe_report.report_data[..32] {
         bail!("QE report hash mismatch");
     }
@@ -473,25 +467,23 @@ fn verify_qe_report_data(
 // =============================================================================
 
 /// Verify ISV enclave report signature using attestation key
-fn verify_isv_report_signature(
+fn verify_isv_report_signature<C: Config>(
     raw_quote: &[u8],
     quote: &Quote,
     auth_data: &crate::quote::AuthDataV3,
-    backend: &CryptoBackend,
 ) -> Result<()> {
     // Prepend 0x04 to raw public key for SEC1 uncompressed format
     let mut pub_key = [0x04u8; 65];
     pub_key[1..].copy_from_slice(&auth_data.ecdsa_attestation_key);
 
     // DER-encode the raw r||s signature for SignatureVerificationAlgorithm
-    let der_sig = encode_as_der(&auth_data.ecdsa_signature)?;
+    let der_sig = encode_as_der_with::<C>(&auth_data.ecdsa_signature)?;
 
     let signed_data = raw_quote
         .get(..quote.signed_length())
         .context("Failed to get signed quote scope")?;
 
-    backend
-        .sig_algo
+    C::Crypto::sig_algo()
         .verify_signature(&pub_key, signed_data, &der_sig)
         .map_err(|_| anyhow::anyhow!("ISV enclave report signature is invalid"))
 }
@@ -753,12 +745,11 @@ fn match_tdx_module_identity(
 /// 8. Match Platform TCB (PCK Cert's CPU_SVN/PCE_SVN/FMSPC vs TCB Info)
 /// 9. Match QE TCB (QE Report's ISVSVN vs QE Identity tcb_levels)
 /// 10. Merge TCB statuses
-fn verify_impl(
+fn verify_impl<C: Config>(
     raw_quote: &[u8],
     collateral: &QuoteCollateralV3,
     now_secs: u64,
     root_ca_der: &[u8],
-    backend: &CryptoBackend,
     #[cfg(feature = "danger-allow-tcb-override")] override_tcb_info: Option<
         impl FnOnce(TcbInfo) -> TcbInfo,
     >,
@@ -805,7 +796,7 @@ fn verify_impl(
 
     // Step 1: Verify TCB Info signature
     let mut tcb_info =
-        verify_tcb_info_signature(collateral, now, &crls, trust_anchor.clone(), backend)?;
+        verify_tcb_info_signature::<C>(collateral, now, &crls, trust_anchor.clone())?;
 
     #[cfg(feature = "danger-allow-tcb-override")]
     {
@@ -820,7 +811,7 @@ fn verify_impl(
 
     // Step 2: Verify QE Identity signature
     let qe_identity =
-        verify_qe_identity_signature(collateral, now, &crls, trust_anchor.clone(), backend)?;
+        verify_qe_identity_signature::<C>(collateral, now, &crls, trust_anchor.clone())?;
     let (expected_qe_id, allowed_qe_versions): (&str, &[u8]) = match tee_type {
         TeeType::Sgx => ("QE", &[2]),
         TeeType::Tdx => ("TD_QE", &[2, 3]),
@@ -836,7 +827,7 @@ fn verify_impl(
     }
 
     // Step 3: Verify PCK certificate chain
-    let pck_result = verify_pck_cert_chain(
+    let pck_result = verify_pck_cert_chain::<C>(
         collateral,
         &auth_data.certification_data,
         now,
@@ -846,16 +837,16 @@ fn verify_impl(
     let pck_leaf = CertificateDer::from(pck_result.pck_leaf_der.as_slice());
 
     // Step 4: Verify QE Report signature
-    let qe_report = verify_qe_report_signature(&pck_leaf, &auth_data, backend)?;
+    let qe_report = verify_qe_report_signature::<C>(&pck_leaf, &auth_data)?;
 
     // Step 5: Verify QE Report content (hash check)
-    verify_qe_report_data(&qe_report, &auth_data, backend)?;
+    verify_qe_report_data::<C>(&qe_report, &auth_data)?;
 
     // Step 6: Verify QE Report policy
     let qe_status = verify_qe_identity_policy(&qe_report, &qe_identity)?;
 
     // Step 7: Verify ISV Report signature
-    verify_isv_report_signature(raw_quote, &quote, &auth_data, backend)?;
+    verify_isv_report_signature::<C>(raw_quote, &quote, &auth_data)?;
 
     // Step 8: Match Platform TCB
     let platform_status = match_platform_tcb(
@@ -925,40 +916,26 @@ fn validate_attrs(report: &Report) -> Result<()> {
     }
 }
 
-/// Ring crypto backend module.
-///
-/// Provides a pre-configured [`CryptoBackend`] using ring for ECDSA P-256 and SHA-256.
+/// Convenience entry points pinning the [`crate::configs::RingConfig`]
+/// (audited cert parser + sig encoder + ring crypto). Equivalent to calling
+/// `verify_with::<RingConfig>(...)` on a default `QuoteVerifier`.
 #[cfg(feature = "ring")]
 pub mod ring {
     use super::*;
+    pub use crate::configs::RingConfig;
 
-    fn ring_sha256(data: &[u8]) -> [u8; 32] {
-        let digest = ::ring::digest::digest(&::ring::digest::SHA256, data);
-        let mut out = [0u8; 32];
-        out.copy_from_slice(digest.as_ref());
-        out
-    }
-
-    /// Returns a [`CryptoBackend`] backed by ring.
-    pub fn backend() -> CryptoBackend {
-        CryptoBackend {
-            sig_algo: webpki::ring::ECDSA_P256_SHA256,
-            sha256: ring_sha256,
-        }
-    }
-
-    /// Verify a quote using Intel's trusted root CA and ring backend.
+    /// Verify a quote using Intel's trusted root CA and the ring crypto provider.
     pub fn verify(
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new(TRUSTED_ROOT_CA_DER.to_vec(), backend())
-            .verify(raw_quote, collateral, now_secs)
+        QuoteVerifier::new_prod().verify_with::<RingConfig>(raw_quote, collateral, now_secs)
     }
 
-    /// Verify a quote using Intel's trusted root CA and ring backend,
-    /// passing a function to override TCB info after the signature check
+    /// Verify a quote using Intel's trusted root CA and the ring crypto
+    /// provider, passing a function to override TCB info after the signature
+    /// check.
     #[cfg(feature = "danger-allow-tcb-override")]
     pub fn dangerous_verify_with_tcb_override(
         raw_quote: &[u8],
@@ -966,43 +943,37 @@ pub mod ring {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new(TRUSTED_ROOT_CA_DER.to_vec(), backend())
-            .dangerous_verify_with_tcb_override(raw_quote, collateral, now_secs, override_tcb_info)
+        QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<RingConfig, _>(
+            raw_quote,
+            collateral,
+            now_secs,
+            override_tcb_info,
+        )
     }
 }
 
-/// RustCrypto backend module.
-///
-/// Provides a pre-configured [`CryptoBackend`] using RustCrypto (sha2 + p256) for ECDSA P-256 and SHA-256.
+/// Convenience entry points pinning the
+/// [`crate::configs::RustCryptoConfig`] (audited cert parser + sig
+/// encoder + RustCrypto crypto). Equivalent to calling
+/// `verify_with::<RustCryptoConfig>(...)` on a default `QuoteVerifier`.
 #[cfg(feature = "rustcrypto")]
 pub mod rustcrypto {
     use super::*;
+    pub use crate::configs::RustCryptoConfig;
 
-    fn rustcrypto_sha256(data: &[u8]) -> [u8; 32] {
-        use sha2::Digest;
-        sha2::Sha256::digest(data).into()
-    }
-
-    /// Returns a [`CryptoBackend`] backed by RustCrypto.
-    pub fn backend() -> CryptoBackend {
-        CryptoBackend {
-            sig_algo: webpki::rustcrypto::ECDSA_P256_SHA256,
-            sha256: rustcrypto_sha256,
-        }
-    }
-
-    /// Verify a quote using Intel's trusted root CA and RustCrypto backend.
+    /// Verify a quote using Intel's trusted root CA and the RustCrypto
+    /// crypto provider.
     pub fn verify(
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new(TRUSTED_ROOT_CA_DER.to_vec(), backend())
-            .verify(raw_quote, collateral, now_secs)
+        QuoteVerifier::new_prod().verify_with::<RustCryptoConfig>(raw_quote, collateral, now_secs)
     }
 
-    /// Verify a quote using Intel's trusted root CA and RustCrypto backend,
-    /// passing a function to override TCB info after the signature check
+    /// Verify a quote using Intel's trusted root CA and the RustCrypto crypto
+    /// provider, passing a function to override TCB info after the signature
+    /// check.
     #[cfg(feature = "danger-allow-tcb-override")]
     pub fn dangerous_verify_with_tcb_override(
         raw_quote: &[u8],
@@ -1010,48 +981,73 @@ pub mod rustcrypto {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new(TRUSTED_ROOT_CA_DER.to_vec(), backend())
-            .dangerous_verify_with_tcb_override(raw_quote, collateral, now_secs, override_tcb_info)
+        QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<RustCryptoConfig, _>(
+            raw_quote,
+            collateral,
+            now_secs,
+            override_tcb_info,
+        )
     }
 }
 
-/// Verify a quote using Intel's trusted root CA (ring backend).
+/// Verify a quote using Intel's trusted root CA, with [`DefaultConfig`].
 ///
-/// This is a backwards-compatible convenience function that uses the ring backend.
-/// For rustcrypto, use [`rustcrypto::verify()`].
-///
-/// # Arguments
-///
-/// * `raw_quote` - The raw quote to verify. Supported SGX and TDX quotes.
-/// * `quote_collateral` - The quote collateral to verify. Can be obtained from PCCS by `get_collateral`.
-/// * `now` - The current time in seconds since the Unix epoch
-///
-/// # Returns
-///
-/// * `Ok(VerifiedReport)` - The verified report
-/// * `Err(Error)` - The error
+/// `DefaultConfig` selects the audited cert parser + sig encoder, plus the
+/// `ring` crypto provider when the `ring` feature is enabled, otherwise
+/// `rustcrypto`. To pin a specific config, use [`verify_with`] or one of the
+/// [`ring::verify`] / [`rustcrypto::verify`] convenience entry points.
 #[cfg(feature = "_anycrypto")]
-pub use self::default_crypto::verify;
+pub fn verify(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::new_prod().verify(raw_quote, collateral, now_secs)
+}
 
-/// Verify a quote using Intel's trusted root CA (ring backend), passing a function which modifies
-/// TCB info after the signature check.
-///
-/// This is a backwards-compatible convenience function that uses the ring backend.
-/// For rustcrypto, use [`rustcrypto::dangerous_verify_with_tcb_override()`].
-///
-/// # Arguments
-///
-/// * `raw_quote` - The raw quote to verify. Supported SGX and TDX quotes.
-/// * `quote_collateral` - The quote collateral to verify. Can be obtained from PCCS by `get_collateral`.
-/// * `now` - The current time in seconds since the Unix epoch
-/// * `override_tcb_info` - a function which modifies TCB info after the signature check
-///
-/// # Returns
-///
-/// * `Ok(VerifiedReport)` - The verified report
-/// * `Err(Error)` - The error
+/// Variant of [`verify`] with an explicit [`Config`]. Use this to plug in a
+/// custom backend.
+#[cfg(feature = "_anycrypto")]
+pub fn verify_with<C: Config>(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::new_prod().verify_with::<C>(raw_quote, collateral, now_secs)
+}
+
+/// Like [`verify`], but takes a closure to mutate TCB info after the
+/// signature check. Uses [`DefaultConfig`].
 #[cfg(all(feature = "_anycrypto", feature = "danger-allow-tcb-override"))]
-pub use self::default_crypto::dangerous_verify_with_tcb_override;
+pub fn dangerous_verify_with_tcb_override(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+    override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::new_prod().dangerous_verify_with_tcb_override(
+        raw_quote,
+        collateral,
+        now_secs,
+        override_tcb_info,
+    )
+}
+
+/// Variant of [`dangerous_verify_with_tcb_override`] with an explicit [`Config`].
+#[cfg(all(feature = "_anycrypto", feature = "danger-allow-tcb-override"))]
+pub fn dangerous_verify_with_tcb_override_with<C: Config, F: FnOnce(TcbInfo) -> TcbInfo>(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+    override_tcb_info: F,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<C, _>(
+        raw_quote,
+        collateral,
+        now_secs,
+        override_tcb_info,
+    )
+}
 
 // =============================================================================
 // Step 6 & 9: Verify QE Report policy and match QE TCB

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -1,0 +1,62 @@
+//! Audited [`X509Codec`] implementation backed by `x509-cert` + `der`.
+//!
+//! Selected by [`crate::configs::RingConfig`] / [`crate::configs::RustCryptoConfig`]
+//! / [`crate::configs::DefaultConfig`].
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::config::{ParsedCert, X509Codec};
+
+/// Audited default [`X509Codec`] implementation, built on `x509-cert` + `der`.
+///
+/// Zero-sized factory; produces [`X509CertParsed`] from raw DER bytes. The
+/// `x509_cert::Certificate` type owns its parsed data, so this backend does
+/// not borrow from the input slice — but the GAT shape leaves room for
+/// downstream zero-copy backends (e.g. `asn1_der`).
+pub struct X509CertBackend;
+
+/// Owned, parsed X.509 certificate produced by [`X509CertBackend`].
+pub struct X509CertParsed {
+    cert: x509_cert::Certificate,
+}
+
+impl X509Codec for X509CertBackend {
+    type Parsed<'a> = X509CertParsed;
+
+    fn from_der<'a>(cert_der: &'a [u8]) -> Result<Self::Parsed<'a>> {
+        let cert: x509_cert::Certificate =
+            der::Decode::from_der(cert_der).context("Failed to decode certificate")?;
+        Ok(X509CertParsed { cert })
+    }
+}
+
+impl ParsedCert for X509CertParsed {
+    fn issuer_dn(&self) -> Result<String> {
+        Ok(self.cert.tbs_certificate.issuer.to_string())
+    }
+
+    fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>> {
+        let oid = const_oid::ObjectIdentifier::from_bytes(oid)
+            .map_err(|_| anyhow!("Invalid OID encoding"))?;
+        let mut iter = self
+            .cert
+            .tbs_certificate
+            .extensions
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .filter(|e| e.extn_id == oid)
+            .map(|e| e.extn_value.clone());
+
+        let extension = match iter.next() {
+            Some(ext) => ext,
+            None => return Ok(None),
+        };
+        if iter.next().is_some() {
+            bail!("extension {} appears more than once", oid);
+        }
+        Ok(Some(extension.into_bytes()))
+    }
+}

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -1,0 +1,173 @@
+//! Conformance harness for `Config` implementations.
+//!
+//! Any custom config SHOULD pass [`assert_config_conforms`] against a
+//! representative cert/signature corpus. This module also drives the in-tree
+//! [`DefaultConfig`] over the bundled SGX/TDX sample quotes as a regression
+//! gate — if the default backend's output ever changes, these tests catch it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use dcap_qvl::config::{Config, EcdsaSigEncoder, ParsedCert, X509Codec};
+use dcap_qvl::configs::DefaultConfig;
+use dcap_qvl::crypto::RingCrypto;
+use dcap_qvl::quote::Quote;
+use dcap_qvl::signature::DerSigEncoder;
+use dcap_qvl::x509::X509CertBackend;
+use dcap_qvl::QuoteCollateralV3;
+use scale::Decode;
+
+const SGX_QUOTE: &[u8] = include_bytes!("../sample/sgx_quote");
+const TDX_QUOTE: &[u8] = include_bytes!("../sample/tdx_quote");
+
+const SGX_EXTENSION_OID: &[u8] = &[0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x01, 0x0D, 0x01];
+
+fn pck_leaf_certs() -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    for raw in [SGX_QUOTE, TDX_QUOTE] {
+        let q = Quote::decode(&mut &raw[..]).expect("decode quote");
+        let pem = q.raw_cert_chain().expect("cert chain");
+        let leaf = pem::parse_many(pem)
+            .expect("parse pem")
+            .into_iter()
+            .next()
+            .expect("leaf cert")
+            .into_contents();
+        out.push(leaf);
+    }
+    out
+}
+
+/// Drive a custom [`Config`] through the sample corpus and assert byte-for-
+/// byte equivalence with [`DefaultConfig`]. Custom-config implementers
+/// should call this from their own test module.
+pub fn assert_config_conforms<C: Config>() {
+    for cert_der in pck_leaf_certs() {
+        let custom = C::X509::from_der(&cert_der).expect("custom from_der");
+        let default =
+            <DefaultConfig as Config>::X509::from_der(&cert_der).expect("default from_der");
+
+        assert_eq!(
+            custom.issuer_dn().expect("custom issuer_dn"),
+            default.issuer_dn().expect("default issuer_dn"),
+            "issuer_dn output mismatch"
+        );
+
+        let custom_ext = custom.extension(SGX_EXTENSION_OID).expect("custom ext");
+        let default_ext = default.extension(SGX_EXTENSION_OID).expect("default ext");
+        assert_eq!(custom_ext, default_ext, "extension output mismatch");
+    }
+
+    // Signature encoding vectors — see encode_test_vectors() below for rationale.
+    for (r, s) in encode_test_vectors() {
+        assert_eq!(
+            C::SigEncoder::encode_ecdsa_sig(&r, &s).expect("custom encode"),
+            <DefaultConfig as Config>::SigEncoder::encode_ecdsa_sig(&r, &s)
+                .expect("default encode"),
+            "encode_ecdsa_sig output mismatch for r={:02x?} s={:02x?}",
+            &r,
+            &s,
+        );
+    }
+}
+
+/// Test vectors stress the DER integer encoding edge cases:
+/// - high bit of leading byte set (must prepend 0x00 for unsigned)
+/// - leading zero byte (must be stripped)
+/// - all-zero (must encode as `02 01 00`)
+/// - typical random-looking values
+fn encode_test_vectors() -> Vec<(Vec<u8>, Vec<u8>)> {
+    /// Build a 32-byte vector with a single non-zero trailing byte.
+    fn trailing(b: u8) -> Vec<u8> {
+        let mut v = vec![0u8; 32];
+        if let Some(last) = v.last_mut() {
+            *last = b;
+        }
+        v
+    }
+    vec![
+        // high bit set on both
+        (vec![0x80; 32], vec![0xFF; 32]),
+        // leading zero on r
+        (trailing(0x42), vec![0x7F; 32]),
+        // leading zero on s
+        (vec![0x55; 32], trailing(0x01)),
+        // both all-zero
+        (vec![0u8; 32], vec![0u8; 32]),
+        // mixed typical
+        ((0u8..32).collect(), (32u8..64).collect()),
+    ]
+}
+
+#[test]
+fn default_config_conforms_to_itself() {
+    // Sanity check that the harness runs end-to-end on the default config.
+    // Anyone wiring up a custom config can copy this test and swap the type.
+    assert_config_conforms::<DefaultConfig>();
+}
+
+#[test]
+fn encode_ecdsa_sig_handles_edge_cases() {
+    // Verify the audited encoder produces well-formed DER on the edge-case
+    // vectors. (Decoded structure check, not just self-equivalence.)
+    for (r, s) in encode_test_vectors() {
+        let der = DerSigEncoder::encode_ecdsa_sig(&r, &s).expect("encode succeeds on edge cases");
+        // Must start with SEQUENCE tag.
+        assert_eq!(der.first(), Some(&0x30), "ECDSA sig must be a SEQUENCE");
+        // Must be parseable back as a SequenceOf<UintRef, 2>.
+        let _decoded: ::der::asn1::SequenceOf<::der::asn1::UintRef, 2> =
+            ::der::Decode::from_der(&der).expect("re-decode succeeds");
+    }
+}
+
+/// A `Config` defined entirely in this test crate, to prove the plumbing in
+/// `verify_with::<C>` actually accepts a downstream-defined config and that
+/// custom configs can mix-and-match per-component.
+struct ForwardingConfig;
+impl Config for ForwardingConfig {
+    type X509 = X509CertBackend;
+    type SigEncoder = DerSigEncoder;
+    type Crypto = RingCrypto;
+}
+
+#[test]
+fn verify_with_custom_config_matches_default() {
+    use dcap_qvl::verify::{verify, verify_with};
+
+    let raw_quote = include_bytes!("../sample/tdx_quote");
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/tdx_quote_collateral.json"))
+            .expect("collateral");
+
+    // Use a permissive `now` — the precise value isn't material here; we only
+    // care that the generic plumbing reaches the same outcome as the default
+    // entry point. Either both succeed with equal reports, or both fail with
+    // equal error strings.
+    let now = chrono::DateTime::parse_from_rfc3339(
+        &serde_json::from_str::<serde_json::Value>(&collateral.tcb_info).expect("tcb json")
+            ["nextUpdate"]
+            .as_str()
+            .expect("nextUpdate")
+            .to_string(),
+    )
+    .expect("nextUpdate parse")
+    .timestamp() as u64
+        - 1;
+
+    let default_result = verify(raw_quote, &collateral, now);
+    let custom_result = verify_with::<ForwardingConfig>(raw_quote, &collateral, now);
+    assert_eq!(
+        default_result.map_err(|e| e.to_string()),
+        custom_result.map_err(|e| e.to_string()),
+        "verify_with::<ForwardingConfig> must match verify"
+    );
+}
+
+#[test]
+fn extension_returns_none_for_missing_oid() {
+    let certs = pck_leaf_certs();
+    let cert_der = certs.first().expect("at least one cert");
+    let cert = X509CertBackend::from_der(cert_der).expect("parse cert");
+    // OID that definitely doesn't exist in a PCK cert.
+    let bogus_oid: &[u8] = &[0x2A, 0x03, 0x04, 0x05, 0x06];
+    assert!(matches!(cert.extension(bogus_oid), Ok(None)));
+}

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -6,6 +6,7 @@
 //! gate — if the default backend's output ever changes, these tests catch it.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "default-x509")]
 
 use dcap_qvl::config::{Config, EcdsaSigEncoder, ParsedCert, X509Codec};
 use dcap_qvl::configs::DefaultConfig;

--- a/tests/quote_parsing.rs
+++ b/tests/quote_parsing.rs
@@ -6,6 +6,7 @@ use dcap_qvl::{
 };
 use scale::Decode as ScaleDecode;
 
+#[cfg(feature = "default-x509")]
 #[test]
 fn tdx_quote_parsing_exports_cert_chain_and_extension() {
     let raw_quote = include_bytes!("../sample/tdx_quote");
@@ -29,6 +30,7 @@ fn tdx_quote_parsing_exports_cert_chain_and_extension() {
     assert!(!ext.ppid.is_empty());
 }
 
+#[cfg(feature = "default-x509")]
 #[test]
 fn sgx_quote_parsing_exports_cert_chain_and_extension() {
     let raw_quote = include_bytes!("../sample/sgx_quote");

--- a/tests/quote_parsing.rs
+++ b/tests/quote_parsing.rs
@@ -25,7 +25,7 @@ fn tdx_quote_parsing_exports_cert_chain_and_extension() {
     let ext = intel::parse_pck_extension(leaf).expect("parse pck extension");
 
     // FMSPC from quote should match extension.
-    assert_eq!(quote.fmspc().unwrap(), ext.fmspc);
+    assert_eq!(intel::quote_fmspc(&quote).unwrap(), ext.fmspc);
     assert!(!ext.ppid.is_empty());
 }
 
@@ -44,7 +44,7 @@ fn sgx_quote_parsing_exports_cert_chain_and_extension() {
     let leaf = certs_der.first().expect("leaf cert");
     let ext = intel::parse_pck_extension(leaf).expect("parse pck extension");
 
-    assert_eq!(quote.fmspc().unwrap(), ext.fmspc);
+    assert_eq!(intel::quote_fmspc(&quote).unwrap(), ext.fmspc);
     assert!(!ext.ppid.is_empty());
 }
 

--- a/tests/verify_quote.rs
+++ b/tests/verify_quote.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "default-x509")]
 
 use dcap_qvl::{quote::Quote, verify::VerifiedReport, QuoteCollateralV3};
 use der::Decode as DerDecode;


### PR DESCRIPTION
## Summary

Introduces a small `Config` trait that bundles **every** pluggable component for quote verification as associated types — X.509 parser, ECDSA signature encoder, and crypto provider — so a downstream consumer can swap each independently. The audited in-tree implementations (`x509-cert` + `der` + ring/rustcrypto) remain the default — **zero behavior change** for callers using the legacy entry points.

The motivation is to give downstream consumers (e.g. #142, WASM smart contracts that want to drop ~37KB of cert-parsing code) a clean extension point so they can plug in a smaller-footprint backend without forking the crate or replacing the audited parser globally.

## Module layout

Trait surface separated from audited implementations; each implementation in its own purpose-named module:

```
src/
├── config.rs       ← trait surface only:
│                       X509Codec, ParsedCert, EcdsaSigEncoder, CryptoProvider, Config
├── x509.rs         ← X509CertBackend + X509CertParsed   (impl X509Codec / ParsedCert)
├── signature.rs    ← DerSigEncoder                      (impl EcdsaSigEncoder)
├── crypto.rs       ← RingCrypto + RustCryptoCrypto      (impl CryptoProvider, feature-gated)
└── configs.rs      ← RingConfig + RustCryptoConfig + DefaultConfig (Config bundles)
```

Public paths:

- `dcap_qvl::config::{Config, X509Codec, ParsedCert, EcdsaSigEncoder, CryptoProvider}`
- `dcap_qvl::x509::{X509CertBackend, X509CertParsed}`
- `dcap_qvl::signature::DerSigEncoder`
- `dcap_qvl::crypto::{RingCrypto, RustCryptoCrypto}`
- `dcap_qvl::configs::{RingConfig, RustCryptoConfig, DefaultConfig}`

## Trait shape (`dcap_qvl::config`)

```rust
/// Parser factory. The associated `Parsed` GAT lets backends choose to own
/// or borrow zero-copy from the input bytes.
pub trait X509Codec {
    type Parsed<'a>: ParsedCert where Self: 'a;
    fn from_der<'a>(cert_der: &'a [u8]) -> Result<Self::Parsed<'a>>;
}

/// Read-only accessors over a parsed cert. Parse once, query many.
pub trait ParsedCert {
    fn issuer_dn(&self) -> Result<String>;
    fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>>;
}

/// Encode raw `r ‖ s` as DER `Ecdsa-Sig-Value` (RFC 5480) for webpki.
pub trait EcdsaSigEncoder {
    fn encode_ecdsa_sig(r: &[u8], s: &[u8]) -> Result<Vec<u8>>;
}

/// ECDSA P-256 SHA-256 algorithm + SHA-256 hash. Replaces the old runtime
/// `CryptoBackend` struct with a compile-time selection.
pub trait CryptoProvider {
    fn sig_algo() -> &'static dyn rustls_pki_types::SignatureVerificationAlgorithm;
    fn sha256(data: &[u8]) -> [u8; 32];
}

/// Bundles pluggable components. Adding a new component (e.g. `type Time`,
/// `type Crl`) later is backwards-compatible.
pub trait Config {
    type X509: X509Codec;
    type SigEncoder: EcdsaSigEncoder;
    type Crypto: CryptoProvider;
}
```

## Plugging in a custom backend

```rust
use dcap_qvl::config::{Config, EcdsaSigEncoder};
use dcap_qvl::crypto::RingCrypto;
use dcap_qvl::x509::X509CertBackend;

struct MyMicroEncoder;
impl EcdsaSigEncoder for MyMicroEncoder { /* ... */ }

struct MyConfig;
impl Config for MyConfig {
    type X509       = X509CertBackend; // keep audited cert parsing
    type SigEncoder = MyMicroEncoder;  // bring your own
    type Crypto     = RingCrypto;
}

let report = dcap_qvl::verify::verify_with::<MyConfig>(&quote, &collateral, now)?;
```

## Design choices

1. **`X509Codec::from_der` factory + `ParsedCert` accessors** instead of stateless associated functions. Avoids re-parsing the same cert when a caller needs more than one field — `collateral::extract_fmspc_and_ca_with` is a real instance of this (one shared parse for both the SGX extension and the issuer DN).
2. **GAT on `Parsed<'a>`** so a downstream backend (e.g. `asn1_der`) can hold references into the input DER bytes for true zero-copy parsing. The in-tree default owns its parsed data because `x509_cert::Certificate` owns, but the trait shape doesn't preclude borrowing implementations.
3. **`Config`-with-associated-types** over a single umbrella trait gives:
   - **Mix-and-match**: a custom config can keep the audited cert parser but bring its own micro-encoder.
   - **Forward-compatibility**: adding a new pluggable component is a backwards-compatible change.
4. **Crypto folded into `Config`**: the old runtime `CryptoBackend` struct is gone. Crypto selection is now a compile-time choice via `type Crypto`, sitting alongside cert parser + sig encoder under the same `Config` umbrella. One trait controls all pluggable choices.
5. **Trait surface vs. audited impls separated**: `config.rs` is small and just defines what a backend looks like; `x509.rs` / `signature.rs` / `crypto.rs` / `configs.rs` are the audited implementations and bundles. The audit boundary is visually obvious.

## The trait is reachable from the public API

Every user-facing entry point that touches X.509 / DER / crypto has a `_with::<C: Config>` companion that accepts a downstream-defined config. The non-generic legacy functions are thin shims delegating to `_with::<DefaultConfig>`:

| Public API | Generic companion |
|---|---|
| `verify::verify` | `verify::verify_with::<C>` |
| `verify::dangerous_verify_with_tcb_override` | `verify::dangerous_verify_with_tcb_override_with::<C>` |
| `QuoteVerifier::verify` | `QuoteVerifier::verify_with::<C>` |
| `QuoteVerifier::dangerous_verify_with_tcb_override` | `QuoteVerifier::dangerous_verify_with_tcb_override_with::<C>` |
| `ring::verify` / `rustcrypto::verify` (and `_with_tcb_override` variants) | thin adapters that pin `RingConfig` / `RustCryptoConfig` |
| `intel::parse_pck_extension` | `intel::parse_pck_extension_with::<C>` |
| `intel::parse_pck_extension_from_pem` | `intel::parse_pck_extension_from_pem_with::<C>` |
| `intel::pck_ca` | `intel::pck_ca_with::<C>` |
| `intel::quote_ca` | `intel::quote_ca_with::<C>` |
| `intel::quote_fmspc` | `intel::quote_fmspc_with::<C>` |
| `collateral::get_collateral` | `collateral::get_collateral_with::<C>` |
| `collateral::get_collateral_from_pcs` | `collateral::get_collateral_from_pcs_with::<C>` |
| `collateral::get_collateral_and_verify` | `collateral::get_collateral_and_verify_with::<C>` |
| `utils::get_intel_extension_with::<C>`, `utils::encode_as_der_with::<C>` | (always generic) |

Outside the `_with::<C>` shim pattern, the only places that pin a concrete `Config` are FFI boundaries that can't take type parameters — `js_verify` / `js_verify_with_root_ca` / `ffi.rs` / `python.rs` — each of which concretizes on `DefaultConfig` (or a chosen `Config`) at its own boundary, which is the intended pattern.

## Breaking changes (audit-boundary unification)

These are the necessary breaks to get a single `Config` trait that controls all configurable choices, with no parallel mechanisms.

| Removed | Replacement |
|---|---|
| `pub struct CryptoBackend { sig_algo, sha256 }` | A `Config` whose `Crypto` is `RingCrypto` / `RustCryptoCrypto` / your own `CryptoProvider` |
| `QuoteVerifier::new(root_ca_der, backend)` | `QuoteVerifier::new(root_ca_der)`; for trusted root, `QuoteVerifier::new_prod()` |
| `QuoteVerifier::new_prod(backend)` | `QuoteVerifier::new_prod()` (no args) |
| `Quote::ca(&self)` | `intel::quote_ca(&quote)` (or `intel::quote_ca_with::<C>(&quote)`) |
| `Quote::fmspc(&self)` | `intel::quote_fmspc(&quote)` (or `intel::quote_fmspc_with::<C>(&quote)`) |
| `verify::ring::backend()` / `verify::rustcrypto::backend()` | `RingCrypto` / `RustCryptoCrypto` (zero-sized; no instance needed) |

The `Quote::ca` / `Quote::fmspc` removals bear a note: previously they hid a hardcoded `DefaultConfig` behind a method on `Quote`. By moving the work to free functions in `intel` (with `_with::<C>` companions), every entry point either accepts a `Config` or commits to one explicitly at its boundary. The FFI/Python bindings now do that concretization in their own files instead of inheriting it from a `Quote` method.

## Audit boundary

Only the in-tree backends (`x509::X509CertBackend`, `signature::DerSigEncoder`, `crypto::RingCrypto` / `RustCryptoCrypto`) and the bundles (`configs::RingConfig` / `RustCryptoConfig` / `DefaultConfig`) are audited as part of `dcap-qvl`. Custom implementations of any trait in `config` (and the `Config`s that combine them) are the implementer's responsibility and are explicitly **not** audited. The new `tests/config_conformance.rs` provides:

```rust
pub fn assert_config_conforms<C: Config>();
```

so implementers can validate byte-for-byte equivalence with `DefaultConfig` on the bundled SGX/TDX sample corpus, plus ECDSA encoding edge-case vectors (high-bit-set, leading-zero, all-zero). A smoke test (`verify_with_custom_config_matches_default`) defines a `ForwardingConfig` in the test crate and asserts that `verify_with::<ForwardingConfig>` produces the same outcome as `verify`, exercising the full generic plumbing.

## Other improvements

- `collateral::extract_fmspc_and_ca_with` parses the PCK leaf cert once (was: once for the SGX extension, once for the issuer DN).
- All previously inlined `der::Decode::from_der(cert)` / `x509_cert::Certificate` calls in `utils`, `quote`, `intel`, `collateral`, `verify` go through the configured `X509Codec`, so all certificate parsing has a single audited boundary.

## Follow-up (out of scope here)

Make `x509-cert` and `der` optional behind a default-on Cargo feature once a downstream backend exists, so binary-size-sensitive builds can drop them entirely.

#142 can be re-cast as a downstream `Asn1DerBackend` implementation that lives alongside `X509CertBackend` — preserving the audited path for everyone else, with `Asn1DerParsed<'a>` borrowing zero-copy from the input bytes via the GAT, and called via `verify_with::<Asn1DerConfig>(...)`.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo check --no-default-features --features \"std,ring\"`
- [x] `cargo test --test quote_parsing --test verify_quote --test config_conformance --all-features` — 9/9 tests pass (incl. `verify_with_custom_config_matches_default`)
- [x] `cargo clippy --all-features --tests` — no new lints from this change (pre-existing `ffi.rs` lints unchanged)