### PR TITLE
example: asn1_der downstream Config backend (refs #142)

### DIFF
--- a/examples/asn1-der-backend/Cargo.toml
+++ b/examples/asn1-der-backend/Cargo.toml
@@ -7,11 +7,19 @@ description = "Downstream `Config` example: smaller-footprint X.509 / DER backen
 license = "MIT"
 
 [dependencies]
+# Production-shape feature set: this is what a downstream crate would
+# pick to drop `der` / `x509-cert` from the build. `default-x509` is
+# *not* enabled here.
 dcap-qvl = { path = "../..", default-features = false, features = ["std", "ring"] }
 asn1_der = { version = "0.7", default-features = false, features = ["native_types", "std"] }
 anyhow = "1"
 
 [dev-dependencies]
+# Tests need `DefaultConfig` to compare against — pull in `default-x509`
+# only at test time. Cargo unifies features per dep within a build, so
+# `cargo test` sees `std + ring + default-x509` while `cargo build`
+# (lib + example binary) keeps the lean `std + ring` build.
+dcap-qvl = { path = "../..", default-features = false, features = ["std", "ring", "default-x509"] }
 serde_json = "1"
 hex = "0.4"
 pem = "3"

--- a/examples/asn1-der-backend/Cargo.toml
+++ b/examples/asn1-der-backend/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "asn1-der-backend-example"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Downstream `Config` example: smaller-footprint X.509 / DER backend built on `asn1_der`"
+license = "MIT"
+
+[dependencies]
+dcap-qvl = { path = "../..", default-features = false, features = ["std", "ring"] }
+asn1_der = { version = "0.7", default-features = false, features = ["native_types", "std"] }
+anyhow = "1"
+
+[dev-dependencies]
+serde_json = "1"
+hex = "0.4"
+pem = "3"
+scale = { package = "parity-scale-codec", version = "3.6.12" }
+chrono = "0.4"
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+arithmetic_side_effects = "deny"

--- a/examples/asn1-der-backend/README.md
+++ b/examples/asn1-der-backend/README.md
@@ -1,0 +1,64 @@
+# `asn1_der`-based downstream backend (example)
+
+Reference implementation of [`dcap_qvl::config::Config`] backed by `asn1_der`
+instead of the audited `x509-cert` + `der` stack. **Not part of the
+audited `dcap-qvl` codebase** — copy and adapt.
+
+## Why
+
+`x509-cert` + `der` add roughly 37 KiB to a `wasm32-unknown-unknown` build
+(`lto="fat"` + `wasm-opt -O`). For WASM smart contracts (NEAR, ink!, etc.)
+that overhead matters. `asn1_der` is already a transitive dependency of
+`dcap-qvl`, so a backend built on it adds no new dependencies and avoids
+duplicating ASN.1 parsing logic.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `src/lib.rs` | Re-exports + `Asn1DerConfig` bundle |
+| `src/x509.rs` | `Asn1DerCertBackend` (`X509Codec`) + `Asn1DerParsedCert<'_>` (`ParsedCert`) — zero-copy via the `Parsed<'a>` GAT |
+| `src/sig.rs` | `Asn1DerSigEncoder` (`EcdsaSigEncoder`) |
+| `tests/conformance.rs` | Drop-in equivalence checks against `DefaultConfig` on the bundled SGX/TDX corpus |
+
+## Usage
+
+```rust
+use asn1_der_backend_example::Asn1DerConfig;
+
+let report = dcap_qvl::verify::verify_with::<Asn1DerConfig>(
+    &raw_quote,
+    &collateral,
+    now_secs,
+)?;
+```
+
+## Run the conformance tests
+
+```sh
+cd examples/asn1-der-backend
+cargo test
+```
+
+## Adapting this for your project
+
+1. Copy `src/x509.rs` and `src/sig.rs` into your crate.
+2. Define your own `Config` impl picking the crypto provider you prefer
+   (`RingCrypto`, `RustCryptoCrypto`, or your own `CryptoProvider`).
+3. Run `tests/conformance.rs` against a corpus that matches your
+   production traffic.
+4. Audit the parser changes yourself — `dcap-qvl` only audits the
+   in-tree `X509CertBackend` / `DerSigEncoder`.
+
+## Caveats
+
+- `Asn1DerParsedCert::issuer_dn` returns a comma-joined sequence of
+  printable RDN values, **not** RFC 4514. It is sufficient for the
+  substring matching `dcap_qvl::intel::pck_ca_with` performs (`"Processor"`
+  / `"Platform"`), but is not a full DN renderer. If you need stable
+  RFC 4514 output, add the formatting yourself.
+- This crate handles only `PrintableString` (`0x13`), `UTF8String`
+  (`0x0C`), and `IA5String` (`0x16`) inside RDN values. Intel's PCK certs
+  use `PrintableString`; if your corpus contains other DirectoryString
+  variants (`BMPString`, `TeletexString`, etc.), extend `STRING_TAGS`.
+- This crate is **not audited**.

--- a/examples/asn1-der-backend/README.md
+++ b/examples/asn1-der-backend/README.md
@@ -33,12 +33,30 @@ let report = dcap_qvl::verify::verify_with::<Asn1DerConfig>(
 )?;
 ```
 
-## Run the conformance tests
+## Run it
 
 ```sh
 cd examples/asn1-der-backend
+
+# End-to-end demo against the bundled TDX sample (no args).
+cargo run --example verify_sample
+
+# Or with your own quote / collateral / now (unix secs):
+cargo run --example verify_sample -- path/to/quote.bin path/to/collateral.json 1700000000
+
+# Conformance tests vs DefaultConfig.
 cargo test
 ```
+
+The interesting line is in `examples/verify_sample.rs`:
+
+```rust
+let report = verify_with::<Asn1DerConfig>(&quote, &collateral, now)?;
+```
+
+That single type parameter is the entire opt-in surface — every X.509,
+DER, and crypto operation downstream of that call goes through
+`Asn1DerConfig`'s associated types.
 
 ## Adapting this for your project
 

--- a/examples/asn1-der-backend/README.md
+++ b/examples/asn1-der-backend/README.md
@@ -12,6 +12,20 @@ that overhead matters. `asn1_der` is already a transitive dependency of
 `dcap-qvl`, so a backend built on it adds no new dependencies and avoids
 duplicating ASN.1 parsing logic.
 
+To opt out of the audited backend, depend on `dcap-qvl` without the
+`default-x509` feature:
+
+```toml
+[dependencies]
+dcap-qvl = { version = "...", default-features = false, features = ["std", "ring"] }
+```
+
+This drops `der` and `x509-cert` from the build entirely. The trade-off
+is that the non-generic entry points (`verify::verify`,
+`intel::quote_fmspc`, `intel::quote_ca`, etc.) are gone — you must use
+the `_with::<C>` variants and supply your own `Config` impl, which is
+what this example provides.
+
 ## Layout
 
 | File | Purpose |

--- a/examples/asn1-der-backend/examples/verify_sample.rs
+++ b/examples/asn1-der-backend/examples/verify_sample.rs
@@ -1,0 +1,109 @@
+//! End-to-end usage demo: verify a bundled TDX sample quote with the
+//! `asn1_der`-based `Config` instead of `DefaultConfig`.
+//!
+//! Run from this crate's directory:
+//!
+//! ```sh
+//! cargo run --example verify_sample
+//! ```
+//!
+//! Or, with explicit paths to your own quote / collateral / `now`:
+//!
+//! ```sh
+//! cargo run --example verify_sample -- path/to/quote.bin path/to/collateral.json 1700000000
+//! ```
+//!
+//! The only `dcap-qvl` API call that differs from a standard `verify(...)`
+//! is the [`verify_with`] line — that's the entire opt-in surface for a
+//! custom backend.
+
+use std::{env, fs, process::ExitCode, time::SystemTime};
+
+use anyhow::{Context, Result};
+use asn1_der_backend_example::Asn1DerConfig;
+use dcap_qvl::{verify::verify_with, QuoteCollateralV3};
+
+const DEFAULT_QUOTE: &[u8] = include_bytes!("../../../sample/tdx_quote");
+const DEFAULT_COLLATERAL: &[u8] = include_bytes!("../../../sample/tdx_quote_collateral.json");
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("verify failed: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<()> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let (quote, collateral, now) = match args.as_slice() {
+        [] => {
+            // The bundled TDX collateral was issued in 2024 and has long
+            // since expired. Pin `now` to just before its `nextUpdate`
+            // so the demo verifies cleanly out of the box.
+            let collateral: QuoteCollateralV3 = serde_json::from_slice(DEFAULT_COLLATERAL)
+                .context("parse bundled tdx_quote_collateral.json")?;
+            let now = pin_now_before_next_update(&collateral.tcb_info)?;
+            (DEFAULT_QUOTE.to_vec(), collateral, now)
+        }
+        [quote_path, collateral_path] => {
+            let quote = fs::read(quote_path).with_context(|| format!("read {quote_path}"))?;
+            let collateral_bytes =
+                fs::read(collateral_path).with_context(|| format!("read {collateral_path}"))?;
+            let collateral: QuoteCollateralV3 =
+                serde_json::from_slice(&collateral_bytes).context("parse collateral json")?;
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .context("system time before unix epoch")?
+                .as_secs();
+            (quote, collateral, now)
+        }
+        [quote_path, collateral_path, now] => {
+            let quote = fs::read(quote_path).with_context(|| format!("read {quote_path}"))?;
+            let collateral_bytes =
+                fs::read(collateral_path).with_context(|| format!("read {collateral_path}"))?;
+            let collateral: QuoteCollateralV3 =
+                serde_json::from_slice(&collateral_bytes).context("parse collateral json")?;
+            let now: u64 = now.parse().context("`now` arg must be a unix timestamp")?;
+            (quote, collateral, now)
+        }
+        _ => {
+            anyhow::bail!(
+                "usage: verify_sample [<quote> <collateral.json> [<now-unix-secs>]]"
+            );
+        }
+    };
+
+    // === The one line that picks the custom backend. ===
+    let report = verify_with::<Asn1DerConfig>(&quote, &collateral, now)
+        .context("verify_with::<Asn1DerConfig>")?;
+
+    println!("verified using Asn1DerConfig (asn1_der downstream backend)");
+    println!("  tcb status:      {:?}", report.status);
+    println!("  advisory ids:    {:?}", report.advisory_ids);
+    println!("  qe tcb:          {:?}", report.qe_status);
+    println!("  platform tcb:    {:?}", report.platform_status);
+    println!("  ppid (hex):      {}", hex::encode(&report.ppid));
+    Ok(())
+}
+
+/// Parse `tcbInfo.nextUpdate` and back off by a 2-hour margin. The
+/// margin covers the bundled CRLs, which typically expire slightly
+/// earlier than the JSON collateral. Used so the bundled (long-expired)
+/// sample collateral verifies cleanly without requiring the user to
+/// supply a `now` value.
+fn pin_now_before_next_update(tcb_info: &str) -> Result<u64> {
+    const CRL_MARGIN_SECS: u64 = 2 * 60 * 60;
+    let v: serde_json::Value = serde_json::from_str(tcb_info).context("parse tcbInfo")?;
+    let next_update = v
+        .get("nextUpdate")
+        .and_then(|v| v.as_str())
+        .context("tcbInfo.nextUpdate missing")?;
+    let ts = chrono::DateTime::parse_from_rfc3339(next_update)
+        .context("parse tcbInfo.nextUpdate as rfc3339")?
+        .timestamp();
+    let ts_u64: u64 = ts.try_into().context("nextUpdate timestamp before epoch")?;
+    Ok(ts_u64.saturating_sub(CRL_MARGIN_SECS))
+}

--- a/examples/asn1-der-backend/examples/verify_sample.rs
+++ b/examples/asn1-der-backend/examples/verify_sample.rs
@@ -70,9 +70,7 @@ fn run() -> Result<()> {
             (quote, collateral, now)
         }
         _ => {
-            anyhow::bail!(
-                "usage: verify_sample [<quote> <collateral.json> [<now-unix-secs>]]"
-            );
+            anyhow::bail!("usage: verify_sample [<quote> <collateral.json> [<now-unix-secs>]]");
         }
     };
 

--- a/examples/asn1-der-backend/src/lib.rs
+++ b/examples/asn1-der-backend/src/lib.rs
@@ -1,0 +1,68 @@
+//! Downstream `Config` example: smaller-footprint X.509 / DER backend
+//! built on `asn1_der`.
+//!
+//! This crate is **not part of the audited `dcap-qvl` codebase.** It is a
+//! reference implementation showing how a downstream consumer can swap the
+//! pluggable components defined in [`dcap_qvl::config`] without forking
+//! `dcap-qvl`.
+//!
+//! ## Goal
+//!
+//! `dcap-qvl`'s default backends ([`dcap_qvl::x509::X509CertBackend`] and
+//! [`dcap_qvl::signature::DerSigEncoder`]) pull in `x509-cert` + `der`
+//! (~37 KiB on `wasm32-unknown-unknown` with `lto="fat"` + `wasm-opt -O`).
+//! For binary-size-sensitive deployments — WASM smart contracts being the
+//! motivating case — that overhead is significant.
+//!
+//! [`Asn1DerCertBackend`] and [`Asn1DerSigEncoder`] reimplement the same
+//! surface using the `asn1_der` crate, which is already a transitive
+//! dependency of `dcap-qvl`. Once `dcap-qvl` makes `der` / `x509-cert`
+//! optional behind a feature flag (follow-up to PR #144), a downstream
+//! consumer can drop the audited backends entirely and ship only this
+//! `asn1_der`-based path:
+//!
+//! ```ignore
+//! use asn1_der_backend_example::Asn1DerConfig;
+//! let report = dcap_qvl::verify::verify_with::<Asn1DerConfig>(
+//!     &raw_quote,
+//!     &collateral,
+//!     now_secs,
+//! )?;
+//! ```
+//!
+//! ## Conformance
+//!
+//! Custom backends are the implementer's responsibility (see
+//! `dcap_qvl::config` module docs). This crate's `tests/conformance.rs`
+//! exercises [`Asn1DerConfig`] against the bundled SGX/TDX sample quotes
+//! and asserts byte-for-byte equivalence with [`dcap_qvl::configs::DefaultConfig`]
+//! on cert parsing, issuer DN extraction, and ECDSA signature DER encoding.
+//! Any downstream consumer adopting this code SHOULD run the same test
+//! suite (or stronger) on a corpus that matches their production traffic.
+
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+
+extern crate alloc;
+
+mod sig;
+mod x509;
+
+pub use sig::Asn1DerSigEncoder;
+pub use x509::{Asn1DerCertBackend, Asn1DerParsedCert};
+
+use dcap_qvl::config::Config;
+
+/// `Config` bundle pairing the `asn1_der`-based backends with `dcap-qvl`'s
+/// `ring` crypto provider. Drop-in replacement for
+/// [`dcap_qvl::configs::RingConfig`].
+///
+/// To use a different crypto provider, write your own `Config` impl that
+/// names [`Asn1DerCertBackend`] and [`Asn1DerSigEncoder`] for the X.509 and
+/// signature components.
+pub struct Asn1DerConfig;
+
+impl Config for Asn1DerConfig {
+    type X509 = Asn1DerCertBackend;
+    type SigEncoder = Asn1DerSigEncoder;
+    type Crypto = dcap_qvl::crypto::RingCrypto;
+}

--- a/examples/asn1-der-backend/src/sig.rs
+++ b/examples/asn1-der-backend/src/sig.rs
@@ -1,0 +1,57 @@
+//! `asn1_der`-based [`EcdsaSigEncoder`] implementation.
+//!
+//! ECDSA P-256 signatures inside DCAP quotes are 64-byte raw `r ‖ s`
+//! payloads. webpki's signature verifier expects them DER-encoded as
+//! `Ecdsa-Sig-Value ::= SEQUENCE { r INTEGER, s INTEGER }` (RFC 5480).
+//!
+//! `asn1_der::typed::Integer::write` already does the DER integer dance:
+//! strip leading zero bytes, prepend `0x00` when the high bit would
+//! otherwise make the value negative, and emit `02 01 00` for zero. We
+//! call it twice (once per component) into a temporary buffer, then wrap
+//! the concatenation in a SEQUENCE header.
+
+use alloc::vec::Vec;
+use anyhow::{anyhow, Result};
+use asn1_der::{
+    typed::{DerTypeView, Integer, Sequence},
+    DerObject, VecBacking,
+};
+
+use dcap_qvl::config::EcdsaSigEncoder;
+
+/// Zero-sized [`EcdsaSigEncoder`] backed by `asn1_der`. Selected by
+/// [`crate::Asn1DerConfig`].
+pub struct Asn1DerSigEncoder;
+
+impl EcdsaSigEncoder for Asn1DerSigEncoder {
+    fn encode_ecdsa_sig(r: &[u8], s: &[u8]) -> Result<Vec<u8>> {
+        // Worst case per integer: payload + 1-byte sign pad + 2-byte
+        // tag-length header. SEQUENCE wrapper adds another 4 bytes of
+        // overhead.  Pre-sizing is purely a perf hint; `Vec` will grow
+        // if asn1_der ever needs more.
+        let payload_cap = r
+            .len()
+            .checked_add(s.len())
+            .and_then(|n| n.checked_add(6))
+            .ok_or_else(|| anyhow!("ecdsa-sig payload size overflow"))?;
+        let total_cap = payload_cap
+            .checked_add(4)
+            .ok_or_else(|| anyhow!("ecdsa-sig total size overflow"))?;
+
+        let mut payload = Vec::with_capacity(payload_cap);
+        Integer::write(r, false, &mut VecBacking(&mut payload))
+            .map_err(|e| anyhow!("Failed to encode r INTEGER: {e}"))?;
+        Integer::write(s, false, &mut VecBacking(&mut payload))
+            .map_err(|e| anyhow!("Failed to encode s INTEGER: {e}"))?;
+
+        let mut out = Vec::with_capacity(total_cap);
+        DerObject::write(
+            <Sequence as DerTypeView>::TAG,
+            payload.len(),
+            &mut payload.iter(),
+            &mut VecBacking(&mut out),
+        )
+        .map_err(|e| anyhow!("Failed to encode ECDSA sig SEQUENCE: {e}"))?;
+        Ok(out)
+    }
+}

--- a/examples/asn1-der-backend/src/x509.rs
+++ b/examples/asn1-der-backend/src/x509.rs
@@ -1,0 +1,181 @@
+//! `asn1_der`-based [`X509Codec`] / [`ParsedCert`] implementation.
+//!
+//! Parses just enough of X.509 to satisfy the surface
+//! [`dcap_qvl::config::ParsedCert`] requires: issuer DN extraction and
+//! single-extension lookup. The full `x509-cert` decoder is not pulled in.
+//!
+//! ## Zero-copy
+//!
+//! [`Asn1DerParsedCert`] is generic over the input lifetime: the `tbs`
+//! field is an `asn1_der::typed::Sequence<'a>` view that borrows directly
+//! from the input DER bytes. No allocation, no cloning of the certificate
+//! body.
+//!
+//! The audited [`dcap_qvl::x509::X509CertBackend`] cannot do this because
+//! `x509_cert::Certificate` owns its parsed data. The GAT shape on
+//! [`dcap_qvl::config::X509Codec::Parsed`] exists precisely so a
+//! zero-copy backend like this one can be plugged in.
+
+use alloc::{string::String, vec::Vec};
+use anyhow::{anyhow, bail, Context, Result};
+use asn1_der::{
+    typed::{DerDecodable, Sequence},
+    DerObject,
+};
+
+use dcap_qvl::config::{ParsedCert, X509Codec};
+
+/// Context-tag byte for `[0] EXPLICIT` (X.509 `version` wrapper).
+const TAG_CTX_0: u8 = 0xA0;
+/// Context-tag byte for `[3] EXPLICIT` (X.509 `extensions` wrapper).
+const TAG_CTX_3: u8 = 0xA3;
+
+/// Tags asn1 DirectoryString variants we handle when stringifying issuer DN.
+/// `0x13` = PrintableString, `0x0C` = UTF8String, `0x16` = IA5String.
+const STRING_TAGS: &[u8] = &[0x13, 0x0C, 0x16];
+
+/// Zero-sized factory implementing [`X509Codec`] on top of `asn1_der`.
+///
+/// Selected by [`crate::Asn1DerConfig`].
+pub struct Asn1DerCertBackend;
+
+/// Parsed certificate handle. Borrows from the input DER bytes for true
+/// zero-copy reads.
+#[derive(Copy, Clone)]
+pub struct Asn1DerParsedCert<'a> {
+    /// `tbsCertificate` SEQUENCE. All accessors walk this view.
+    tbs: Sequence<'a>,
+}
+
+impl X509Codec for Asn1DerCertBackend {
+    type Parsed<'a>
+        = Asn1DerParsedCert<'a>
+    where
+        Self: 'a;
+
+    fn from_der<'a>(cert_der: &'a [u8]) -> Result<Self::Parsed<'a>> {
+        // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+        let cert: Sequence<'a> =
+            Sequence::decode(cert_der).map_err(|e| anyhow!("Failed to decode certificate: {e}"))?;
+        let tbs: Sequence<'a> = cert
+            .get_as(0)
+            .map_err(|e| anyhow!("Failed to decode tbsCertificate: {e}"))?;
+        Ok(Asn1DerParsedCert { tbs })
+    }
+}
+
+impl<'a> ParsedCert for Asn1DerParsedCert<'a> {
+    /// Concatenate every printable RDN value in the issuer with `,` so the
+    /// substring matches in `dcap_qvl::intel::pck_ca_with` (looking for
+    /// e.g. `"Intel SGX PCK Processor CA"`) keep working unchanged.
+    ///
+    /// This is intentionally less structured than RFC 4514 — it is just
+    /// enough to satisfy the substring contract documented on
+    /// [`ParsedCert::issuer_dn`].
+    fn issuer_dn(&self) -> Result<String> {
+        // tbsCertificate ::= SEQUENCE {
+        //     version         [0] EXPLICIT Version DEFAULT v1,
+        //     serialNumber    CertificateSerialNumber,
+        //     signature       AlgorithmIdentifier,
+        //     issuer          Name,
+        //     ...
+        // }
+        // If `version` is omitted (v1), `issuer` is at index 2; otherwise 3.
+        let first = self
+            .tbs
+            .get(0)
+            .map_err(|e| anyhow!("Empty tbsCertificate: {e}"))?;
+        let issuer_idx: usize = if first.tag() == TAG_CTX_0 { 3 } else { 2 };
+
+        let issuer: Sequence<'a> = self
+            .tbs
+            .get_as(issuer_idx)
+            .map_err(|e| anyhow!("Failed to decode issuer: {e}"))?;
+
+        // Name ::= SEQUENCE OF RelativeDistinguishedName
+        // RelativeDistinguishedName ::= SET OF AttributeTypeAndValue
+        // AttributeTypeAndValue ::= SEQUENCE { type OID, value ANY }
+        let mut parts: Vec<&'a str> = Vec::new();
+        for i in 0..issuer.len() {
+            let rdn = issuer
+                .get(i)
+                .map_err(|e| anyhow!("Failed to get RDN: {e}"))?;
+            let rdn_bytes = rdn.value();
+            let mut pos: usize = 0;
+            while pos < rdn_bytes.len() {
+                let atv = DerObject::decode_at(rdn_bytes, pos)
+                    .map_err(|e| anyhow!("Failed to decode ATV: {e}"))?;
+                pos = pos
+                    .checked_add(atv.raw().len())
+                    .context("ATV offset overflow")?;
+                let atv_seq = Sequence::load(atv)
+                    .map_err(|e| anyhow!("Failed to load ATV as sequence: {e}"))?;
+                let value = match atv_seq.get(1) {
+                    Ok(v) if STRING_TAGS.contains(&v.tag()) => v,
+                    // Skip OID-only or non-string values; downstream substring
+                    // match doesn't depend on them.
+                    _ => continue,
+                };
+                if let Ok(s) = core::str::from_utf8(value.value()) {
+                    parts.push(s);
+                }
+            }
+        }
+        Ok(parts.join(","))
+    }
+
+    fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>> {
+        // Walk tbsCertificate looking for the `[3] EXPLICIT` extensions
+        // wrapper. Earlier optional fields (issuerUniqueID `[1]`,
+        // subjectUniqueID `[2]`) come before it, so iterate.
+        let mut extensions_inner: Option<&'a [u8]> = None;
+        for i in 0..self.tbs.len() {
+            let elem = self
+                .tbs
+                .get(i)
+                .map_err(|e| anyhow!("Failed to get tbsCertificate element: {e}"))?;
+            if elem.tag() == TAG_CTX_3 {
+                extensions_inner = Some(elem.value());
+                break;
+            }
+        }
+        let extensions_inner = match extensions_inner {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+
+        // Extensions ::= SEQUENCE OF Extension
+        // Extension  ::= SEQUENCE { extnID OID, critical BOOLEAN OPTIONAL, extnValue OCTET STRING }
+        let ext_seq = Sequence::decode(extensions_inner)
+            .map_err(|e| anyhow!("Failed to decode extensions sequence: {e}"))?;
+
+        let mut found: Option<Vec<u8>> = None;
+        for i in 0..ext_seq.len() {
+            let ext: Sequence<'a> = ext_seq
+                .get_as(i)
+                .map_err(|e| anyhow!("Failed to decode extension: {e}"))?;
+
+            let oid_obj = ext
+                .get(0)
+                .map_err(|e| anyhow!("Missing extension OID: {e}"))?;
+            if oid_obj.value() != oid {
+                continue;
+            }
+            if found.is_some() {
+                bail!("extension appears more than once");
+            }
+
+            // The OCTET STRING value is the last element of the SEQUENCE
+            // (index 1 if `critical` absent, 2 if present).
+            let value_idx = ext
+                .len()
+                .checked_sub(1)
+                .context("Empty extension sequence")?;
+            let value_obj = ext
+                .get(value_idx)
+                .map_err(|e| anyhow!("Missing extension value: {e}"))?;
+            found = Some(value_obj.value().to_vec());
+        }
+        Ok(found)
+    }
+}

--- a/examples/asn1-der-backend/tests/conformance.rs
+++ b/examples/asn1-der-backend/tests/conformance.rs
@@ -118,8 +118,7 @@ fn encode_ecdsa_sig_matches_default() {
 
 #[test]
 fn verify_with_asn1_der_config_matches_default() {
-    let collateral: QuoteCollateralV3 =
-        serde_json::from_slice(TDX_COLLATERAL).expect("collateral");
+    let collateral: QuoteCollateralV3 = serde_json::from_slice(TDX_COLLATERAL).expect("collateral");
     let now: u64 = chrono::DateTime::parse_from_rfc3339(
         serde_json::from_str::<serde_json::Value>(&collateral.tcb_info)
             .expect("tcb json")
@@ -133,8 +132,7 @@ fn verify_with_asn1_der_config_matches_default() {
         - 1;
 
     let default_result = dcap_qvl::verify::verify(TDX_QUOTE, &collateral, now);
-    let custom_result =
-        dcap_qvl::verify::verify_with::<Asn1DerConfig>(TDX_QUOTE, &collateral, now);
+    let custom_result = dcap_qvl::verify::verify_with::<Asn1DerConfig>(TDX_QUOTE, &collateral, now);
 
     assert_eq!(
         default_result.map_err(|e| e.to_string()),

--- a/examples/asn1-der-backend/tests/conformance.rs
+++ b/examples/asn1-der-backend/tests/conformance.rs
@@ -1,0 +1,144 @@
+//! Conformance harness: prove [`Asn1DerConfig`] is a drop-in equivalent
+//! of [`DefaultConfig`] on the bundled corpus.
+//!
+//! Mirrors `dcap-qvl/tests/config_conformance.rs`. A downstream consumer
+//! adopting the `asn1_der` backend should run something like this against
+//! a representative cert/signature corpus from their own deployment.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use asn1_der_backend_example::{Asn1DerCertBackend, Asn1DerConfig, Asn1DerSigEncoder};
+use dcap_qvl::config::{Config, EcdsaSigEncoder, ParsedCert, X509Codec};
+use dcap_qvl::configs::DefaultConfig;
+use dcap_qvl::quote::Quote;
+use dcap_qvl::QuoteCollateralV3;
+use scale::Decode;
+
+const SGX_QUOTE: &[u8] = include_bytes!("../../../sample/sgx_quote");
+const TDX_QUOTE: &[u8] = include_bytes!("../../../sample/tdx_quote");
+const TDX_COLLATERAL: &[u8] = include_bytes!("../../../sample/tdx_quote_collateral.json");
+
+/// DER-encoded body of the Intel SGX OID (1.2.840.113741.1.13.1) — same
+/// constant used by the in-tree `dcap-qvl` test harness.
+const SGX_EXTENSION_OID: &[u8] = &[0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x01, 0x0D, 0x01];
+
+fn pck_leaf_certs() -> Vec<Vec<u8>> {
+    [SGX_QUOTE, TDX_QUOTE]
+        .into_iter()
+        .map(|raw| {
+            let q = Quote::decode(&mut &raw[..]).expect("decode quote");
+            let pem = q.raw_cert_chain().expect("cert chain");
+            pem::parse_many(pem)
+                .expect("parse pem")
+                .into_iter()
+                .next()
+                .expect("leaf cert")
+                .into_contents()
+        })
+        .collect()
+}
+
+#[test]
+fn parsed_cert_matches_default_on_sample_corpus() {
+    for cert_der in pck_leaf_certs() {
+        let custom = Asn1DerCertBackend::from_der(&cert_der).expect("custom from_der");
+        let default =
+            <DefaultConfig as Config>::X509::from_der(&cert_der).expect("default from_der");
+
+        // The default `issuer_dn` returns RFC 4514 form; the asn1_der
+        // backend returns a comma-joined sequence of printable RDN
+        // values. They are not byte-identical, but they MUST agree on
+        // the substrings `pck_ca_with` checks for.
+        let custom_issuer = custom.issuer_dn().expect("custom issuer_dn");
+        let default_issuer = default.issuer_dn().expect("default issuer_dn");
+        // Same substrings `dcap_qvl::intel::pck_ca_with` looks for to
+        // classify the issuing CA. Hardcoded here because the underlying
+        // constants live in a private module.
+        for needle in ["Processor", "Platform"] {
+            assert_eq!(
+                custom_issuer.contains(needle),
+                default_issuer.contains(needle),
+                "issuer DN substring match diverged for {needle:?}: \
+                 custom={custom_issuer:?} default={default_issuer:?}",
+            );
+        }
+
+        // The SGX extension OCTET STRING contents MUST be byte-identical
+        // — downstream code parses these bytes with `find_extension` and
+        // any divergence would break TCB matching.
+        assert_eq!(
+            custom.extension(SGX_EXTENSION_OID).expect("custom ext"),
+            default.extension(SGX_EXTENSION_OID).expect("default ext"),
+            "Intel SGX extension bytes diverged",
+        );
+
+        // Missing extensions: both must agree on `None`.
+        let bogus_oid: &[u8] = &[0x2A, 0x03, 0x04, 0x05, 0x06];
+        assert_eq!(
+            custom.extension(bogus_oid).expect("custom missing"),
+            default.extension(bogus_oid).expect("default missing"),
+            "missing-extension behavior diverged",
+        );
+    }
+}
+
+/// Edge cases for DER INTEGER encoding: high bit set (must prepend `0x00`),
+/// leading zeros (must be stripped), all-zero (must encode as `02 01 00`),
+/// and mixed values.
+fn encode_test_vectors() -> Vec<(Vec<u8>, Vec<u8>)> {
+    fn trailing(b: u8) -> Vec<u8> {
+        let mut v = vec![0u8; 32];
+        if let Some(last) = v.last_mut() {
+            *last = b;
+        }
+        v
+    }
+    vec![
+        (vec![0x80; 32], vec![0xFF; 32]),
+        (trailing(0x42), vec![0x7F; 32]),
+        (vec![0x55; 32], trailing(0x01)),
+        (vec![0u8; 32], vec![0u8; 32]),
+        ((0u8..32).collect(), (32u8..64).collect()),
+    ]
+}
+
+#[test]
+fn encode_ecdsa_sig_matches_default() {
+    for (r, s) in encode_test_vectors() {
+        let custom = Asn1DerSigEncoder::encode_ecdsa_sig(&r, &s).expect("custom encode");
+        let default = <DefaultConfig as Config>::SigEncoder::encode_ecdsa_sig(&r, &s)
+            .expect("default encode");
+        assert_eq!(
+            custom, default,
+            "encode_ecdsa_sig diverged for r={:02x?} s={:02x?}",
+            &r, &s,
+        );
+    }
+}
+
+#[test]
+fn verify_with_asn1_der_config_matches_default() {
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(TDX_COLLATERAL).expect("collateral");
+    let now: u64 = chrono::DateTime::parse_from_rfc3339(
+        serde_json::from_str::<serde_json::Value>(&collateral.tcb_info)
+            .expect("tcb json")
+            .get("nextUpdate")
+            .expect("nextUpdate field")
+            .as_str()
+            .expect("nextUpdate str"),
+    )
+    .expect("nextUpdate parse")
+    .timestamp() as u64
+        - 1;
+
+    let default_result = dcap_qvl::verify::verify(TDX_QUOTE, &collateral, now);
+    let custom_result =
+        dcap_qvl::verify::verify_with::<Asn1DerConfig>(TDX_QUOTE, &collateral, now);
+
+    assert_eq!(
+        default_result.map_err(|e| e.to_string()),
+        custom_result.map_err(|e| e.to_string()),
+        "verify_with::<Asn1DerConfig> diverged from verify (DefaultConfig)",
+    );
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is a reference demo, not intended to be merged.**
> It exists to show #142's author (and any future size-sensitive consumer) the shape an `asn1_der`-based downstream backend should take once #144 lands. The example crate is meant to live as documentation / a copy-paste starting point — feel free to close after review, or merge as-is if having it under `examples/` is useful for discoverability.

## Summary

Reference downstream implementation of the [`Config`](https://github.com/Phala-Network/dcap-qvl/pull/144) trait introduced in #144, demonstrating how the goal of #142 — replacing the audited `x509-cert` + `der` stack with `asn1_der` to shrink WASM binary size — can be done **as a downstream crate** without forking `dcap-qvl`.

Stacked on top of #144. Once #144 merges, the base of this PR will retarget to \`master\`.

## What this is

\`examples/asn1-der-backend/\` — a standalone, **unaudited** example crate that reimplements every pluggable component of \`dcap-qvl::config\`:

| Trait | Default impl (audited) | This example (\`asn1_der\`) |
|---|---|---|
| \`X509Codec\` / \`ParsedCert\` | \`x509::X509CertBackend\` (\`x509-cert\` + \`der\`) | \`Asn1DerCertBackend\` / \`Asn1DerParsedCert<'_>\` |
| \`EcdsaSigEncoder\` | \`signature::DerSigEncoder\` (\`der\`) | \`Asn1DerSigEncoder\` |
| \`CryptoProvider\` | \`crypto::RingCrypto\` | \`crypto::RingCrypto\` (reused) |
| \`Config\` | \`configs::DefaultConfig\` | \`Asn1DerConfig\` |

Used like:

\`\`\`rust
use asn1_der_backend_example::Asn1DerConfig;
let report = dcap_qvl::verify::verify_with::<Asn1DerConfig>(&raw_quote, &collateral, now)?;
\`\`\`

## Why this matters for #142

#142 wants to drop ~37 KiB from WASM contracts by removing \`x509-cert\` + \`der\`. With #144 landed:

- The \`Config\` trait is the documented extension point for exactly this use case.
- An \`asn1_der\`-based \`Config\` can live in the consumer's own crate; \`dcap-qvl\` remains untouched and audited.
- The audited path (\`DefaultConfig\`) keeps working for everyone else — no breaking changes, no fork.
- With the \`default-x509\` feature also added in #144, a consumer using \`Asn1DerConfig\` can disable that feature in their own \`Cargo.toml\` and the audited backends are excluded from the build entirely (verified in the example's \`[dependencies]\` — \`cargo build\` no longer pulls in \`der\` / \`x509-cert\`).

This PR turns the abstract "downstream backend" pattern from #144's design notes into something \`pbeza\` (or any other size-sensitive consumer) can copy verbatim and adapt.

## Test plan

- [x] \`cd examples/asn1-der-backend && cargo build\` — verified \`der\` / \`x509-cert\` are NOT in the build (cargo metadata)
- [x] \`cd examples/asn1-der-backend && cargo test\` — 3/3 conformance tests pass
- [x] \`cd examples/asn1-der-backend && cargo run --example verify_sample\` — verifies bundled TDX sample, prints \`UpToDate\`
- [x] \`cd examples/asn1-der-backend && cargo fmt --all -- --check\` — clean
- [x] \`cd examples/asn1-der-backend && cargo clippy --all-targets -- -D warnings\` — clean

cc @pbeza — this is the shape #142 can take once #144 lands.