### PR TITLE
feat(collateral): accept caller-provided reqwest::Client

### DIFF
--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -280,6 +280,9 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
 pub async fn get_collateral(pccs_url: &str, quote: &[u8]) -> Result<QuoteCollateralV3> {
+    // Fail fast on invalid quotes before building an HTTP client — preserves
+    // the error precedence the pre-refactor version had.
+    let _ = Quote::decode(&mut &quote[..])?;
     let client = build_http_client()?;
     get_collateral_with_client(&client, pccs_url, quote).await
 }
@@ -300,8 +303,9 @@ pub async fn get_collateral(pccs_url: &str, quote: &[u8]) -> Result<QuoteCollate
 pub async fn get_collateral_with_client(
     client: &reqwest::Client,
     pccs_url: &str,
-    mut quote: &[u8],
+    quote: &[u8],
 ) -> Result<QuoteCollateralV3> {
+    let mut quote = quote;
     let parsed_quote = Quote::decode(&mut quote)?;
 
     // Get PCK certificate chain (from quote or PCCS)

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -266,6 +266,10 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 
 /// Get collateral given DCAP quote and base URL of PCCS server URL.
 ///
+/// Builds a default HTTP client internally. Use [`get_collateral_with_client`]
+/// if you need to configure TLS (e.g. add custom root CAs for a local PCCS
+/// with a self-signed cert), timeouts, or other client options.
+///
 /// # Arguments
 ///
 /// * `pccs_url` - The base URL of PCCS server. (e.g. `https://pccs.example.com/sgx/certification/v4`)
@@ -275,12 +279,33 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 ///
 /// * `Ok(QuoteCollateralV3)` - The quote collateral
 /// * `Err(Error)` - The error
-pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCollateralV3> {
-    let parsed_quote = Quote::decode(&mut quote)?;
+pub async fn get_collateral(pccs_url: &str, quote: &[u8]) -> Result<QuoteCollateralV3> {
     let client = build_http_client()?;
+    get_collateral_with_client(&client, pccs_url, quote).await
+}
+
+/// Get collateral using a caller-provided HTTP client.
+///
+/// Same as [`get_collateral`] but lets callers configure the
+/// [`reqwest::Client`] — useful for pointing at a local PCCS with a
+/// self-signed TLS cert (via `add_root_certificate` or
+/// `danger_accept_invalid_certs`), setting custom timeouts, attaching
+/// headers, or routing through a proxy.
+///
+/// # Arguments
+///
+/// * `client` - The HTTP client to use for all PCCS requests.
+/// * `pccs_url` - The base URL of the PCCS server.
+/// * `quote` - The raw quote to verify. Supported SGX and TDX quotes.
+pub async fn get_collateral_with_client(
+    client: &reqwest::Client,
+    pccs_url: &str,
+    mut quote: &[u8],
+) -> Result<QuoteCollateralV3> {
+    let parsed_quote = Quote::decode(&mut quote)?;
 
     // Get PCK certificate chain (from quote or PCCS)
-    let pck_chain = get_pck_chain(&client, pccs_url, &parsed_quote)
+    let pck_chain = get_pck_chain(client, pccs_url, &parsed_quote)
         .await
         .context("Failed to get PCK certificate chain")?;
 
@@ -288,9 +313,14 @@ pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCol
     let (fmspc, ca) = extract_fmspc_and_ca(&pck_chain)?;
 
     // Fetch the rest of the collateral
-    let mut collateral =
-        get_collateral_for_fmspc_impl(&client, pccs_url, fmspc, ca, parsed_quote.header.is_sgx())
-            .await?;
+    let mut collateral = get_collateral_for_fmspc_with_client(
+        client,
+        pccs_url,
+        fmspc,
+        ca,
+        parsed_quote.header.is_sgx(),
+    )
+    .await?;
 
     // Attach the PCK certificate chain for offline verification
     collateral.pck_certificate_chain = Some(pck_chain);
@@ -299,6 +329,9 @@ pub async fn get_collateral(pccs_url: &str, mut quote: &[u8]) -> Result<QuoteCol
 }
 
 /// Get collateral for a known FMSPC (public API, builds its own HTTP client).
+///
+/// Use [`get_collateral_for_fmspc_with_client`] if you need to configure the
+/// HTTP client.
 pub async fn get_collateral_for_fmspc(
     pccs_url: &str,
     fmspc: String,
@@ -306,11 +339,11 @@ pub async fn get_collateral_for_fmspc(
     for_sgx: bool,
 ) -> Result<QuoteCollateralV3> {
     let client = build_http_client()?;
-    get_collateral_for_fmspc_impl(&client, pccs_url, fmspc, ca, for_sgx).await
+    get_collateral_for_fmspc_with_client(&client, pccs_url, fmspc, ca, for_sgx).await
 }
 
-/// Internal implementation that uses a provided HTTP client.
-async fn get_collateral_for_fmspc_impl(
+/// Get collateral for a known FMSPC using a caller-provided HTTP client.
+pub async fn get_collateral_for_fmspc_with_client(
     client: &reqwest::Client,
     pccs_url: &str,
     fmspc: String,


### PR DESCRIPTION
## Summary

Add `get_collateral_with_client` and `get_collateral_for_fmspc_with_client` that take a pre-built `reqwest::Client`, letting callers configure TLS (custom root CA, cert pinning, or `danger_accept_invalid_certs`), timeouts, proxy settings, headers, etc.

The existing `get_collateral` and `get_collateral_for_fmspc` are **unchanged from the caller's perspective** — they now delegate to the new entry points with a default-built client, so there's no behavior change for existing users.

## Motivation

Operators running a **local Intel PCCS** hit a wall: the stock Ubuntu `sgx-dcap-pccs` package ships a self-signed TLS cert (pre-bundled in the `.deb`, expired, X.509 v1, no SAN). `dcap-qvl`'s internal `build_http_client()` calls `reqwest::Client::builder().build()` with only a timeout — there is currently no public-API way to add a custom root CA, pin a cert, or disable TLS verification, so pointing `pccs_url` at the local PCCS fails with:

```
invalid peer certificate: Other(OtherError(UnsupportedCertVersion))
```

With this patch, callers can do:

```rust
// Pin the operator's self-signed PCCS cert (production-friendly)
let cert = reqwest::Certificate::from_pem(&pem_bytes)?;
let client = reqwest::Client::builder()
    .add_root_certificate(cert)
    .timeout(Duration::from_secs(180))
    .build()?;
dcap_qvl::collateral::get_collateral_with_client(&client, pccs_url, &quote).await?;

// Or, for development against a local PCCS with the stock self-signed cert:
let client = reqwest::Client::builder()
    .danger_accept_invalid_certs(true)
    .build()?;
dcap_qvl::collateral::get_collateral_with_client(&client, pccs_url, &quote).await?;
```

This keeps `dcap-qvl` strict by default (system-CA trust only), puts the decision to relax TLS in the operator's hands, and follows the same pattern used elsewhere in the crate (`get_collateral_for_fmspc_impl` already takes a `&reqwest::Client` internally — this just exposes it publicly through new `_with_client` entry points).


## Changes

- `src/collateral.rs`:
  - New `pub async fn get_collateral_with_client(&reqwest::Client, &str, &[u8])`
  - New `pub async fn get_collateral_for_fmspc_with_client(&reqwest::Client, &str, String, &str, bool)`
  - `get_collateral` and `get_collateral_for_fmspc` delegate to the `_with_client` variants after calling `build_http_client()`. No other changes.
- Doc comments reference the new entry points from the existing ones.

## Test plan

- [x] `cargo check` (default features)
- [x] `cargo check --features "reqwest report"`
- [x] `cargo test --lib --features "reqwest report"` — all 28 tests pass
- [x] No behavior change for existing `get_collateral` / `get_collateral_for_fmspc` callers — both paths go through the same `_impl` as before, just with an extra parameter hop.