### PR TITLE
chore: use default-features = false in anyhow to reduce dep size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,6 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 name = "dcap-qvl"
 version = "0.3.12"
 dependencies = [
- "anyhow",
  "asn1_der",
  "base64 0.22.1",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ der = { version = "0.7.8", default-features = false, features = [
 
 log = { version = "0.4.29", default-features = false }
 
-anyhow = { version = "1.0.100", optional = true }
+anyhow = { version = "1.0.100", optional = true, default-features = false }
 
 reqwest = { version = "0.12.24", optional = true, default-features = false, features = [
     "rustls-tls",


### PR DESCRIPTION
anyhow's was pulling quite a few Kbs in our contract, so here we just change to not use the default features and already gained around 45Kbs in https://github.com/near/mpc/pull/2990