### PR TITLE
refactor: make anyhow a non-optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 name = "dcap-qvl"
 version = "0.3.12"
 dependencies = [
+ "anyhow",
  "asn1_der",
  "base64 0.22.1",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ der = { version = "0.7.8", default-features = false, features = [
 
 log = { version = "0.4.29", default-features = false }
 
-anyhow = { version = "1.0.100", optional = true, default-features = false }
+anyhow = { version = "1.0.100", default-features = false }
 
 reqwest = { version = "0.12.24", optional = true, default-features = false, features = [
     "rustls-tls",
@@ -101,7 +101,6 @@ std = [
     "asn1_der/std",
     "der?/std",
     "serde_json",
-    "anyhow",
     "urlencoding",
     "borsh?/std",
 ]


### PR DESCRIPTION
## Summary

\`anyhow\` is imported unconditionally from \`src/quote.rs\`, \`src/verify.rs\`, \`src/intel.rs\`, \`src/utils.rs\`, \`src/tcb_info.rs\`, \`src/qe_identity.rs\` — none of those modules are \`#[cfg]\`-gated behind \`std\`. The \`optional = true\` + \`std\` feature wrapping was cosmetic: \`--no-default-features\` (and \`--features contract --no-default-features\`) never compiled on master either, so nothing actually benefited from the gating.

Drop the optional marker and the corresponding \`"anyhow"\` entry in the \`std\` feature list so the manifest matches actual usage. \`default-features = false\` (from #149) is preserved, so binary size is unchanged.

## Test plan
- [x] \`cargo build\` (default features)
- [x] \`cargo build --features python\`
- [x] \`cargo build --features go\`
- [x] \`cargo check --target wasm32-unknown-unknown --features js\` (via parallel check)