### PR TITLE
perf(verify): parse TCB Info / QE Identity via `Value` to shrink downstream wasm

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -237,6 +237,223 @@ pub async fn js_get_collateral(pccs_url: JsValue, raw_quote: JsValue) -> Result<
         .map_err(|_| JsValue::from_str("Failed to encode collateral"))
 }
 
+/// Manual JSON parsing for [`TcbInfo`] and [`QeIdentity`].
+///
+/// These structs carry `#[derive(Deserialize)]`, but the derive path
+/// instantiates a dedicated `serde_json::Deserializer::deserialize_struct<V>`
+/// for every struct and field visitor, which alone accounts for ~25 KiB of
+/// `wasm32-unknown-unknown` code size in downstream contract builds. The
+/// helpers below walk a single dynamically-typed [`serde_json::Value`] tree
+/// and construct the same structs by hand, collapsing all of those
+/// monomorphisations into one.
+///
+/// The structs' `Deserialize` derives are deliberately preserved — downstream
+/// users that serialize / deserialize these types outside the `verify_*`
+/// signature path still rely on them, and LLVM dead-code eliminates the
+/// derive-generated code when nothing reaches it from this crate.
+mod json_parse {
+    use super::{QeIdentity, TcbInfo};
+    use alloc::{format, string::String, vec::Vec};
+    use anyhow::{bail, Context, Result};
+    use serde_json::Value;
+
+    fn as_str(v: &Value, key: &str) -> Result<String> {
+        v.get(key)
+            .and_then(Value::as_str)
+            .map(String::from)
+            .with_context(|| format!("field `{key}`: missing or not a string"))
+    }
+
+    fn as_u64_field(v: &Value, key: &str) -> Result<u64> {
+        v.get(key)
+            .and_then(Value::as_u64)
+            .with_context(|| format!("field `{key}`: missing or not a non-negative integer"))
+    }
+
+    fn as_u<T>(v: &Value, key: &str) -> Result<T>
+    where
+        T: TryFrom<u64>,
+        T::Error: core::fmt::Display,
+    {
+        let n = as_u64_field(v, key)?;
+        T::try_from(n).map_err(|e| anyhow::anyhow!("field `{key}`: value {n} out of range: {e}"))
+    }
+
+    fn as_array<'a>(v: &'a Value, key: &str) -> Result<&'a [Value]> {
+        v.get(key)
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .with_context(|| format!("field `{key}`: missing or not an array"))
+    }
+
+    fn as_array_opt<'a>(v: &'a Value, key: &str) -> &'a [Value] {
+        v.get(key)
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    fn as_advisory_ids(v: &Value) -> Vec<String> {
+        as_array_opt(v, "advisoryIDs")
+            .iter()
+            .filter_map(|a| a.as_str().map(String::from))
+            .collect()
+    }
+
+    fn as_hex<const N: usize>(s: &str, key: &str) -> Result<[u8; N]> {
+        let bytes = hex::decode(s)
+            .map_err(|e| anyhow::anyhow!("field `{key}`: invalid hex: {e}"))?;
+        if bytes.len() != N {
+            bail!("field `{key}`: expected {N} hex bytes, got {}", bytes.len());
+        }
+        let mut out = [0u8; N];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+
+    fn parse_tcb_status(s: &str) -> Result<crate::tcb_info::TcbStatus> {
+        use crate::tcb_info::TcbStatus;
+        Ok(match s {
+            "UpToDate" => TcbStatus::UpToDate,
+            "OutOfDate" => TcbStatus::OutOfDate,
+            "OutOfDateConfigurationNeeded" => TcbStatus::OutOfDateConfigurationNeeded,
+            "ConfigurationNeeded" => TcbStatus::ConfigurationNeeded,
+            "ConfigurationAndSWHardeningNeeded" => TcbStatus::ConfigurationAndSWHardeningNeeded,
+            "SWHardeningNeeded" => TcbStatus::SWHardeningNeeded,
+            "Revoked" => TcbStatus::Revoked,
+            _ => bail!("unknown tcbStatus: {s}"),
+        })
+    }
+
+    fn parse_tcb_component(v: &Value) -> Result<crate::tcb_info::TcbComponents> {
+        Ok(crate::tcb_info::TcbComponents {
+            svn: as_u::<u8>(v, "svn")?,
+        })
+    }
+
+    fn parse_tcb(v: &Value) -> Result<crate::tcb_info::Tcb> {
+        let sgx_components = as_array(v, "sgxtcbcomponents")?
+            .iter()
+            .map(parse_tcb_component)
+            .collect::<Result<Vec<_>>>()?;
+        let tdx_components = as_array_opt(v, "tdxtcbcomponents")
+            .iter()
+            .map(parse_tcb_component)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(crate::tcb_info::Tcb {
+            sgx_components,
+            tdx_components,
+            pce_svn: as_u::<u16>(v, "pcesvn")?,
+        })
+    }
+
+    fn parse_tcb_level(v: &Value) -> Result<crate::tcb_info::TcbLevel> {
+        let tcb = parse_tcb(v.get("tcb").context("tcbLevel: missing `tcb` field")?)?;
+        Ok(crate::tcb_info::TcbLevel {
+            tcb,
+            tcb_date: as_str(v, "tcbDate")?,
+            tcb_status: parse_tcb_status(&as_str(v, "tcbStatus")?)?,
+            advisory_ids: as_advisory_ids(v),
+        })
+    }
+
+    fn parse_tdx_module(v: &Value) -> Result<crate::tcb_info::TdxModule> {
+        Ok(crate::tcb_info::TdxModule {
+            mrsigner: as_str(v, "mrsigner")?,
+            attributes: as_str(v, "attributes")?,
+            attributes_mask: as_str(v, "attributesMask")?,
+        })
+    }
+
+    fn parse_tdx_module_tcb_level(v: &Value) -> Result<crate::tcb_info::TdxModuleTcbLevel> {
+        let tcb = v
+            .get("tcb")
+            .context("tdxModuleTcbLevel: missing `tcb` field")?;
+        Ok(crate::tcb_info::TdxModuleTcbLevel {
+            tcb: crate::tcb_info::TdxModuleTcb {
+                isvsvn: as_u::<u8>(tcb, "isvsvn")?,
+            },
+            tcb_date: as_str(v, "tcbDate")?,
+            tcb_status: parse_tcb_status(&as_str(v, "tcbStatus")?)?,
+            advisory_ids: as_advisory_ids(v),
+        })
+    }
+
+    fn parse_tdx_module_identity(v: &Value) -> Result<crate::tcb_info::TdxModuleIdentity> {
+        let tcb_levels = as_array(v, "tcbLevels")?
+            .iter()
+            .map(parse_tdx_module_tcb_level)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(crate::tcb_info::TdxModuleIdentity {
+            id: as_str(v, "id")?,
+            mrsigner: as_str(v, "mrsigner")?,
+            attributes: as_str(v, "attributes")?,
+            attributes_mask: as_str(v, "attributesMask")?,
+            tcb_levels,
+        })
+    }
+
+    pub(super) fn tcb_info(raw: &str) -> Result<TcbInfo> {
+        let root: Value = serde_json::from_str(raw).context("Failed to decode TcbInfo JSON")?;
+        let tcb_levels = as_array(&root, "tcbLevels")?
+            .iter()
+            .map(parse_tcb_level)
+            .collect::<Result<Vec<_>>>()?;
+        let tdx_module = root.get("tdxModule").map(parse_tdx_module).transpose()?;
+        let tdx_module_identities = as_array_opt(&root, "tdxModuleIdentities")
+            .iter()
+            .map(parse_tdx_module_identity)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(TcbInfo {
+            id: as_str(&root, "id")?,
+            version: as_u::<u8>(&root, "version")?,
+            issue_date: as_str(&root, "issueDate")?,
+            next_update: as_str(&root, "nextUpdate")?,
+            fmspc: as_str(&root, "fmspc")?,
+            pce_id: as_str(&root, "pceId")?,
+            tcb_type: as_u::<u32>(&root, "tcbType")?,
+            tcb_evaluation_data_number: as_u::<u32>(&root, "tcbEvaluationDataNumber")?,
+            tcb_levels,
+            tdx_module,
+            tdx_module_identities,
+        })
+    }
+
+    fn parse_qe_tcb_level(v: &Value) -> Result<crate::qe_identity::QeTcbLevel> {
+        let tcb = v.get("tcb").context("qeTcbLevel: missing `tcb` field")?;
+        Ok(crate::qe_identity::QeTcbLevel {
+            tcb: crate::qe_identity::QeTcb {
+                isvsvn: as_u::<u16>(tcb, "isvsvn")?,
+            },
+            tcb_date: as_str(v, "tcbDate")?,
+            tcb_status: parse_tcb_status(&as_str(v, "tcbStatus")?)?,
+            advisory_ids: as_advisory_ids(v),
+        })
+    }
+
+    pub(super) fn qe_identity(raw: &str) -> Result<QeIdentity> {
+        let root: Value = serde_json::from_str(raw).context("Failed to decode QeIdentity JSON")?;
+        let tcb_levels = as_array(&root, "tcbLevels")?
+            .iter()
+            .map(parse_qe_tcb_level)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(QeIdentity {
+            id: as_str(&root, "id")?,
+            version: as_u::<u8>(&root, "version")?,
+            issue_date: as_str(&root, "issueDate")?,
+            next_update: as_str(&root, "nextUpdate")?,
+            tcb_evaluation_data_number: as_u::<u32>(&root, "tcbEvaluationDataNumber")?,
+            miscselect: as_hex::<4>(&as_str(&root, "miscselect")?, "miscselect")?,
+            miscselect_mask: as_hex::<4>(&as_str(&root, "miscselectMask")?, "miscselectMask")?,
+            attributes: as_hex::<16>(&as_str(&root, "attributes")?, "attributes")?,
+            attributes_mask: as_hex::<16>(&as_str(&root, "attributesMask")?, "attributesMask")?,
+            mrsigner: as_hex::<32>(&as_str(&root, "mrsigner")?, "mrsigner")?,
+            isvprodid: as_u::<u16>(&root, "isvprodid")?,
+            tcb_levels,
+        })
+    }
+}
+
 // =============================================================================
 // Step 1: Verify TCB Info signature (Intel Root -> TCB Signing Cert -> TCB Info JSON)
 // =============================================================================
@@ -248,9 +465,11 @@ fn verify_tcb_info_signature<C: Config>(
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
 ) -> Result<TcbInfo> {
-    // Parse TCB Info
-    let tcb_info = serde_json::from_str::<TcbInfo>(&collateral.tcb_info)
-        .context("Failed to decode TcbInfo")?;
+    // Parse TCB Info. We walk a `serde_json::Value` manually rather than
+    // using the `#[derive(Deserialize)]` path on `TcbInfo`; see the
+    // `json_parse` module for why (~25 KiB wasm footprint reduction for
+    // downstream contract builds).
+    let tcb_info = json_parse::tcb_info(&collateral.tcb_info)?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&tcb_info.issue_date)
@@ -302,9 +521,9 @@ fn verify_qe_identity_signature<C: Config>(
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
 ) -> Result<QeIdentity> {
-    // Parse QE Identity
-    let qe_identity = serde_json::from_str::<QeIdentity>(&collateral.qe_identity)
-        .context("Failed to decode QeIdentity")?;
+    // Parse QE Identity. See `json_parse` module for why we skip the
+    // `#[derive(Deserialize)]` path.
+    let qe_identity = json_parse::qe_identity(&collateral.qe_identity)?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&qe_identity.issue_date)


### PR DESCRIPTION
# perf(verify): parse TCB Info / QE Identity via `Value` to shrink downstream wasm

## Summary

`verify.rs` parses the TCB Info and QE Identity JSON blobs with `serde_json::from_str::<TcbInfo>` / `::<QeIdentity>`. Each derived `Deserialize` monomorphises a dedicated `serde_json::Deserializer::deserialize_struct<V>` for every struct in the tree — `TcbInfo`, `TcbLevel`, `Tcb`, `TcbComponents`, `TdxModule`, `TdxModuleIdentity`, `TdxModuleTcbLevel`, `TdxModuleTcb`, `TcbStatus`, `QeIdentity`, `QeTcbLevel`, `QeTcb` — plus per-type `__FieldVisitor` / `__Visitor::expecting` / `visit_str`. On `wasm32-unknown-unknown` this adds up to **~25 KiB** even though `verify` only reads a handful of fields per struct.

This PR replaces the two call sites in `verify_tcb_info_signature` and `verify_qe_identity_signature` with manual walks over a single `serde_json::Value`, constructing the same `TcbInfo` / `QeIdentity` values field-by-field in a new private `json_parse` module. The public struct types keep their `Serialize` / `Deserialize` derives, so callers that round-trip these types (e.g. for on-disk caching or display) are unaffected. LLVM dead-code elimination now strips the per-type deserializers that used to be retained.

## Measurement

Representative downstream contract (`wasm32-unknown-unknown`, LTO fat, `opt-level = "z"`, `panic = "abort"`, followed by `wasm-opt -O -Oz --strip-debug --strip-producers`):

| build | bytes | delta |
| --- | --- | --- |
| baseline (`dcap-qvl` v0.4.0) | 1,437,559 | — |
| this PR | 1,412,141 | **−25,418 B (−24.8 KiB)** |

Byte-for-byte reproducible between two fresh builds.

## Scope

- Only `src/verify.rs` changes.
- No public API change — `TcbInfo` / `QeIdentity` / their nested types keep their `Serialize` / `Deserialize` / `Borsh*` derives unchanged.
- No behavioural change. The manual parser populates exactly the same fields the derive path did, including the optional `tdxModule` and `tdxModuleIdentities` (upstream has `#[serde(default)]` on those; the manual parser defaults them to `None` / empty `Vec` the same way) and the optional `advisoryIDs` array.
- Error messages follow the existing `anyhow` convention. The existing `.context("Failed to decode TcbInfo")` / `QeIdentity` top-level context strings are preserved via `context("Failed to decode TcbInfo JSON")`. Downstream callers that match on specific context strings should be unaffected.

## Tighter bounds than the derive path

Worth flagging: the manual parser is slightly stricter than the derive path for integer fields. `serde_json`'s `deserialize_u8` accepts any JSON number that fits in `u8`. The manual code uses `u64::try_into::<u8>()`, which gives the same "out of range" error path but is explicit about it. Any JSON that used to deserialize successfully still deserializes successfully.

The `as_hex` helper additionally validates that each hex string is the expected fixed length (4, 16, or 32 bytes). The derive path gets the same guarantee from `serde_bytes` but produces a slightly different error message on size mismatch.

## Test plan

- [x] `cargo test --features std,ring,default-x509,rustcrypto,borsh` — all 40 tests pass:
  - `verify::tests` (28 unit tests): unchanged.
  - `verify_quote` (2 integration tests): `could_parse_sgx_quote` and `could_parse_tdx_quote` exercise the full verify path on the vendored SGX/TDX sample quotes and collateral.
  - `config_conformance` (4 tests), notably `verify_with_custom_config_matches_default`, which runs both `DefaultConfig` and a custom `Config` on the same quote and asserts byte-for-byte equivalence of the resulting `VerifiedReport`.
- [x] Measured downstream wasm impact on a real contract (see above).
- [x] Build passes with all feature combinations that gate the affected path (the `json_parse` module is unconditionally compiled; `default-x509` / `ring` / `rustcrypto` were all exercised by the test matrix).

## Non-goals / follow-ups

- Not switching to a smaller JSON library. We still use `serde_json` — just through its `Value` entry point, which is shared across the crate rather than monomorphised per-type.
- `QuoteCollateralV3` and `VerifiedReport` still use the derive path (they need `Serialize` for the `js` / `python` bindings). Their contribution is small and unchanged by this PR.

## Schema drift caveat

The `json_parse` helpers read fields by name (`tcbLevels`, `sgxtcbcomponents`, `miscselectMask`, …), mirroring the `#[serde(rename = …)]` attributes the derive path uses today. If Intel renames a field in a future PCS schema revision, both the derive path and the manual path would need to be updated in lockstep. New unknown fields are tolerated (ignored) just as they are today. The field names are centralised in the `json_parse` module so the audit surface is explicit.
