### PR TITLE
perf(verify): add optional `serde-json-core` JSON parser (`json-core` feature)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,16 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  build-json-core:
+    name: Build & test with json-core feature
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build
+      run: cargo build --verbose --features json-core,default-x509,ring,rustcrypto,report
+    - name: Run tests
+      run: cargo test --verbose --features json-core,default-x509,ring,rustcrypto,report
+
   python-bindings:
     name: Build & Test Python bindings (unit)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-human-bytes",
+ "serde-json-core",
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
@@ -572,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -992,7 +993,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1698,7 +1699,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -1735,7 +1736,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1952,7 +1953,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2102,6 +2103,16 @@ checksum = "6a091af6294712930d01e375cce513e4ac416f823e033e8991ec4e5d6e6ef4c0"
 dependencies = [
  "base64 0.13.1",
  "hex",
+ "serde",
+]
+
+[[package]]
+name = "serde-json-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
+dependencies = [
+ "ryu",
  "serde",
 ]
 
@@ -2345,7 +2356,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,10 @@ go = ["std", "ring", "serde_json", "default-x509"]
 ring = ["dep:ring", "dcap-qvl-webpki/ring", "_anycrypto"]
 rustcrypto = ["dep:sha2", "dep:p256", "dep:signature", "dcap-qvl-webpki/rustcrypto", "_anycrypto"]
 # Opt-in: parse TCB Info / QE Identity JSON via `serde-json-core` instead of
-# `serde_json`. Smaller footprint on `wasm32-unknown-unknown` at the cost of
-# `serde-json-core`'s stricter parser (no `deserialize_any`, no
-# `deserialize_bytes`) — fine for current TCB/QE schemas but a constraint
-# downstream should audit if Intel extends the schema.
+# `serde_json`. Smaller footprint on size-constrained targets (e.g.
+# `wasm32-unknown-unknown`, `no_std` / embedded, TEE enclaves) at the cost
+# of `serde-json-core`'s stricter parser (no `deserialize_any`, no
+# `deserialize_bytes`).
 json-core = ["dep:serde-json-core"]
 _anycrypto = []
 contract = ["getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ serde-wasm-bindgen = { version = "0.6.5", optional = true }
 wasm-bindgen = { version = "0.2.95", optional = true }
 wasm-bindgen-futures = { version = "0.4.56" }
 serde_bytes = { package = "serde-human-bytes", version = "0.1" }
+serde-json-core = { version = "0.6", default-features = false, optional = true }
 
 # Python bindings
 pyo3 = { version = "0.25", optional = true, features = [
@@ -126,6 +127,12 @@ python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report", "ring"]
 go = ["std", "ring", "serde_json", "default-x509"]
 ring = ["dep:ring", "dcap-qvl-webpki/ring", "_anycrypto"]
 rustcrypto = ["dep:sha2", "dep:p256", "dep:signature", "dcap-qvl-webpki/rustcrypto", "_anycrypto"]
+# Opt-in: parse TCB Info / QE Identity JSON via `serde-json-core` instead of
+# `serde_json`. Smaller footprint on `wasm32-unknown-unknown` at the cost of
+# `serde-json-core`'s stricter parser (no `deserialize_any`, no
+# `deserialize_bytes`) — fine for current TCB/QE schemas but a constraint
+# downstream should audit if Intel extends the schema.
+json-core = ["dep:serde-json-core"]
 _anycrypto = []
 contract = ["getrandom"]
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -246,8 +246,11 @@ pub async fn js_get_collateral(pccs_url: JsValue, raw_quote: JsValue) -> Result<
 fn from_json_core_str<T: serde::de::DeserializeOwned>(s: &str) -> Result<T> {
     let (value, consumed) =
         serde_json_core::from_str::<T>(s).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let trailing = s
+        .get(consumed..)
+        .context("serde_json_core returned an invalid consumed offset")?;
     ensure!(
-        s[consumed..]
+        trailing
             .trim_end_matches([' ', '\n', '\r', '\t'])
             .is_empty(),
         "trailing non-whitespace content"

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -237,6 +237,24 @@ pub async fn js_get_collateral(pccs_url: JsValue, raw_quote: JsValue) -> Result<
         .map_err(|_| JsValue::from_str("Failed to encode collateral"))
 }
 
+// Parse JSON with `serde-json-core`, matching `serde_json::from_str`'s strictness:
+// `serde-json-core` returns the value plus bytes consumed and silently ignores the
+// tail, while `serde_json` rejects anything after the value except JSON whitespace
+// (` `, `\n`, `\r`, `\t`). Enforce the same here so parsing behavior stays identical
+// across the `json-core` feature flag.
+#[cfg(feature = "json-core")]
+fn from_json_core_str<T: serde::de::DeserializeOwned>(s: &str) -> Result<T> {
+    let (value, consumed) =
+        serde_json_core::from_str::<T>(s).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    ensure!(
+        s[consumed..]
+            .trim_end_matches([' ', '\n', '\r', '\t'])
+            .is_empty(),
+        "trailing non-whitespace content"
+    );
+    Ok(value)
+}
+
 // =============================================================================
 // Step 1: Verify TCB Info signature (Intel Root -> TCB Signing Cert -> TCB Info JSON)
 // =============================================================================
@@ -249,15 +267,15 @@ fn verify_tcb_info_signature<C: Config>(
     trust_anchor: rustls_pki_types::TrustAnchor,
 ) -> Result<TcbInfo> {
     // Parse TCB Info. Under the `json-core` feature, route through
-    // `serde-json-core` instead of `serde_json` for a smaller
-    // `wasm32-unknown-unknown` footprint in downstream builds.
+    // `serde-json-core` instead of `serde_json` for a smaller footprint
+    // on size-constrained targets (e.g. `wasm32-unknown-unknown`,
+    // `no_std` / embedded, TEE enclaves).
     #[cfg(not(feature = "json-core"))]
     let tcb_info = serde_json::from_str::<TcbInfo>(&collateral.tcb_info)
         .context("Failed to decode TcbInfo")?;
     #[cfg(feature = "json-core")]
-    let tcb_info = serde_json_core::from_str::<TcbInfo>(&collateral.tcb_info)
-        .map(|(t, _consumed)| t)
-        .map_err(|e| anyhow::anyhow!("Failed to decode TcbInfo: {e:?}"))?;
+    let tcb_info =
+        from_json_core_str::<TcbInfo>(&collateral.tcb_info).context("Failed to decode TcbInfo")?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&tcb_info.issue_date)
@@ -314,9 +332,8 @@ fn verify_qe_identity_signature<C: Config>(
     let qe_identity = serde_json::from_str::<QeIdentity>(&collateral.qe_identity)
         .context("Failed to decode QeIdentity")?;
     #[cfg(feature = "json-core")]
-    let qe_identity = serde_json_core::from_str::<QeIdentity>(&collateral.qe_identity)
-        .map(|(t, _consumed)| t)
-        .map_err(|e| anyhow::anyhow!("Failed to decode QeIdentity: {e:?}"))?;
+    let qe_identity = from_json_core_str::<QeIdentity>(&collateral.qe_identity)
+        .context("Failed to decode QeIdentity")?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&qe_identity.issue_date)

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -248,9 +248,16 @@ fn verify_tcb_info_signature<C: Config>(
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
 ) -> Result<TcbInfo> {
-    // Parse TCB Info
+    // Parse TCB Info. Under the `json-core` feature, route through
+    // `serde-json-core` instead of `serde_json` for a smaller
+    // `wasm32-unknown-unknown` footprint in downstream builds.
+    #[cfg(not(feature = "json-core"))]
     let tcb_info = serde_json::from_str::<TcbInfo>(&collateral.tcb_info)
         .context("Failed to decode TcbInfo")?;
+    #[cfg(feature = "json-core")]
+    let tcb_info = serde_json_core::from_str::<TcbInfo>(&collateral.tcb_info)
+        .map(|(t, _consumed)| t)
+        .map_err(|e| anyhow::anyhow!("Failed to decode TcbInfo: {e:?}"))?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&tcb_info.issue_date)
@@ -302,9 +309,14 @@ fn verify_qe_identity_signature<C: Config>(
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
 ) -> Result<QeIdentity> {
-    // Parse QE Identity
+    // Parse QE Identity. See TCB-Info site above for `json-core` feature.
+    #[cfg(not(feature = "json-core"))]
     let qe_identity = serde_json::from_str::<QeIdentity>(&collateral.qe_identity)
         .context("Failed to decode QeIdentity")?;
+    #[cfg(feature = "json-core")]
+    let qe_identity = serde_json_core::from_str::<QeIdentity>(&collateral.qe_identity)
+        .map(|(t, _consumed)| t)
+        .map_err(|e| anyhow::anyhow!("Failed to decode QeIdentity: {e:?}"))?;
 
     // Check validity window
     let issue_date = chrono::DateTime::parse_from_rfc3339(&qe_identity.issue_date)


### PR DESCRIPTION
## Summary

Introduce a `json-core` Cargo feature that swaps the TCB Info / QE Identity JSON parser in `verify.rs` from `serde_json` to `serde-json-core`.

**Default behaviour is unchanged** — `serde_json` remains the audited parser for all existing users. The new feature is strictly opt-in: downstream consumers sensitive to wasm footprint can enable it in their own `Cargo.toml`.

## Diff shape

Tiny and focused (+38, −8):

- `Cargo.toml`: one new optional dep (`serde-json-core = "0.6"`, no default features) and one new feature `json-core = ["dep:serde-json-core"]`.
- `src/verify.rs`: two existing `serde_json::from_str::<T>` call sites gain a `#[cfg(feature = "json-core")]` alternative that calls `serde_json_core::from_str::<T>` instead.
- `Cargo.lock`: regenerated.

## Measurement

Representative downstream consumer: [NEAR MPC contract](https://github.com/near/mpc/tree/main/crates/contract) built for `wasm32-unknown-unknown` with `lto = "fat"`, `opt-level = "z"`, `codegen-units = 1`, `panic = "abort"`, then `wasm-opt -O -Oz --strip-debug --strip-producers`.

| Build | bytes | Δ |
|---|---|---|
| Default (`serde_json`) | 1,437,559 | baseline |
| With `json-core` feature | 1,426,244 | **−11,315 B (−11.05 KiB)** |

Byte-identical across two consecutive builds (SHA-256 `c9bd2356...`).

## Correctness

`cargo test --features std,ring,default-x509,rustcrypto,borsh` and `cargo test --features std,ring,default-x509,rustcrypto,borsh,json-core` both pass with **40 tests passed, 0 failed, 1 ignored**. Coverage includes:

- `tests/verify_quote.rs` — end-to-end verification against the vendored SGX + TDX sample quotes and collateral.
- `tests/config_conformance.rs` — byte-for-byte equivalence vs `DefaultConfig` on the sample corpus.
- 28 unit tests across `collateral::tests`, `constants`, `tcb_info::tests`, and `verify::tests`.

`serde_json_core` parses the same `TcbInfo` / `QeIdentity` structs to semantically equivalent values as `serde_json` on the Intel sample corpus.

## Compatibility envelope

`serde-json-core` is documented not to support:

- `deserialize_any` (so `#[serde(untagged)]`, `#[serde(flatten)]`, and `serde_json::Value` fields won't parse).
- `deserialize_bytes` (so `#[serde(with = "serde_bytes")]` raw-byte paths won't parse).

Neither applies to `dcap-qvl`'s current `TcbInfo` / `QeIdentity`:

- No `#[serde(untagged)]` / `#[serde(flatten)]` / `Value` fields.
- The `#[serde(with = "serde_bytes")]` fields on `QeIdentity` route via `serde-human-bytes`, which uses `deserialize_str` on human-readable JSON — not `deserialize_bytes`.

If a future TCB/QE schema change introduces either of those patterns, the feature would need re-evaluation. Downstream consumers enabling the feature inherit this envelope.

## When to enable

Consumers on `wasm32-unknown-unknown` (smart-contract builders, TEE verifiers in resource-constrained runtimes) can opt in for ~11 KiB savings. Native builds, server-side verifiers, and anyone else should keep the default — the difference is negligible off-wasm and the audited `serde_json` path is the safer default.

## Sibling approach

[PR #152](https://github.com/Phala-Network/dcap-qvl/pull/152) takes a different trade-off for the same underlying goal: ~25 KiB savings via a manual `serde_json::Value` walker inside `verify.rs` (no new dep, larger `verify.rs` diff, single code path for everyone).

This PR is the smaller-surgical-change alternative that keeps downstream choice. The two can coexist (feature flag + manual walker as the `serde_json` branch) if upstream wants both — but this PR intentionally does not overlap with #152 to keep review scope minimal.
