### PR TITLE
feat: re-export reqwest for downstream callers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,19 @@ pub mod collateral;
 #[cfg(feature = "report")]
 pub use collateral::PHALA_PCCS_URL;
 
+/// Re-export of the [`reqwest`] types used by this crate's public API.
+/// Use `dcap_qvl::reqwest::Client` when constructing a client to pass
+/// into [`collateral::CollateralClient::new`] — guarantees type
+/// compatibility regardless of which `reqwest` version the downstream
+/// workspace pins. `Certificate` is included so callers can build a
+/// trust-anchor-augmented client without a separate `reqwest` dep.
+/// `Certificate` is gated `not(target_arch = "wasm32")` to match
+/// reqwest, which only exposes it on native targets.
+#[cfg(all(feature = "reqwest", not(target_arch = "wasm32")))]
+pub use reqwest::Certificate;
+#[cfg(feature = "reqwest")]
+pub use reqwest::Client;
+
 pub mod config;
 #[cfg(feature = "default-x509")]
 pub mod configs;


### PR DESCRIPTION
Re-exports the `reqwest` types used by this crate's public API so downstream callers passing a `reqwest::Client` into `CollateralClient::new` (#146) can reference `dcap_qvl::reqwest::Client` instead of depending on `reqwest` directly. Lets them automatically use whatever `reqwest` version this crate links against.

```rust
#[cfg(feature = "reqwest")]
pub use reqwest::{Certificate, Client};
```

`Client` crosses the public API boundary; `Certificate` is included so callers can build a trust-anchor-augmented client (e.g. `add_root_certificate`) without a separate `reqwest` dep.

Without this, a workspace on `reqwest 0.13` ends up with both 0.12 and 0.13 compiled side-by-side and has to pin `reqwest = "0.12.x"` explicitly to make the types line up — extra binary weight and manual version tracking.

Real-world example: near/mpc#3026 carries this kind of explicit pin and tracks the cleanup in near/mpc#3027.

> Narrowed from `pub use reqwest;` to `pub use reqwest::{Certificate, Client};` per @netrome's review — only the types that cross the public API boundary (plus `Certificate` for caller convenience).

## Tests

- `cargo check` (default), `--features report`, `--features "reqwest report"` — all compile
- `cargo test --lib --features "reqwest report"` — 28/28 pass
