### PR TITLE
feat(collateral): abstract HTTP transport behind HttpClient trait

### DIFF
--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -17,7 +17,7 @@ use crate::configs::DefaultConfig;
 use crate::constants::{
     PCK_ID_ENCRYPTED_PPID_2048, PCK_ID_ENCRYPTED_PPID_3072, PCK_ID_PCK_CERT_CHAIN,
 };
-use crate::http::{HttpClient, HttpResponse};
+use crate::http::{HttpClient, HttpResponse, ReqwestHttp};
 use crate::quote::{EncryptedPpidParams, Quote};
 use crate::QuoteCollateralV3;
 
@@ -278,11 +278,12 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 /// A PCCS / PCS client parameterized by [`Config`] for pluggable X.509 /
 /// crypto backends, and by [`HttpClient`] for the HTTP transport.
 ///
-/// `H` defaults to [`reqwest::Client`] (its [`HttpClient`] impl ships
-/// with the `reqwest` feature). Implement [`HttpClient`] on your own
-/// type to plug in a different HTTP stack — useful when the workspace
-/// is on a different `reqwest` major or wants to avoid a direct
-/// `reqwest` dependency / exposing `reqwest` types in its own API.
+/// `H` defaults to [`ReqwestHttp`](crate::http::ReqwestHttp), the
+/// crate's bundled `reqwest` adapter (gated by `feature = "reqwest"`).
+/// Implement [`HttpClient`] on your own type to plug in a different
+/// HTTP stack — useful when the workspace is on a different `reqwest`
+/// major or wants to avoid a direct `reqwest` dependency / exposing
+/// `reqwest` types in its own API.
 ///
 /// Exposes three fetch methods:
 ///
@@ -310,11 +311,11 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 /// ```no_run
 /// # use dcap_qvl::collateral::CollateralClient;
 /// # async fn run(http: reqwest::Client, quote: Vec<u8>) -> anyhow::Result<()> {
-/// let client: CollateralClient = CollateralClient::new(http, "https://pccs.local:8081");
+/// let client = CollateralClient::with_reqwest(http, "https://pccs.local:8081");
 /// let collateral = client.fetch(&quote).await?;
 /// # Ok(()) }
 /// ```
-pub struct CollateralClient<C: Config = DefaultConfig, H: HttpClient = reqwest::Client> {
+pub struct CollateralClient<C: Config = DefaultConfig, H: HttpClient = ReqwestHttp> {
     http: H,
     pccs_url: String,
     _cfg: PhantomData<fn() -> C>,
@@ -333,11 +334,12 @@ impl<C: Config, H: HttpClient + Clone> Clone for CollateralClient<C, H> {
 impl<C: Config, H: HttpClient> CollateralClient<C, H> {
     /// Build a client with a caller-provided HTTP transport.
     ///
-    /// Any type implementing [`HttpClient`] is accepted, including
-    /// [`reqwest::Client`] when the `reqwest` feature is on. Use this
-    /// when you need custom TLS trust roots, timeouts, proxies, or a
-    /// non-`reqwest` HTTP stack. For the common "just give me something
-    /// that works" path see
+    /// Any type implementing [`HttpClient`] is accepted. To pass a
+    /// [`reqwest::Client`], wrap it in
+    /// [`ReqwestHttp`](crate::http::ReqwestHttp) (or use the
+    /// [`with_reqwest`](CollateralClient::<DefaultConfig>::with_reqwest)
+    /// shortcut). For the common "just give me something that works"
+    /// path see
     /// [`with_default_http`](CollateralClient::<DefaultConfig>::with_default_http).
     pub fn new(http: H, pccs_url: impl Into<String>) -> Self {
         Self {
@@ -514,12 +516,27 @@ impl<C: Config, H: HttpClient> CollateralClient<C, H> {
     }
 }
 
-impl CollateralClient<DefaultConfig, reqwest::Client> {
+impl CollateralClient<DefaultConfig, ReqwestHttp> {
     /// Convenience constructor: build a default `reqwest::Client`
     /// (180s timeout on non-`js` targets) and pair it with the given
     /// PCCS URL. Uses [`DefaultConfig`] (audited `x509-cert` backend).
     pub fn with_default_http(pccs_url: impl Into<String>) -> Result<Self> {
-        Ok(Self::new(default_http_client()?, pccs_url))
+        Ok(Self::new(
+            ReqwestHttp::new(default_http_client()?),
+            pccs_url,
+        ))
+    }
+
+    /// Wrap a caller-provided [`reqwest::Client`] in [`ReqwestHttp`] and
+    /// pair it with the given PCCS URL. Uses [`DefaultConfig`].
+    ///
+    /// Use this for the common case of "I built my own
+    /// `reqwest::Client` (custom TLS roots, proxies, headers) and want
+    /// to plug it in." For a non-`reqwest` HTTP stack, implement
+    /// [`HttpClient`] on your own type and call
+    /// [`new`](Self::new) directly.
+    pub fn with_reqwest(client: reqwest::Client, pccs_url: impl Into<String>) -> Self {
+        Self::new(ReqwestHttp::new(client), pccs_url)
     }
 
     /// Zero-arg convenience constructor: default HTTP client + PCCS URL

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -264,11 +264,7 @@ pub fn default_http_client() -> Result<reqwest::Client> {
 /// Get PCK certificate chain for a quote.
 /// - cert_type 5: extracts from quote
 /// - cert_type 2/3: fetches from PCCS using encrypted PPID
-async fn get_pck_chain<H: HttpClient>(
-    client: &H,
-    pccs_url: &str,
-    quote: &Quote,
-) -> Result<String> {
+async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote) -> Result<String> {
     match quote.inner_cert_type() {
         PCK_ID_PCK_CERT_CHAIN => Ok(String::from_utf8_lossy(quote.inner_cert_data()).to_string()),
         PCK_ID_ENCRYPTED_PPID_2048 | PCK_ID_ENCRYPTED_PPID_3072 => {
@@ -285,8 +281,8 @@ async fn get_pck_chain<H: HttpClient>(
 /// `H` defaults to [`reqwest::Client`] (its [`HttpClient`] impl ships
 /// with the `reqwest` feature). Implement [`HttpClient`] on your own
 /// type to plug in a different HTTP stack — useful when the workspace
-/// is on a different `reqwest` major or doesn't want a `reqwest`
-/// dependency at all.
+/// is on a different `reqwest` major or wants to avoid a direct
+/// `reqwest` dependency / exposing `reqwest` types in its own API.
 ///
 /// Exposes three fetch methods:
 ///

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -17,6 +17,7 @@ use crate::configs::DefaultConfig;
 use crate::constants::{
     PCK_ID_ENCRYPTED_PPID_2048, PCK_ID_ENCRYPTED_PPID_3072, PCK_ID_PCK_CERT_CHAIN,
 };
+use crate::http::{HttpClient, HttpResponse};
 use crate::quote::{EncryptedPpidParams, Quote};
 use crate::QuoteCollateralV3;
 
@@ -94,12 +95,10 @@ impl PcsEndpoints {
     }
 }
 
-fn get_header(response: &reqwest::Response, name: &str) -> Result<String> {
+fn get_header(response: &HttpResponse, name: &str) -> Result<String> {
     let value = response
-        .headers()
-        .get(name)
-        .ok_or_else(|| anyhow!("Missing {name}"))?
-        .to_str()?;
+        .header(name)
+        .ok_or_else(|| anyhow!("Missing {name}"))?;
     let value = urlencoding::decode(value)?;
     Ok(value.into_owned())
 }
@@ -148,8 +147,8 @@ fn extract_crl_url(cert_der: &[u8]) -> Result<Option<String>> {
 }
 
 /// Fetch PCK certificate from PCCS using encrypted PPID parameters.
-async fn fetch_pck_certificate(
-    client: &reqwest::Client,
+async fn fetch_pck_certificate<H: HttpClient>(
+    client: &H,
     pccs_url: &str,
     qeid: &[u8],
     params: &EncryptedPpidParams,
@@ -169,22 +168,19 @@ async fn fetch_pck_certificate(
     let url = format!(
         "{base_url}/sgx/certification/v4/pckcert?qeid={qeid}&encrypted_ppid={encrypted_ppid}&cpusvn={cpusvn}&pcesvn={pcesvn}&pceid={pceid}"
     );
-    let response = client.get(&url).send().await?;
+    let response = client.get(&url).await?;
 
-    if !response.status().is_success() {
+    if !response.is_success() {
         bail!(
-            "Failed to fetch PCK certificate from {}: {}",
+            "Failed to fetch PCK certificate from {}: HTTP {}",
             url,
-            response.status()
+            response.status
         );
     }
 
     // Check if Intel returned a certificate for a different TCB level
     // SGX-TCBm header format: cpusvn (16 bytes) + pcesvn (2 bytes, little-endian)
-    if let Some(tcbm) = response.headers().get("SGX-TCBm") {
-        let tcbm_str = tcbm
-            .to_str()
-            .context("SGX-TCBm header contains invalid characters")?;
+    if let Some(tcbm_str) = response.header("SGX-TCBm") {
         let tcbm_bytes =
             hex::decode(tcbm_str).map_err(|e| anyhow!("SGX-TCBm header is not valid hex: {e}"))?;
         let (matched_cpusvn, matched_pcesvn) = <([u8; 16], u16)>::decode(&mut &tcbm_bytes[..])
@@ -210,7 +206,8 @@ async fn fetch_pck_certificate(
     let pck_cert_chain = get_header(&response, "SGX-PCK-Certificate-Issuer-Chain")?;
 
     // The body is the leaf PCK certificate
-    let pck_cert = response.text().await?;
+    let pck_cert = String::from_utf8(response.body)
+        .context("PCK certificate response body is not valid UTF-8")?;
 
     // Combine into a full PEM chain (leaf first, then issuer chain)
     Ok(format!("{pck_cert}\n{pck_cert_chain}"))
@@ -267,7 +264,11 @@ pub fn default_http_client() -> Result<reqwest::Client> {
 /// Get PCK certificate chain for a quote.
 /// - cert_type 5: extracts from quote
 /// - cert_type 2/3: fetches from PCCS using encrypted PPID
-async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) -> Result<String> {
+async fn get_pck_chain<H: HttpClient>(
+    client: &H,
+    pccs_url: &str,
+    quote: &Quote,
+) -> Result<String> {
     match quote.inner_cert_type() {
         PCK_ID_PCK_CERT_CHAIN => Ok(String::from_utf8_lossy(quote.inner_cert_data()).to_string()),
         PCK_ID_ENCRYPTED_PPID_2048 | PCK_ID_ENCRYPTED_PPID_3072 => {
@@ -279,10 +280,15 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 }
 
 /// A PCCS / PCS client parameterized by [`Config`] for pluggable X.509 /
-/// crypto backends.
+/// crypto backends, and by [`HttpClient`] for the HTTP transport.
 ///
-/// Bundles a `reqwest::Client` and a PCCS base URL, and exposes three
-/// fetch methods:
+/// `H` defaults to [`reqwest::Client`] (its [`HttpClient`] impl ships
+/// with the `reqwest` feature). Implement [`HttpClient`] on your own
+/// type to plug in a different HTTP stack — useful when the workspace
+/// is on a different `reqwest` major or doesn't want a `reqwest`
+/// dependency at all.
+///
+/// Exposes three fetch methods:
 ///
 /// * [`fetch`](Self::fetch) — from a raw DCAP quote.
 /// * [`fetch_for_fmspc`](Self::fetch_for_fmspc) — when the caller already
@@ -312,13 +318,13 @@ async fn get_pck_chain(client: &reqwest::Client, pccs_url: &str, quote: &Quote) 
 /// let collateral = client.fetch(&quote).await?;
 /// # Ok(()) }
 /// ```
-pub struct CollateralClient<C: Config = DefaultConfig> {
-    http: reqwest::Client,
+pub struct CollateralClient<C: Config = DefaultConfig, H: HttpClient = reqwest::Client> {
+    http: H,
     pccs_url: String,
     _cfg: PhantomData<fn() -> C>,
 }
 
-impl<C: Config> Clone for CollateralClient<C> {
+impl<C: Config, H: HttpClient + Clone> Clone for CollateralClient<C, H> {
     fn clone(&self) -> Self {
         Self {
             http: self.http.clone(),
@@ -328,14 +334,16 @@ impl<C: Config> Clone for CollateralClient<C> {
     }
 }
 
-impl<C: Config> CollateralClient<C> {
-    /// Build a client with a caller-provided `reqwest::Client`.
+impl<C: Config, H: HttpClient> CollateralClient<C, H> {
+    /// Build a client with a caller-provided HTTP transport.
     ///
-    /// Use this when you need custom TLS trust roots, timeouts, proxies,
-    /// or any other [`reqwest::ClientBuilder`] options. For the common
-    /// "just give me something that works" path see
+    /// Any type implementing [`HttpClient`] is accepted, including
+    /// [`reqwest::Client`] when the `reqwest` feature is on. Use this
+    /// when you need custom TLS trust roots, timeouts, proxies, or a
+    /// non-`reqwest` HTTP stack. For the common "just give me something
+    /// that works" path see
     /// [`with_default_http`](CollateralClient::<DefaultConfig>::with_default_http).
-    pub fn new(http: reqwest::Client, pccs_url: impl Into<String>) -> Self {
+    pub fn new(http: H, pccs_url: impl Into<String>) -> Self {
         Self {
             http,
             pccs_url: pccs_url.into(),
@@ -344,7 +352,7 @@ impl<C: Config> CollateralClient<C> {
     }
 
     /// Rebind the `Config` type without rebuilding the HTTP client / URL.
-    pub fn with_config<D: Config>(self) -> CollateralClient<D> {
+    pub fn with_config<D: Config>(self) -> CollateralClient<D, H> {
         CollateralClient {
             http: self.http,
             pccs_url: self.pccs_url,
@@ -399,10 +407,10 @@ impl<C: Config> CollateralClient<C> {
         // Send a GET and fail with a useful message on non-2xx, so the
         // header / body readers below don't surface misleading errors
         // like "missing issuer-chain header" on an HTTP 500.
-        async fn checked_get(client: &reqwest::Client, url: &str) -> Result<reqwest::Response> {
-            let response = client.get(url).send().await?;
-            if !response.status().is_success() {
-                bail!("Failed to fetch {url}: {}", response.status());
+        async fn checked_get<H: HttpClient>(client: &H, url: &str) -> Result<HttpResponse> {
+            let response = client.get(url).await?;
+            if !response.is_success() {
+                bail!("Failed to fetch {url}: HTTP {}", response.status);
             }
             Ok(response)
         }
@@ -412,7 +420,7 @@ impl<C: Config> CollateralClient<C> {
         {
             let response = checked_get(client, &endpoints.url_pckcrl()).await?;
             pck_crl_issuer_chain = get_header(&response, "SGX-PCK-CRL-Issuer-Chain")?;
-            pck_crl = response.bytes().await?.to_vec();
+            pck_crl = response.body;
         };
 
         let tcb_info_issuer_chain;
@@ -421,18 +429,20 @@ impl<C: Config> CollateralClient<C> {
             let response = checked_get(client, &endpoints.url_tcb()).await?;
             tcb_info_issuer_chain = get_header(&response, "SGX-TCB-Info-Issuer-Chain")
                 .or(get_header(&response, "TCB-Info-Issuer-Chain"))?;
-            raw_tcb_info = response.text().await?;
+            raw_tcb_info = String::from_utf8(response.body)
+                .context("TCB Info response body is not valid UTF-8")?;
         };
         let qe_identity_issuer_chain;
         let raw_qe_identity;
         {
             let response = checked_get(client, &endpoints.url_qe_identity()).await?;
             qe_identity_issuer_chain = get_header(&response, "SGX-Enclave-Identity-Issuer-Chain")?;
-            raw_qe_identity = response.text().await?;
+            raw_qe_identity = String::from_utf8(response.body)
+                .context("QE Identity response body is not valid UTF-8")?;
         };
 
-        async fn http_get(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> {
-            Ok(checked_get(client, url).await?.bytes().await?.to_vec())
+        async fn http_get<H: HttpClient>(client: &H, url: &str) -> Result<Vec<u8>> {
+            Ok(checked_get(client, url).await?.body)
         }
 
         // First try to get root CA CRL directly from the PCCS endpoint
@@ -508,7 +518,7 @@ impl<C: Config> CollateralClient<C> {
     }
 }
 
-impl CollateralClient<DefaultConfig> {
+impl CollateralClient<DefaultConfig, reqwest::Client> {
     /// Convenience constructor: build a default `reqwest::Client`
     /// (180s timeout on non-`js` targets) and pair it with the given
     /// PCCS URL. Uses [`DefaultConfig`] (audited `x509-cert` backend).

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -251,10 +251,12 @@ fn extract_fmspc_and_ca_with<C: Config>(pem_chain: &str) -> Result<(String, &'st
 }
 
 /// Build a `reqwest::Client` with this crate's default settings (180s
-/// timeout on non-`js` targets). Callers who need custom TLS roots,
-/// proxies, or headers should construct their own `reqwest::Client` and
-/// pass it to [`CollateralClient::new`].
-pub fn default_http_client() -> Result<reqwest::Client> {
+/// timeout on non-`js` targets). Crate-private on purpose: the
+/// `reqwest::Client` type is intentionally kept off the public API so
+/// that a future `reqwest` major bump is an internal change. Callers
+/// who need a custom HTTP stack implement [`HttpClient`] on their own
+/// type and pass it to [`CollateralClient::new`].
+pub(crate) fn default_http_client() -> Result<reqwest::Client> {
     let builder = reqwest::Client::builder();
     #[cfg(not(feature = "js"))]
     let builder = builder.timeout(Duration::from_secs(180));
@@ -278,12 +280,14 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 /// A PCCS / PCS client parameterized by [`Config`] for pluggable X.509 /
 /// crypto backends, and by [`HttpClient`] for the HTTP transport.
 ///
-/// `H` defaults to [`ReqwestHttp`](crate::http::ReqwestHttp), the
-/// crate's bundled `reqwest` adapter (gated by `feature = "reqwest"`).
-/// Implement [`HttpClient`] on your own type to plug in a different
-/// HTTP stack — useful when the workspace is on a different `reqwest`
-/// major or wants to avoid a direct `reqwest` dependency / exposing
-/// `reqwest` types in its own API.
+/// `H` defaults to a crate-private `reqwest`-backed adapter (gated on
+/// `feature = "reqwest"`). `reqwest::Client` deliberately does **not**
+/// appear in any public function signature, so a future `reqwest`
+/// major bump is an internal change rather than a breaking one for
+/// downstream callers. To plug in a custom HTTP stack — different TLS
+/// config, workspace-pinned `reqwest` major, non-`reqwest` transport,
+/// wasm host fetch, … — implement [`HttpClient`] on your own type and
+/// hand it to [`new`](Self::new).
 ///
 /// Exposes three fetch methods:
 ///
@@ -296,6 +300,8 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 ///
 /// # Examples
 ///
+/// Default path — let the crate build a `reqwest`-backed transport:
+///
 /// ```no_run
 /// use dcap_qvl::collateral::{CollateralClient, PHALA_PCCS_URL};
 /// # async fn run(quote: Vec<u8>) -> anyhow::Result<()> {
@@ -305,15 +311,22 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 /// # Ok(()) }
 /// ```
 ///
-/// With a custom `reqwest::Client` (e.g. for a local PCCS with a
-/// self-signed TLS cert) and the default config:
+/// Custom transport — implement [`HttpClient`] on a type you own:
 ///
-/// ```no_run
-/// # use dcap_qvl::collateral::CollateralClient;
-/// # async fn run(http: reqwest::Client, quote: Vec<u8>) -> anyhow::Result<()> {
-/// let client = CollateralClient::with_reqwest(http, "https://pccs.local:8081");
-/// let collateral = client.fetch(&quote).await?;
-/// # Ok(()) }
+/// ```ignore
+/// use dcap_qvl::collateral::CollateralClient;
+/// use dcap_qvl::http::{HttpClient, HttpResponse};
+///
+/// struct MyHttp { /* your HTTP client of choice */ }
+///
+/// impl HttpClient for MyHttp {
+///     async fn get(&self, url: &str) -> anyhow::Result<HttpResponse> {
+///         /* … */
+/// #       todo!()
+///     }
+/// }
+///
+/// let client = CollateralClient::<_, MyHttp>::new(MyHttp { /* … */ }, "https://pccs.local");
 /// ```
 pub struct CollateralClient<C: Config = DefaultConfig, H: HttpClient = ReqwestHttp> {
     http: H,
@@ -334,13 +347,11 @@ impl<C: Config, H: HttpClient + Clone> Clone for CollateralClient<C, H> {
 impl<C: Config, H: HttpClient> CollateralClient<C, H> {
     /// Build a client with a caller-provided HTTP transport.
     ///
-    /// Any type implementing [`HttpClient`] is accepted. To pass a
-    /// [`reqwest::Client`], wrap it in
-    /// [`ReqwestHttp`](crate::http::ReqwestHttp) (or use the
-    /// [`with_reqwest`](CollateralClient::<DefaultConfig>::with_reqwest)
-    /// shortcut). For the common "just give me something that works"
-    /// path see
-    /// [`with_default_http`](CollateralClient::<DefaultConfig>::with_default_http).
+    /// Any type implementing [`HttpClient`] is accepted. For the common
+    /// "just give me something that works" path see
+    /// [`with_default_http`](CollateralClient::<DefaultConfig>::with_default_http);
+    /// the default-path `reqwest::Client` is intentionally not exposed
+    /// on the public API.
     pub fn new(http: H, pccs_url: impl Into<String>) -> Self {
         Self {
             http,
@@ -517,26 +528,18 @@ impl<C: Config, H: HttpClient> CollateralClient<C, H> {
 }
 
 impl CollateralClient<DefaultConfig, ReqwestHttp> {
-    /// Convenience constructor: build a default `reqwest::Client`
-    /// (180s timeout on non-`js` targets) and pair it with the given
-    /// PCCS URL. Uses [`DefaultConfig`] (audited `x509-cert` backend).
+    /// Convenience constructor: build a default `reqwest`-backed
+    /// transport (180s timeout on non-`js` targets) and pair it with
+    /// the given PCCS URL. Uses [`DefaultConfig`] (audited `x509-cert`
+    /// backend). The underlying `reqwest::Client` is intentionally not
+    /// exposed; callers who need a custom HTTP stack implement
+    /// [`HttpClient`] on their own type and use
+    /// [`CollateralClient::new`].
     pub fn with_default_http(pccs_url: impl Into<String>) -> Result<Self> {
         Ok(Self::new(
             ReqwestHttp::new(default_http_client()?),
             pccs_url,
         ))
-    }
-
-    /// Wrap a caller-provided [`reqwest::Client`] in [`ReqwestHttp`] and
-    /// pair it with the given PCCS URL. Uses [`DefaultConfig`].
-    ///
-    /// Use this for the common case of "I built my own
-    /// `reqwest::Client` (custom TLS roots, proxies, headers) and want
-    /// to plug it in." For a non-`reqwest` HTTP stack, implement
-    /// [`HttpClient`] on your own type and call
-    /// [`new`](Self::new) directly.
-    pub fn with_reqwest(client: reqwest::Client, pccs_url: impl Into<String>) -> Self {
-        Self::new(ReqwestHttp::new(client), pccs_url)
     }
 
     /// Zero-arg convenience constructor: default HTTP client + PCCS URL

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,89 @@
+//! HTTP client abstraction used by [`crate::collateral`].
+//!
+//! `dcap-qvl` ships a default [`HttpClient`] impl on [`reqwest::Client`]
+//! (gated by `feature = "reqwest"`). Downstream users who can't depend on
+//! `reqwest` (e.g. workspaces with their own HTTP stack, or wasm targets
+//! using a host-provided fetch) can implement [`HttpClient`] on their own
+//! type and pass an instance to
+//! [`CollateralClient::new`](crate::collateral::CollateralClient::new).
+//!
+//! The trait is deliberately narrow — it covers only what
+//! [`crate::collateral`] needs: a `GET`, plus access to status, named
+//! headers, and the response body.
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use anyhow::Result;
+
+/// Owned HTTP response.
+///
+/// Bodies are buffered into memory: the PCCS endpoints used by this crate
+/// return small payloads (≤ a few hundred KiB), so streaming is not worth
+/// the abstraction cost.
+pub struct HttpResponse {
+    /// HTTP status code (e.g. `200`).
+    pub status: u16,
+    /// Response headers. Names MUST be stored lower-cased so
+    /// [`HttpResponse::header`] can perform case-insensitive lookups
+    /// without re-walking the map. Implementations are responsible for
+    /// lower-casing on insertion.
+    pub headers: BTreeMap<String, String>,
+    /// Response body bytes.
+    pub body: Vec<u8>,
+}
+
+impl HttpResponse {
+    /// Case-insensitive header lookup.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .get(&name.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+
+    /// `true` if [`status`](Self::status) is in `200..300`.
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// Decode the body as UTF-8.
+    pub fn text(&self) -> Result<&str> {
+        Ok(core::str::from_utf8(&self.body)?)
+    }
+}
+
+/// HTTP transport used by [`CollateralClient`](crate::collateral::CollateralClient).
+///
+/// Implementations only need to support `GET`; the crate buffers
+/// responses in memory (see [`HttpResponse`]).
+///
+/// The `async fn` here intentionally has no `Send` bound. Auto-traits
+/// propagate through monomorphization, so callers using a `Send` impl
+/// (e.g. the built-in [`reqwest::Client`] adapter) get `Send` futures
+/// automatically; callers on single-threaded runtimes don't pay the
+/// `Send` bound they don't need.
+#[allow(async_fn_in_trait)]
+pub trait HttpClient {
+    /// Issue a GET request and buffer the full response.
+    async fn get(&self, url: &str) -> Result<HttpResponse>;
+}
+
+#[cfg(feature = "reqwest")]
+impl HttpClient for reqwest::Client {
+    async fn get(&self, url: &str) -> Result<HttpResponse> {
+        let resp = reqwest::Client::get(self, url).send().await?;
+        let status = resp.status().as_u16();
+        let mut headers = BTreeMap::new();
+        for (name, value) in resp.headers() {
+            if let Ok(v) = value.to_str() {
+                headers.insert(name.as_str().to_ascii_lowercase(), v.to_string());
+            }
+        }
+        let body = resp.bytes().await?.to_vec();
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,13 +1,21 @@
 //! HTTP client abstraction used by [`crate::collateral`].
 //!
-//! `dcap-qvl` ships a default [`HttpClient`] impl for [`reqwest::Client`]
-//! when `feature = "reqwest"` is enabled. The trait lets downstream users
-//! avoid taking a *direct* dependency on `reqwest` (and the resulting
-//! version / type coupling on the public API boundary): they can
-//! implement [`HttpClient`] on their own type — backed by a different
-//! HTTP stack, a host-provided fetch on wasm, etc. — and pass an
-//! instance to
+//! `dcap-qvl` ships a default [`HttpClient`] adapter for `reqwest` —
+//! [`ReqwestHttp`] — when `feature = "reqwest"` is enabled. The trait
+//! lets downstream users avoid taking a *direct* dependency on
+//! `reqwest` (and the resulting version / type coupling on the public
+//! API boundary): they can implement [`HttpClient`] on their own type —
+//! backed by a different HTTP stack, a host-provided fetch on wasm,
+//! etc. — and pass an instance to
 //! [`CollateralClient::new`](crate::collateral::CollateralClient::new).
+//!
+//! `reqwest::Client` is intentionally bridged through a newtype rather
+//! than a direct trait impl: it mirrors the only pattern available to
+//! downstream users (the orphan rule forbids them from impl'ing
+//! [`HttpClient`] on a `reqwest::Client` from a *different* `reqwest`
+//! version), and avoids method-resolution surprises between
+//! `reqwest::Client::get` (returns a builder) and
+//! [`HttpClient::get`] (returns a future).
 //!
 //! The trait is deliberately narrow — it covers only what
 //! [`crate::collateral`] needs: a `GET`, plus access to status, named
@@ -63,7 +71,7 @@ impl HttpResponse {
 ///
 /// The `async fn` here intentionally has no `Send` bound. Auto-traits
 /// propagate through monomorphization, so callers using a `Send` impl
-/// (e.g. the built-in [`reqwest::Client`] adapter) get `Send` futures
+/// (e.g. the built-in [`ReqwestHttp`] adapter) get `Send` futures
 /// automatically; callers on single-threaded runtimes don't pay the
 /// `Send` bound they don't need.
 #[allow(async_fn_in_trait)]
@@ -72,10 +80,37 @@ pub trait HttpClient {
     async fn get(&self, url: &str) -> Result<HttpResponse>;
 }
 
+/// [`HttpClient`] adapter over [`reqwest::Client`].
+///
+/// Modeled as a newtype rather than a direct `impl HttpClient for
+/// reqwest::Client` so that downstream users on a different `reqwest`
+/// major version can write the same shape on their side (the orphan
+/// rule blocks them from impl'ing [`HttpClient`] on a foreign
+/// `reqwest::Client` directly).
 #[cfg(feature = "reqwest")]
-impl HttpClient for reqwest::Client {
+#[derive(Clone, Debug)]
+pub struct ReqwestHttp(pub reqwest::Client);
+
+#[cfg(feature = "reqwest")]
+impl ReqwestHttp {
+    /// Wrap a [`reqwest::Client`] for use with
+    /// [`CollateralClient`](crate::collateral::CollateralClient).
+    pub fn new(client: reqwest::Client) -> Self {
+        Self(client)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl From<reqwest::Client> for ReqwestHttp {
+    fn from(client: reqwest::Client) -> Self {
+        Self(client)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl HttpClient for ReqwestHttp {
     async fn get(&self, url: &str) -> Result<HttpResponse> {
-        let resp = reqwest::Client::get(self, url).send().await?;
+        let resp = self.0.get(url).send().await?;
         let status = resp.status().as_u16();
         let headers = resp
             .headers()

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,21 +1,17 @@
 //! HTTP client abstraction used by [`crate::collateral`].
 //!
-//! `dcap-qvl` ships a default [`HttpClient`] adapter for `reqwest` —
-//! [`ReqwestHttp`] — when `feature = "reqwest"` is enabled. The trait
-//! lets downstream users avoid taking a *direct* dependency on
-//! `reqwest` (and the resulting version / type coupling on the public
-//! API boundary): they can implement [`HttpClient`] on their own type —
-//! backed by a different HTTP stack, a host-provided fetch on wasm,
-//! etc. — and pass an instance to
-//! [`CollateralClient::new`](crate::collateral::CollateralClient::new).
+//! The `HttpClient` trait keeps `reqwest` (and its types / version) out
+//! of this crate's public API surface. The default-path constructors
+//! ([`with_default_http`](crate::collateral::CollateralClient::<crate::configs::DefaultConfig>::with_default_http),
+//! [`from_env`](crate::collateral::CollateralClient::<crate::configs::DefaultConfig>::from_env))
+//! still use `reqwest` internally, but no public function signature
+//! mentions `reqwest::Client` — so a future `reqwest` major bump is an
+//! internal change, not a breaking one for downstream callers.
 //!
-//! `reqwest::Client` is intentionally bridged through a newtype rather
-//! than a direct trait impl: it mirrors the only pattern available to
-//! downstream users (the orphan rule forbids them from impl'ing
-//! [`HttpClient`] on a `reqwest::Client` from a *different* `reqwest`
-//! version), and avoids method-resolution surprises between
-//! `reqwest::Client::get` (returns a builder) and
-//! [`HttpClient::get`] (returns a future).
+//! Callers that need a custom HTTP stack (different TLS config,
+//! workspace-pinned `reqwest` major, non-`reqwest` transport, wasm host
+//! fetch, …) implement [`HttpClient`] on their own type and pass it to
+//! [`CollateralClient::new`](crate::collateral::CollateralClient::new).
 //!
 //! The trait is deliberately narrow — it covers only what
 //! [`crate::collateral`] needs: a `GET`, plus access to status, named
@@ -71,38 +67,33 @@ impl HttpResponse {
 ///
 /// The `async fn` here intentionally has no `Send` bound. Auto-traits
 /// propagate through monomorphization, so callers using a `Send` impl
-/// (e.g. the built-in [`ReqwestHttp`] adapter) get `Send` futures
-/// automatically; callers on single-threaded runtimes don't pay the
-/// `Send` bound they don't need.
+/// still get `Send` futures automatically; callers on single-threaded
+/// runtimes don't pay the `Send` bound they don't need.
 #[allow(async_fn_in_trait)]
 pub trait HttpClient {
     /// Issue a GET request and buffer the full response.
     async fn get(&self, url: &str) -> Result<HttpResponse>;
 }
 
-/// [`HttpClient`] adapter over [`reqwest::Client`].
+/// Opaque `reqwest`-backed [`HttpClient`] adapter.
 ///
-/// Modeled as a newtype rather than a direct `impl HttpClient for
-/// reqwest::Client` so that downstream users on a different `reqwest`
-/// major version can write the same shape on their side (the orphan
-/// rule blocks them from impl'ing [`HttpClient`] on a foreign
-/// `reqwest::Client` directly).
+/// The type name is `pub` only so it can sit as the default `H` on
+/// [`CollateralClient`](crate::collateral::CollateralClient); the inner
+/// `reqwest::Client` and the constructor are crate-private. Callers
+/// obtain a value only indirectly via
+/// [`with_default_http`](crate::collateral::CollateralClient::<crate::configs::DefaultConfig>::with_default_http)
+/// /
+/// [`from_env`](crate::collateral::CollateralClient::<crate::configs::DefaultConfig>::from_env)
+/// and treat it as an opaque token — `reqwest::Client` does not appear
+/// in any public signature, so a future `reqwest` major bump is an
+/// internal change.
 #[cfg(feature = "reqwest")]
-#[derive(Clone, Debug)]
-pub struct ReqwestHttp(pub reqwest::Client);
+#[derive(Clone)]
+pub struct ReqwestHttp(reqwest::Client);
 
 #[cfg(feature = "reqwest")]
 impl ReqwestHttp {
-    /// Wrap a [`reqwest::Client`] for use with
-    /// [`CollateralClient`](crate::collateral::CollateralClient).
-    pub fn new(client: reqwest::Client) -> Self {
-        Self(client)
-    }
-}
-
-#[cfg(feature = "reqwest")]
-impl From<reqwest::Client> for ReqwestHttp {
-    fn from(client: reqwest::Client) -> Self {
+    pub(crate) fn new(client: reqwest::Client) -> Self {
         Self(client)
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,10 +1,12 @@
 //! HTTP client abstraction used by [`crate::collateral`].
 //!
-//! `dcap-qvl` ships a default [`HttpClient`] impl on [`reqwest::Client`]
-//! (gated by `feature = "reqwest"`). Downstream users who can't depend on
-//! `reqwest` (e.g. workspaces with their own HTTP stack, or wasm targets
-//! using a host-provided fetch) can implement [`HttpClient`] on their own
-//! type and pass an instance to
+//! `dcap-qvl` ships a default [`HttpClient`] impl for [`reqwest::Client`]
+//! when `feature = "reqwest"` is enabled. The trait lets downstream users
+//! avoid taking a *direct* dependency on `reqwest` (and the resulting
+//! version / type coupling on the public API boundary): they can
+//! implement [`HttpClient`] on their own type — backed by a different
+//! HTTP stack, a host-provided fetch on wasm, etc. — and pass an
+//! instance to
 //! [`CollateralClient::new`](crate::collateral::CollateralClient::new).
 //!
 //! The trait is deliberately narrow — it covers only what
@@ -24,21 +26,23 @@ use anyhow::Result;
 pub struct HttpResponse {
     /// HTTP status code (e.g. `200`).
     pub status: u16,
-    /// Response headers. Names MUST be stored lower-cased so
-    /// [`HttpResponse::header`] can perform case-insensitive lookups
-    /// without re-walking the map. Implementations are responsible for
-    /// lower-casing on insertion.
+    /// Response headers. Use [`HttpResponse::header`] for
+    /// case-insensitive lookups; the field itself imposes no
+    /// case-normalization invariant on implementations.
     pub headers: BTreeMap<String, String>,
     /// Response body bytes.
     pub body: Vec<u8>,
 }
 
 impl HttpResponse {
-    /// Case-insensitive header lookup.
+    /// Case-insensitive header lookup. O(n) over header count — header
+    /// counts are small (typically < 20), so a linear scan is cheaper
+    /// than imposing a normalization invariant on every implementation.
     pub fn header(&self, name: &str) -> Option<&str> {
         self.headers
-            .get(&name.to_ascii_lowercase())
-            .map(String::as_str)
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
     }
 
     /// `true` if [`status`](Self::status) is in `200..300`.
@@ -73,12 +77,16 @@ impl HttpClient for reqwest::Client {
     async fn get(&self, url: &str) -> Result<HttpResponse> {
         let resp = reqwest::Client::get(self, url).send().await?;
         let status = resp.status().as_u16();
-        let mut headers = BTreeMap::new();
-        for (name, value) in resp.headers() {
-            if let Ok(v) = value.to_str() {
-                headers.insert(name.as_str().to_ascii_lowercase(), v.to_string());
-            }
-        }
+        let headers = resp
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                let v = value
+                    .to_str()
+                    .map_err(|e| anyhow::anyhow!("Header {name} has non-ASCII value: {e}"))?;
+                Ok::<_, anyhow::Error>((name.as_str().to_string(), v.to_string()))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
         let body = resp.bytes().await?.to_vec();
         Ok(HttpResponse {
             status,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ pub mod collateral;
 #[cfg(feature = "report")]
 pub use collateral::PHALA_PCCS_URL;
 
+#[cfg(feature = "report")]
+pub mod http;
+
 pub mod config;
 #[cfg(feature = "default-x509")]
 pub mod configs;


### PR DESCRIPTION
## Summary

- Adds a small `HttpClient` trait + buffered `HttpResponse` in `dcap_qvl::http` (covers only what `collateral` actually uses: status, case-insensitive header lookup, body bytes).
- `CollateralClient` becomes generic over `H: HttpClient`. The default `H` is an opaque, in-tree `reqwest`-backed adapter; **`reqwest::Client` does not appear in any public function signature**, so a future `reqwest` major bump is an internal change rather than a breaking one for downstream callers.
- Existing default-path API is unchanged: `CollateralClient::with_default_http(url)`, `from_env()`, `.fetch()`, `.fetch_for_fmspc()`, `.fetch_and_verify()` all keep working as before.

`cargo public-api` confirms zero `reqwest::*` items in the public surface.

## Motivation

Alternative to #155, addressing the same downstream pain (workspaces stuck reconciling two `reqwest` majors) but at the abstraction layer rather than via re-export. The objective is stronger than #155: not just "downstream doesn't have to write `reqwest = "0.12.x"`", but "this crate's API never breaks when `reqwest` itself breaks."

## Plugging in a custom HTTP transport

Callers who need a custom HTTP stack — different TLS config, workspace-pinned `reqwest` major, non-`reqwest` transport, wasm host fetch — implement `HttpClient` on a type they own and pass it to `CollateralClient::new`. Since `reqwest::Client` is not part of this crate's public API, downstream is free to depend on whatever `reqwest` version it likes (or none at all).

```rust
// In the downstream crate's Cargo.toml:
//   reqwest  = "0.13"   # whatever version the workspace pins
//   dcap-qvl = "..."    # links its own reqwest internally — not exposed
//   anyhow   = "1"

use dcap_qvl::collateral::CollateralClient;
use dcap_qvl::http::{HttpClient, HttpResponse};
use std::collections::BTreeMap;

pub struct WorkspaceHttp(pub reqwest::Client); // your reqwest, not ours

impl HttpClient for WorkspaceHttp {
    async fn get(&self, url: &str) -> anyhow::Result<HttpResponse> {
        let resp = self.0.get(url).send().await?;
        let status = resp.status().as_u16();
        let headers = resp
            .headers()
            .iter()
            .map(|(name, value)| {
                Ok::<_, anyhow::Error>((
                    name.as_str().to_string(),
                    value.to_str()?.to_string(),
                ))
            })
            .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
        let body = resp.bytes().await?.to_vec();
        Ok(HttpResponse { status, headers, body })
    }
}

let http = WorkspaceHttp(reqwest::Client::new());
let client = CollateralClient::<_, WorkspaceHttp>::new(http, "https://pccs.example.com");
let collateral = client.fetch(&quote).await?;
```

The same pattern covers any non-`reqwest` HTTP stack (`hyper`, `ureq`, `surf`, a wasm host fetch, …) — write a small wrapper, `impl HttpClient`, hand it to `CollateralClient::new`. The orphan rule means callers always need a newtype on their side anyway (they can't `impl HttpClient` directly on a foreign `reqwest::Client`); since this crate doesn't expose its own bridge type's constructor, the boundary is clean.

## Why is `reqwest::Client` not exposed for "easy" wrapping?

That was an earlier draft (`with_reqwest(client, url)`, `ReqwestHttp::new(client)`, `From<reqwest::Client>`). It was removed because it defeated the point: any `reqwest` type on the public API is a breaking-change bait when `reqwest` bumps majors. Callers who want their own reqwest-backed transport write the ~15-line `impl HttpClient` shown above — once, in their crate, against whatever `reqwest` version they like.

## Design notes

- Trait is deliberately narrow (only `GET` and a buffered response). PCCS payloads are small, so streaming isn't worth the abstraction cost.
- `async fn get(&self, url: &str)` has no explicit `Send` bound. Auto-traits propagate through monomorphization, so callers using a `Send` impl still get `Send` futures automatically; callers on single-threaded runtimes (or wasm) don't pay a `Send` bound they don't need.
- `HttpResponse::header(name)` is truly case-insensitive (linear scan; header counts are tiny), so implementations are free to preserve original casing.
- The bundled `ReqwestHttp` adapter is `pub` only so it can be the default for `CollateralClient`'s `H` parameter without tripping `private_interfaces`. Its inner `reqwest::Client` and constructor are crate-private; from outside it is an opaque token.

## Test plan

- [x] `cargo public-api` — no `reqwest::*` in public API
- [x] `cargo check --lib` (default features)
- [x] `cargo check --lib --no-default-features --features "report ring default-x509"`
- [x] `cargo check --lib --no-default-features --features "report rustcrypto"`
- [x] `cargo check --lib --no-default-features --features "report ring rustcrypto"`
- [x] `cargo check --lib --no-default-features --features "js report ring default-x509" --target wasm32-unknown-unknown`
- [x] `cargo test --lib` — 28/28 pass
- [x] `cargo test --doc` — passes
- [x] `cargo build` for `cli/`
- [x] `cargo fmt --all -- --check`