### PR TITLE
refactor(config): replace `issuer_contains(&[u8])` with `pck_ca() -> Option<PckCa>`

### DIFF
--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -239,12 +239,9 @@ fn extract_fmspc_and_ca_with<C: Config>(pem_chain: &str) -> Result<(String, &'st
     let fmspc_hex = hex::encode_upper(fmspc);
 
     // Extract CA type from issuer (reuses parsed cert above)
-    let issuer = parsed
-        .issuer_dn()
-        .context("Failed to extract certificate issuer")?;
-    let ca = if issuer.contains(crate::constants::PROCESSOR_ISSUER) {
+    let ca = if parsed.issuer_contains(crate::constants::PROCESSOR_ISSUER.as_bytes()) {
         crate::constants::PROCESSOR_ISSUER_ID
-    } else if issuer.contains(crate::constants::PLATFORM_ISSUER) {
+    } else if parsed.issuer_contains(crate::constants::PLATFORM_ISSUER.as_bytes()) {
         crate::constants::PLATFORM_ISSUER_ID
     } else {
         crate::constants::PROCESSOR_ISSUER_ID

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -238,14 +238,12 @@ fn extract_fmspc_and_ca_with<C: Config>(pem_chain: &str) -> Result<(String, &'st
     let fmspc = crate::utils::get_fmspc(&extension)?;
     let fmspc_hex = hex::encode_upper(fmspc);
 
-    // Extract CA type from issuer (reuses parsed cert above)
-    let ca = if parsed.issuer_contains(crate::constants::PROCESSOR_ISSUER.as_bytes()) {
-        crate::constants::PROCESSOR_ISSUER_ID
-    } else if parsed.issuer_contains(crate::constants::PLATFORM_ISSUER.as_bytes()) {
-        crate::constants::PLATFORM_ISSUER_ID
-    } else {
-        crate::constants::PROCESSOR_ISSUER_ID
-    };
+    // Extract CA type from issuer (reuses parsed cert above). Legacy
+    // fallback: an unrecognised issuer is treated as Processor.
+    let ca = parsed
+        .pck_ca()
+        .unwrap_or(crate::config::PckCa::Processor)
+        .as_id_str();
 
     Ok((fmspc_hex, ca))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,6 @@
 //! that owns or borrows the parsed data, so multiple field accesses share a
 //! single parse.
 
-use alloc::string::String;
 use alloc::vec::Vec;
 use anyhow::Result;
 
@@ -74,19 +73,33 @@ pub trait X509Codec {
 
 /// Read-only accessors over a parsed X.509 certificate.
 pub trait ParsedCert {
-    /// Returns the issuer Distinguished Name as a human-readable string in
-    /// RFC 4514 form (e.g. `"CN=Foo,O=Bar"`).
+    /// Returns `true` if any RDN component of the issuer DN whose tag is
+    /// `PrintableString`, `UTF8String`, `IA5String`, or `TeletexString`
+    /// contains `needle` as a byte substring.
     ///
-    /// The string is consumed by `intel::quote_ca` for substring matching, so
-    /// a stable, conventional representation is required.
-    fn issuer_dn(&self) -> Result<String>;
+    /// Wide-char `BMPString` / `UniversalString` and non-string ATVs are
+    /// skipped — an ASCII needle cannot meaningfully match those encodings,
+    /// which is also what the former `issuer_dn().to_string().contains(...)`
+    /// produced (`x509-cert`'s `Display` hex-encodes non-byte-string ATVs).
+    ///
+    /// Used by [`crate::intel::pck_ca_with`] to classify an Intel PCK leaf.
+    /// Intel PCK issuer CNs are `UTF8String`, so the skipped tags are not
+    /// reachable on the production path.
+    fn issuer_contains(&self, needle: &[u8]) -> bool;
 
     /// Returns the OCTET STRING contents of the unique extension whose
     /// `extnID` equals `oid`, where `oid` is the DER-encoded OID body
-    /// (no tag/length).
+    /// (no tag/length). Callers SHOULD construct `oid` from a
+    /// [`const_oid::ObjectIdentifier`] and pass `.as_bytes()`.
     ///
     /// * `Ok(Some(value))` — exactly one matching extension was found.
-    /// * `Ok(None)` — no matching extension.
+    /// * `Ok(None)` — no matching extension, *including* when `oid` is not a
+    ///   well-formed OID body: a malformed needle cannot equal any cert's
+    ///   `extnID` (which was DER-validated during [`X509Codec::from_der`]),
+    ///   so "not found" is vacuously correct. Implementations are not
+    ///   required to reject malformed `oid` inputs — runtime validation
+    ///   would be pure overhead for callers that supply
+    ///   `const_oid`-constructed OIDs.
     /// * `Err(_)` — the extension was found more than once, or the certificate
     ///   is malformed.
     fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>>;

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,21 +71,32 @@ pub trait X509Codec {
     fn from_der<'a>(cert_der: &'a [u8]) -> Result<Self::Parsed<'a>>;
 }
 
+/// Intel PCK certificate authority that issued a leaf cert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PckCa {
+    Processor,
+    Platform,
+}
+
+impl PckCa {
+    /// Lowercase identifier used in PCS URLs and FFI bindings
+    /// (`"processor"` / `"platform"`).
+    pub fn as_id_str(&self) -> &'static str {
+        match self {
+            PckCa::Processor => crate::constants::PROCESSOR_ISSUER_ID,
+            PckCa::Platform => crate::constants::PLATFORM_ISSUER_ID,
+        }
+    }
+}
+
 /// Read-only accessors over a parsed X.509 certificate.
 pub trait ParsedCert {
-    /// Returns `true` if any RDN component of the issuer DN whose tag is
-    /// `PrintableString`, `UTF8String`, `IA5String`, or `TeletexString`
-    /// contains `needle` as a byte substring.
+    /// Classify the issuer of an Intel PCK leaf certificate.
     ///
-    /// Wide-char `BMPString` / `UniversalString` and non-string ATVs are
-    /// skipped — an ASCII needle cannot meaningfully match those encodings,
-    /// which is also what the former `issuer_dn().to_string().contains(...)`
-    /// produced (`x509-cert`'s `Display` hex-encodes non-byte-string ATVs).
-    ///
-    /// Used by [`crate::intel::pck_ca_with`] to classify an Intel PCK leaf.
-    /// Intel PCK issuer CNs are `UTF8String`, so the skipped tags are not
-    /// reachable on the production path.
-    fn issuer_contains(&self, needle: &[u8]) -> bool;
+    /// Returns `None` when the issuer matches neither CA, or when the
+    /// backend cannot interpret the issuer DN. Callers decide how to
+    /// handle `None`.
+    fn pck_ca(&self) -> Option<PckCa>;
 
     /// Returns the OCTET STRING contents of the unique extension whose
     /// `extnID` equals `oid`, where `oid` is the DER-encoded OID body

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -81,9 +81,8 @@ pub const PCK_CERT_CHAIN: u16 = 5;
 pub const QE_REPORT_CERT: u16 = 6;
 pub const PLATFORM_MANIFEST: u16 = 7;
 
-// PCK certificate issuer identifiers
-pub const PROCESSOR_ISSUER: &str = "Processor";
-pub const PLATFORM_ISSUER: &str = "Platform";
+// PCK certificate issuer identifiers (lowercase strings used in PCS URLs
+// and FFI bindings; rendered from `crate::config::PckCa::as_id_str`).
 pub const PROCESSOR_ISSUER_ID: &str = "processor";
 pub const PLATFORM_ISSUER_ID: &str = "platform";
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn dcap_parse_quote_cb(
             Err(e) => return emit_error(format_error(&e), cb, user_data),
         };
         let ca = match crate::intel::quote_ca(&parsed) {
-            Ok(c) => Some(c.to_string()),
+            Ok(c) => Some(c.as_id_str().to_string()),
             Err(e) => return emit_error(format_error(&e), cb, user_data),
         };
         (fmspc, ca)

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -7,7 +7,7 @@ use asn1_der::{
 #[cfg(feature = "default-x509")]
 use crate::configs::DefaultConfig;
 use crate::{
-    config::{Config, ParsedCert, X509Codec},
+    config::{Config, ParsedCert, PckCa, X509Codec},
     constants::{self, CpuSvn, Fmspc, Svn},
     oids,
     quote::{AuthData, Quote},
@@ -120,26 +120,22 @@ pub fn parse_pck_extension_from_pem(pem_data: &[u8]) -> Result<PckExtension> {
 }
 
 /// Classify the PCK certificate authority of a leaf cert as
-/// [`crate::constants::PROCESSOR_ISSUER_ID`] or
-/// [`crate::constants::PLATFORM_ISSUER_ID`] by inspecting the issuer DN.
+/// [`PckCa::Processor`] or [`PckCa::Platform`] by inspecting the issuer DN.
 ///
-/// Generic over [`Config`]; the issuer DN extraction goes through the
-/// configured [`X509Codec`].
-pub fn pck_ca_with<C: Config>(cert_der: &[u8]) -> Result<&'static str> {
+/// Generic over [`Config`]; the classification goes through the
+/// configured [`X509Codec`]. An unrecognised issuer is reported as
+/// [`PckCa::Processor`] for backwards compatibility — see comment.
+pub fn pck_ca_with<C: Config>(cert_der: &[u8]) -> Result<PckCa> {
     let parsed = C::X509::from_der(cert_der).context("Failed to decode certificate")?;
-    if parsed.issuer_contains(constants::PROCESSOR_ISSUER.as_bytes()) {
-        Ok(constants::PROCESSOR_ISSUER_ID)
-    } else if parsed.issuer_contains(constants::PLATFORM_ISSUER.as_bytes()) {
-        Ok(constants::PLATFORM_ISSUER_ID)
-    } else {
-        // Preserve legacy fallback behavior: unknown issuer is treated as processor.
-        Ok(constants::PROCESSOR_ISSUER_ID)
-    }
+    // Legacy fallback: an unrecognised issuer is treated as Processor. This
+    // policy lives at the call site, not in the backend, so future callers
+    // can opt to error or log on `None` without needing trait changes.
+    Ok(parsed.pck_ca().unwrap_or(PckCa::Processor))
 }
 
 /// [`pck_ca_with`] under the audited [`DefaultConfig`].
 #[cfg(feature = "default-x509")]
-pub fn pck_ca(cert_der: &[u8]) -> Result<&'static str> {
+pub fn pck_ca(cert_der: &[u8]) -> Result<PckCa> {
     pck_ca_with::<DefaultConfig>(cert_der)
 }
 
@@ -162,7 +158,7 @@ pub fn quote_fmspc(quote: &Quote) -> Result<Fmspc> {
 /// Return the PCK CA classification of a quote's PCK leaf certificate.
 ///
 /// Generic over [`Config`].
-pub fn quote_ca_with<C: Config>(quote: &Quote) -> Result<&'static str> {
+pub fn quote_ca_with<C: Config>(quote: &Quote) -> Result<PckCa> {
     let chain = extract_cert_chain(quote)?;
     let leaf = chain.first().context("Empty PCK certificate chain")?;
     pck_ca_with::<C>(leaf)
@@ -170,7 +166,7 @@ pub fn quote_ca_with<C: Config>(quote: &Quote) -> Result<&'static str> {
 
 /// [`quote_ca_with`] under the audited [`DefaultConfig`].
 #[cfg(feature = "default-x509")]
-pub fn quote_ca(quote: &Quote) -> Result<&'static str> {
+pub fn quote_ca(quote: &Quote) -> Result<PckCa> {
     quote_ca_with::<DefaultConfig>(quote)
 }
 

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -126,13 +126,10 @@ pub fn parse_pck_extension_from_pem(pem_data: &[u8]) -> Result<PckExtension> {
 /// Generic over [`Config`]; the issuer DN extraction goes through the
 /// configured [`X509Codec`].
 pub fn pck_ca_with<C: Config>(cert_der: &[u8]) -> Result<&'static str> {
-    let issuer = C::X509::from_der(cert_der)
-        .context("Failed to decode certificate")?
-        .issuer_dn()
-        .context("Failed to extract certificate issuer")?;
-    if issuer.contains(constants::PROCESSOR_ISSUER) {
+    let parsed = C::X509::from_der(cert_der).context("Failed to decode certificate")?;
+    if parsed.issuer_contains(constants::PROCESSOR_ISSUER.as_bytes()) {
         Ok(constants::PROCESSOR_ISSUER_ID)
-    } else if issuer.contains(constants::PLATFORM_ISSUER) {
+    } else if parsed.issuer_contains(constants::PLATFORM_ISSUER.as_bytes()) {
         Ok(constants::PLATFORM_ISSUER_ID)
     } else {
         // Preserve legacy fallback behavior: unknown issuer is treated as processor.

--- a/src/python.rs
+++ b/src/python.rs
@@ -482,7 +482,7 @@ impl PyQuote {
 
     fn ca(&self) -> PyResult<String> {
         match intel::quote_ca(&self.inner) {
-            Ok(ca) => Ok(ca.to_string()),
+            Ok(ca) => Ok(ca.as_id_str().to_string()),
             Err(e) => Err(PyValueError::new_err(format!("Failed to get CA: {}", e))),
         }
     }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 use anyhow::{bail, Context, Result};
 use der::{Tag, Tagged};
 
-use crate::config::{ParsedCert, X509Codec};
+use crate::config::{ParsedCert, PckCa, X509Codec};
 
 /// Audited default [`X509Codec`] implementation, built on `x509-cert` + `der`.
 ///
@@ -33,22 +33,34 @@ impl X509Codec for X509CertBackend {
 }
 
 impl ParsedCert for X509CertParsed {
-    fn issuer_contains(&self, needle: &[u8]) -> bool {
-        if needle.is_empty() {
-            return true;
-        }
+    fn pck_ca(&self) -> Option<PckCa> {
+        // Intel PCK issuer CNs are UTF8String; we also accept Printable / IA5 /
+        // Teletex for robustness. BMP/Universal and non-string ATVs are skipped
+        // — an ASCII substring match against wide-char encodings is meaningless,
+        // matching the historic `Display::contains` behaviour (`x509-cert`'s
+        // `Display` hex-encodes non-byte-string ATVs).
         for rdn in self.cert.tbs_certificate.issuer.0.iter() {
             for atv in rdn.0.iter() {
-                if matches!(
+                if !matches!(
                     atv.value.tag(),
                     Tag::PrintableString | Tag::Utf8String | Tag::Ia5String | Tag::TeletexString
-                ) && atv.value.value().windows(needle.len()).any(|w| w == needle)
+                ) {
+                    continue;
+                }
+                let v = atv.value.value();
+                if v.windows(b"Processor".len())
+                    .any(|w| w == b"Processor".as_slice())
                 {
-                    return true;
+                    return Some(PckCa::Processor);
+                }
+                if v.windows(b"Platform".len())
+                    .any(|w| w == b"Platform".as_slice())
+                {
+                    return Some(PckCa::Platform);
                 }
             }
         }
-        false
+        None
     }
 
     fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -3,9 +3,9 @@
 //! Selected by [`crate::configs::RingConfig`] / [`crate::configs::RustCryptoConfig`]
 //! / [`crate::configs::DefaultConfig`].
 
-use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
+use der::{Tag, Tagged};
 
 use crate::config::{ParsedCert, X509Codec};
 
@@ -33,30 +33,54 @@ impl X509Codec for X509CertBackend {
 }
 
 impl ParsedCert for X509CertParsed {
-    fn issuer_dn(&self) -> Result<String> {
-        Ok(self.cert.tbs_certificate.issuer.to_string())
+    fn issuer_contains(&self, needle: &[u8]) -> bool {
+        if needle.is_empty() {
+            return true;
+        }
+        for rdn in self.cert.tbs_certificate.issuer.0.iter() {
+            for atv in rdn.0.iter() {
+                if matches!(
+                    atv.value.tag(),
+                    Tag::PrintableString | Tag::Utf8String | Tag::Ia5String | Tag::TeletexString
+                ) && atv.value.value().windows(needle.len()).any(|w| w == needle)
+                {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>> {
-        let oid = const_oid::ObjectIdentifier::from_bytes(oid)
-            .map_err(|_| anyhow!("Invalid OID encoding"))?;
-        let mut iter = self
+        // Compare raw DER-encoded OID bodies byte-for-byte. Callers pass the
+        // body of a `const_oid`-constructed OID, so there is nothing left to
+        // validate at runtime. (The parse itself would not add footprint —
+        // `der::Decode<ObjectIdentifier>` is already reachable via cert
+        // parsing — but it is pure runtime cost for no benefit.)
+        let mut found: Option<&[u8]> = None;
+        for ext in self
             .cert
             .tbs_certificate
             .extensions
             .as_deref()
             .unwrap_or(&[])
-            .iter()
-            .filter(|e| e.extn_id == oid)
-            .map(|e| e.extn_value.clone());
-
-        let extension = match iter.next() {
-            Some(ext) => ext,
-            None => return Ok(None),
-        };
-        if iter.next().is_some() {
-            bail!("extension {} appears more than once", oid);
+        {
+            if ext.extn_id.as_bytes() == oid {
+                if found.is_some() {
+                    // NOTE: would be friendlier to include the offending OID here
+                    // (e.g. `"extension {} appears more than once", ext.extn_id`),
+                    // but using `<ObjectIdentifier as Display>` from this call
+                    // site adds ~60–100 B of format-args setup to the stripped
+                    // contract wasm (measured on wasm32 `opt-level=z` + `lto=fat`
+                    // + `wasm-opt -O -Oz`). The duplicate-extension path is only
+                    // reachable on a malformed cert, which Intel-signed chains
+                    // never produce, so the ergonomics aren't worth the binary
+                    // cost. Revisit if a maintainer pushes back.
+                    bail!("extension appears more than once");
+                }
+                found = Some(ext.extn_value.as_bytes());
+            }
         }
-        Ok(Some(extension.into_bytes()))
+        Ok(found.map(<[u8]>::to_vec))
     }
 }

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -47,11 +47,19 @@ pub fn assert_config_conforms<C: Config>() {
         let default =
             <DefaultConfig as Config>::X509::from_der(&cert_der).expect("default from_der");
 
-        assert_eq!(
-            custom.issuer_dn().expect("custom issuer_dn"),
-            default.issuer_dn().expect("default issuer_dn"),
-            "issuer_dn output mismatch"
-        );
+        for needle in [
+            b"Processor".as_slice(),
+            b"Platform",
+            b"Intel SGX",
+            b"NotPresent",
+        ] {
+            assert_eq!(
+                custom.issuer_contains(needle),
+                default.issuer_contains(needle),
+                "issuer_contains output mismatch for needle {:?}",
+                core::str::from_utf8(needle).unwrap_or("<non-utf8>"),
+            );
+        }
 
         let custom_ext = custom.extension(SGX_EXTENSION_OID).expect("custom ext");
         let default_ext = default.extension(SGX_EXTENSION_OID).expect("default ext");

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -47,19 +47,11 @@ pub fn assert_config_conforms<C: Config>() {
         let default =
             <DefaultConfig as Config>::X509::from_der(&cert_der).expect("default from_der");
 
-        for needle in [
-            b"Processor".as_slice(),
-            b"Platform",
-            b"Intel SGX",
-            b"NotPresent",
-        ] {
-            assert_eq!(
-                custom.issuer_contains(needle),
-                default.issuer_contains(needle),
-                "issuer_contains output mismatch for needle {:?}",
-                core::str::from_utf8(needle).unwrap_or("<non-utf8>"),
-            );
-        }
+        assert_eq!(
+            custom.pck_ca(),
+            default.pck_ca(),
+            "pck_ca classification mismatch on PCK leaf",
+        );
 
         let custom_ext = custom.extension(SGX_EXTENSION_OID).expect("custom ext");
         let default_ext = default.extension(SGX_EXTENSION_OID).expect("default ext");


### PR DESCRIPTION
## Summary

Per @kvinwang's review feedback on [#154](https://github.com/Phala-Network/dcap-qvl/pull/154#issuecomment-4309827513): the trait method `ParsedCert::issuer_contains(&[u8]) -> bool` exposes *how* a backend classifies an Intel PCK leaf (byte-substring search over specific RDN string tags), not *what* it returns. The contract lived in a ~12-line prose doc comment, and `tests/config_conformance.rs` had to enumerate four needles (`"Processor"`, `"Platform"`, `"Intel SGX"`, `"NotPresent"`) to reverse-engineer equivalence between backends.

This PR replaces the trait surface with `fn pck_ca(&self) -> Option<PckCa>`, where `PckCa` is `enum { Processor, Platform }`. The signature is now the contract: backends classify however they like (RDN walk, precomputed hash, hardcoded lookup). The conformance test collapses to a single equality assertion on the parsed leaf.

This PR is **stacked on [#154](https://github.com/Phala-Network/dcap-qvl/pull/154)** (`perf/issuer-contains`); it should be reviewed and merged after #154 lands. The diff visible here is just the delta on top of #154's trait.

## Trait surface

- `ParsedCert::issuer_contains(&[u8]) -> bool` removed.
- `ParsedCert::pck_ca(&self) -> Option<PckCa>` added (4-line doc).
- `pub enum PckCa { Processor, Platform }` in `src/config.rs`, with `as_id_str()` returning the lowercase `"processor"` / `"platform"` identifiers used in PCS URLs and FFI string output.

The implementation note (which RDN tags, why BMP/Universal are skipped) moves from the trait doc to the `default-x509` impl in `src/x509.rs`, where it belongs — it's an implementation detail, not a contract.

## Public API

- `intel::pck_ca` / `pck_ca_with` / `quote_ca` / `quote_ca_with` return `Result<PckCa>` instead of `Result<&'static str>`. Downstream Rust callers need a one-line `.as_id_str()` adjustment.
- The legacy "unrecognised issuer → Processor" fallback moves from the backend to the call site (`pck_ca_with`), as policy. Future callers can opt to error or log on `None` without trait churn — the policy is documented at the call site, not buried in a backend.

## Cross-language string contract

`src/ffi.rs` (Go) and `src/python.rs` render the enum via `as_id_str().to_string()`, preserving the existing `"processor"` / `"platform"` strings observed by external consumers. No behaviour change at the FFI boundary.

Internal `extract_fmspc_and_ca_with` and `PcsEndpoints` keep their `&str` plumbing — the URL builder accepts the rendered identifier, so propagating `PckCa` further would only churn 10+ test call sites without buying type safety the trait already provides.

## Removed constants

- `constants::PROCESSOR_ISSUER` / `PLATFORM_ISSUER` (the uppercase substring needles) deleted. Only `*_ISSUER_ID` remain, now backing `PckCa::as_id_str`. Note: `PROCESSOR_ISSUER` and `PLATFORM_ISSUER` were `pub`, so this is a small public-API breaking change in the `constants` module.

## Conformance test

`tests/config_conformance.rs` swaps the four-needle loop for:

```rust
assert_eq!(
    custom.pck_ca(),
    default.pck_ca(),
    "pck_ca classification mismatch on PCK leaf",
);
```

Strictly stronger on the existing corpus (both bundled SGX/TDX quotes have Processor-issued leaves). Future Platform fixtures would broaden coverage to both enum variants — sourcing an Intel-signed Platform PCK leaf to vendor as a test fixture is out of scope for this PR. Worth a follow-up.

## Breaking-change blast radius

`ParsedCert` was introduced in v0.4.0, so the audience for this break is exactly the audience the trait was designed for. The new shape is the win, not the cost: typed contract, one-line conformance check, no prose to internalise.

Migration for downstream `ParsedCert` impls:

```diff
 impl ParsedCert for MyParsedCert {
-    fn issuer_contains(&self, needle: &[u8]) -> bool { /* substring match */ }
+    fn pck_ca(&self) -> Option<PckCa> {
+        // classify however your backend prefers
+    }
 }
```

Migration for downstream callers of `intel::pck_ca` / `quote_ca`:

```diff
-let ca: &str = intel::pck_ca(cert)?;
+let ca: &str = intel::pck_ca(cert)?.as_id_str();
```

## Test plan

- [x] `cargo test --features std,ring,default-x509,rustcrypto,borsh` — all pass (28 unit tests + 4 conformance + 3 quote_parsing + 2 verify_quote + 3 doc-tests).
- [x] `cargo clippy --features std,ring,default-x509,rustcrypto,borsh -- -D warnings` — clean.
- [x] `cargo clippy --features report,ring -- -D warnings` — clean (covers the `extract_fmspc_and_ca_with` internal path).
- [x] `cargo fmt --check` — clean.
- [x] FFI / Python builds (`cargo check --features go`, `cargo check --features python`) — clean.
