### PR TITLE
fix(verify): validate TCB component count before zip comparison

### DIFF
--- a/cli/src/bin/generate_all_samples.rs
+++ b/cli/src/bin/generate_all_samples.rs
@@ -738,7 +738,7 @@ fn main() -> Result<()> {
         name: "tdx_missing_components".to_string(),
         description: "TDX quote with missing tdxtcbcomponents in TCB info".to_string(),
         should_succeed: false,
-        expected_error: Some("No TDX components in the TCB info".to_string()),
+        expected_error: Some("TDX component count mismatch".to_string()),
         quote_generator: Box::new(generate_tdx_quote_v4),
         collateral_modifier: Some(Box::new(|collateral| {
             // TDX TCB info without tdxtcbcomponents

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -570,8 +570,15 @@ fn match_platform_tcb(
         }
 
         let sgx_components: Vec<u8> = tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
-        if sgx_components.is_empty() {
-            bail!("No SGX components in the TCB info");
+        // Reject mismatched component count so `.zip()` below cannot
+        // silently truncate a comparison and accept a platform whose
+        // unchecked SVN bytes are below the required level.
+        if sgx_components.len() != cpu_svn.len() {
+            bail!(
+                "SGX component count mismatch: expected {}, got {}",
+                cpu_svn.len(),
+                sgx_components.len()
+            );
         }
 
         // Component-wise comparison: every cpu_svn[i] must be >= sgx_components[i]
@@ -587,8 +594,12 @@ fn match_platform_tcb(
                 .context("Failed to get TD10 report")?;
             let tdx_components: Vec<u8> =
                 tcb_level.tcb.tdx_components.iter().map(|c| c.svn).collect();
-            if tdx_components.is_empty() {
-                bail!("No TDX components in the TCB info");
+            if tdx_components.len() != td_report.tee_tcb_svn.len() {
+                bail!(
+                    "TDX component count mismatch: expected {}, got {}",
+                    td_report.tee_tcb_svn.len(),
+                    tdx_components.len()
+                );
             }
             // Component-wise comparison: every tee_tcb_svn[i] must be >= tdx_components[i]
             if td_report

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -175,6 +175,58 @@ mod tests {
     }
 
     #[test]
+    fn truncated_sgx_components_are_rejected() {
+        let raw_quote = include_bytes!("../sample/tdx_quote");
+        let raw_quote_collateral = include_bytes!("../sample/tdx_quote_collateral.json");
+        let quote_collateral: QuoteCollateralV3 =
+            serde_json::from_slice(raw_quote_collateral).unwrap();
+        let now = now_from_collateral(&quote_collateral);
+
+        let err = dangerous_verify_with_tcb_override(
+            raw_quote,
+            &quote_collateral,
+            now,
+            |mut tcb_info| {
+                for level in &mut tcb_info.tcb_levels {
+                    level.tcb.sgx_components.truncate(8);
+                }
+                tcb_info
+            },
+        )
+        .expect_err("verification must fail when sgx_components count mismatches cpu_svn");
+        assert!(
+            err.to_string().contains("SGX component count mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_tdx_components_are_rejected() {
+        let raw_quote = include_bytes!("../sample/tdx_quote");
+        let raw_quote_collateral = include_bytes!("../sample/tdx_quote_collateral.json");
+        let quote_collateral: QuoteCollateralV3 =
+            serde_json::from_slice(raw_quote_collateral).unwrap();
+        let now = now_from_collateral(&quote_collateral);
+
+        let err = dangerous_verify_with_tcb_override(
+            raw_quote,
+            &quote_collateral,
+            now,
+            |mut tcb_info| {
+                for level in &mut tcb_info.tcb_levels {
+                    level.tcb.tdx_components.truncate(8);
+                }
+                tcb_info
+            },
+        )
+        .expect_err("verification must fail when tdx_components count mismatches tee_tcb_svn");
+        assert!(
+            err.to_string().contains("TDX component count mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn outdated_fixture_with_override_matches_expected_status() {
         let raw_quote = include_bytes!("../sample/tdx_quote_outdated");
         let raw_quote_collateral = include_bytes!("../sample/tdx_quote_outdated_collateral.json");

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -231,7 +231,9 @@ mod tests {
 
     #[test]
     fn overlong_sgx_components_are_rejected() {
-        assert_sgx_count_mismatch_rejected(|c| c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4)));
+        assert_sgx_count_mismatch_rejected(|c| {
+            c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4))
+        });
     }
 
     #[test]
@@ -241,7 +243,9 @@ mod tests {
 
     #[test]
     fn overlong_tdx_components_are_rejected() {
-        assert_tdx_count_mismatch_rejected(|c| c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4)));
+        assert_tdx_count_mismatch_rejected(|c| {
+            c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4))
+        });
     }
 
     #[test]

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -174,8 +174,7 @@ mod tests {
         assert_eq!(parity_overridden.status, "OutOfDate");
     }
 
-    #[test]
-    fn truncated_sgx_components_are_rejected() {
+    fn assert_sgx_count_mismatch_rejected(mutate: impl Fn(&mut Vec<TcbComponents>) + Copy) {
         let raw_quote = include_bytes!("../sample/tdx_quote");
         let raw_quote_collateral = include_bytes!("../sample/tdx_quote_collateral.json");
         let quote_collateral: QuoteCollateralV3 =
@@ -188,7 +187,7 @@ mod tests {
             now,
             |mut tcb_info| {
                 for level in &mut tcb_info.tcb_levels {
-                    level.tcb.sgx_components.truncate(8);
+                    mutate(&mut level.tcb.sgx_components);
                 }
                 tcb_info
             },
@@ -200,8 +199,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn truncated_tdx_components_are_rejected() {
+    fn assert_tdx_count_mismatch_rejected(mutate: impl Fn(&mut Vec<TcbComponents>) + Copy) {
         let raw_quote = include_bytes!("../sample/tdx_quote");
         let raw_quote_collateral = include_bytes!("../sample/tdx_quote_collateral.json");
         let quote_collateral: QuoteCollateralV3 =
@@ -214,7 +212,7 @@ mod tests {
             now,
             |mut tcb_info| {
                 for level in &mut tcb_info.tcb_levels {
-                    level.tcb.tdx_components.truncate(8);
+                    mutate(&mut level.tcb.tdx_components);
                 }
                 tcb_info
             },
@@ -224,6 +222,26 @@ mod tests {
             err.to_string().contains("TDX component count mismatch"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn truncated_sgx_components_are_rejected() {
+        assert_sgx_count_mismatch_rejected(|c| c.truncate(8));
+    }
+
+    #[test]
+    fn overlong_sgx_components_are_rejected() {
+        assert_sgx_count_mismatch_rejected(|c| c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4)));
+    }
+
+    #[test]
+    fn truncated_tdx_components_are_rejected() {
+        assert_tdx_count_mismatch_rejected(|c| c.truncate(8));
+    }
+
+    #[test]
+    fn overlong_tdx_components_are_rejected() {
+        assert_tdx_count_mismatch_rejected(|c| c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #139 (GHSA-6q6c-vvf9-fj3w).

## Summary

`match_platform_tcb` compared platform SVNs against TCB Info components with `cpu_svn.iter().zip(&sgx_components)` (and the analogous `tee_tcb_svn` / `tdx_components` pair for TDX). `.zip()` stops at the shorter iterator, so if a component vector ever arrived shorter than 16 the trailing SVN bytes were never checked — a platform whose unchecked positions were below the required level could match a higher TCB tier.

The previous guard only rejected an *empty* component vector. This PR replaces it with an exact length check against `cpu_svn.len()` / `td_report.tee_tcb_svn.len()` (both fixed at 16) and bails with a descriptive error.

Defense-in-depth: TCB Info is Intel-signed, so in practice this only fires on malformed or unexpected collateral. The check just makes the invariant the comparison already depends on explicit instead of implicit.

## Test plan

- [x] `cargo test --all-features` — passes locally
- [x] New regression tests in `tests/verify_tcb_override.rs` use the existing `dangerous_verify_with_tcb_override` harness to truncate `sgx_components` / `tdx_components` and assert the verifier rejects them with the new error message
- [x] Existing TCB-override and quote-parsing tests still pass