### PR TITLE
feat: opt-in `QuoteVerifier::allow_debug()`

### DIFF
--- a/dcap-qvl-js/src/index.d.ts
+++ b/dcap-qvl-js/src/index.d.ts
@@ -276,6 +276,11 @@ export class QuoteVerifier {
   static newWithRootCa(rootCaDer: Buffer): QuoteVerifier;
 
   /**
+   * Allow debug-mode enclaves (SGX debug bit, TDX TUD.DEBUG). Default false.
+   */
+  allowDebug(allow: boolean): QuoteVerifier;
+
+  /**
    * Verify a quote
    * @param rawQuote - Raw quote bytes
    * @param collateral - Quote collateral

--- a/dcap-qvl-js/src/verify.js
+++ b/dcap-qvl-js/src/verify.js
@@ -32,6 +32,7 @@ class VerifiedReport {
 class QuoteVerifier {
     constructor(rootCaDer) {
         this.rootCaDer = rootCaDer || TRUSTED_ROOT_CA_DER;
+        this.allowDebugFlag = false;
     }
 
     static newProd() {
@@ -42,12 +43,18 @@ class QuoteVerifier {
         return new QuoteVerifier(rootCaDer);
     }
 
+    // Allow debug-mode enclaves (SGX debug bit, TDX TUD.DEBUG). Default false.
+    allowDebug(allow) {
+        this.allowDebugFlag = !!allow;
+        return this;
+    }
+
     verify(rawQuote, collateral, nowSecs) {
-        return verifyImpl(rawQuote, collateral, nowSecs, this.rootCaDer);
+        return verifyImpl(rawQuote, collateral, nowSecs, this.rootCaDer, this.allowDebugFlag);
     }
 }
 
-function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer) {
+function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer, allowDebug = false) {
     const now = new Date(nowSecs * 1000);
 
     // Parse quote
@@ -331,7 +338,7 @@ function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer) {
     }
 
     // Validate attributes
-    validateAttrs(quote.report);
+    validateAttrs(quote.report, allowDebug);
 
     return new VerifiedReport(finalStatus.status, finalStatus.advisoryIds, quote.report, ppid);
 }
@@ -391,8 +398,8 @@ function verifyQeIdentityPolicy(qeReport, qeIdentity) {
         throw new Error(`QE ISVPRODID mismatch: expected ${qeIdentity.isvprodid}, got ${qeReport.isvProdId}`);
     }
 
-    // Validate QE report attributes (debug mode check)
-    validateSgx(qeReport);
+    // QE must always be production-mode; allow_debug only governs the workload.
+    validateSgx(qeReport, false);
 
     // Verify MISCSELECT with mask
     const expectedMiscselect = Buffer.from(qeIdentity.miscselect, 'hex');
@@ -458,28 +465,32 @@ function compareSvnArrays(actual, required) {
 }
 
 // Validate report attributes
-function validateAttrs(report) {
+function validateAttrs(report, allowDebug = false) {
     if (report.type === 'sgx') {
-        validateSgx(report.data);
+        validateSgx(report.data, allowDebug);
     } else if (report.type === 'td10') {
-        validateTd10(report.data);
+        validateTd10(report.data, allowDebug);
     } else if (report.type === 'td15') {
-        validateTd15(report.data);
+        validateTd15(report.data, allowDebug);
     }
 }
 
-function validateSgx(report) {
+function validateSgx(report, allowDebug = false) {
     // Check if debug mode is enabled (bit 1 of attributes[0])
     const isDebug = (report.attributes[0] & 0x02) !== 0;
-    if (isDebug) {
+    if (isDebug && !allowDebug) {
         throw new Error('Debug mode is enabled');
     }
 }
 
-function validateTd10(report) {
+function validateTd10(report, allowDebug = false) {
     const tdAttrs = parseTdAttributes(report.tdAttributes);
 
-    if (tdAttrs.tud !== 0) {
+    // TUD bit 0 is DEBUG; bits 7:1 are reserved and must always be zero.
+    if ((tdAttrs.tud & ~0x01) !== 0) {
+        throw new Error('Reserved bits in TD attributes are set');
+    }
+    if ((tdAttrs.tud & 0x01) !== 0 && !allowDebug) {
         throw new Error('Debug mode is enabled');
     }
 
@@ -492,14 +503,14 @@ function validateTd10(report) {
     }
 }
 
-function validateTd15(report) {
+function validateTd15(report, allowDebug = false) {
     // Check mr_service_td is all zeros
     const allZero = report.mrServiceTd.every(b => b === 0);
     if (!allZero) {
         throw new Error('Invalid mr service td');
     }
 
-    validateTd10(report.base);
+    validateTd10(report.base, allowDebug);
 }
 
 function parseTdAttributes(input) {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -962,7 +962,11 @@ fn validate_attrs(report: &Report, allow_service_td: bool, allow_debug: bool) ->
     fn validate_td10(report: &TDReport10, allow_debug: bool) -> Result<()> {
         let td_attrs =
             TDAttributes::parse(report.td_attributes).context("Failed to parse TD attributes")?;
-        if td_attrs.tud != 0 && !allow_debug {
+        // TUD bit 0 is DEBUG; bits 7:1 are reserved and must always be zero.
+        if td_attrs.tud & !0x01 != 0 {
+            bail!("Reserved bits in TD attributes are set");
+        }
+        if td_attrs.tud & 0x01 != 0 && !allow_debug {
             bail!("Debug mode is enabled");
         }
         if td_attrs.sec.reserved_lower != 0
@@ -1478,5 +1482,83 @@ mod tests {
         // Should match level with isvsvn=6 (7 >= 6)
         assert_eq!(status.status, OutOfDate);
         assert_eq!(status.advisory_ids, vec!["INTEL-SA-00615"]);
+    }
+
+    fn make_sgx_report(attributes_byte0: u8) -> EnclaveReport {
+        let mut report = make_test_qe_report();
+        report.attributes[0] = attributes_byte0;
+        report
+    }
+
+    fn make_td10_report(td_attributes: [u8; 8]) -> TDReport10 {
+        TDReport10 {
+            tee_tcb_svn: [0u8; 16],
+            mr_seam: [0u8; 48],
+            mr_signer_seam: [0u8; 48],
+            seam_attributes: [0u8; 8],
+            td_attributes,
+            xfam: [0u8; 8],
+            mr_td: [0u8; 48],
+            mr_config_id: [0u8; 48],
+            mr_owner: [0u8; 48],
+            mr_owner_config: [0u8; 48],
+            rt_mr0: [0u8; 48],
+            rt_mr1: [0u8; 48],
+            rt_mr2: [0u8; 48],
+            rt_mr3: [0u8; 48],
+            report_data: [0u8; 64],
+        }
+    }
+
+    #[test]
+    fn test_sgx_debug_rejected_by_default() {
+        // SGX attributes byte 0 bit 1 (0x02) is the DEBUG flag.
+        let report = make_sgx_report(0x02);
+        let err = validate_sgx_attrs(&report, false).unwrap_err();
+        assert!(err.to_string().contains("Debug mode is enabled"));
+    }
+
+    #[test]
+    fn test_sgx_debug_allowed_when_opted_in() {
+        let report = make_sgx_report(0x02);
+        validate_sgx_attrs(&report, true).unwrap();
+    }
+
+    #[test]
+    fn test_sgx_non_debug_passes_regardless() {
+        let report = make_sgx_report(0x00);
+        validate_sgx_attrs(&report, false).unwrap();
+        validate_sgx_attrs(&report, true).unwrap();
+    }
+
+    #[test]
+    fn test_td10_debug_rejected_by_default() {
+        // TUD bit 0 = DEBUG, byte 3 bit 4 (0x10) = SEPT_VE_DISABLE (required).
+        let report = Report::TD10(make_td10_report([0x01, 0, 0, 0x10, 0, 0, 0, 0]));
+        let err = validate_attrs(&report, false, false).unwrap_err();
+        assert!(err.to_string().contains("Debug mode is enabled"));
+    }
+
+    #[test]
+    fn test_td10_debug_allowed_when_opted_in() {
+        let report = Report::TD10(make_td10_report([0x01, 0, 0, 0x10, 0, 0, 0, 0]));
+        validate_attrs(&report, false, true).unwrap();
+    }
+
+    #[test]
+    fn test_td10_reserved_tud_bits_always_rejected() {
+        // Bit 1 of TUD is reserved and must remain zero even with allow_debug.
+        let report = Report::TD10(make_td10_report([0x02, 0, 0, 0x10, 0, 0, 0, 0]));
+        let err_default = validate_attrs(&report, false, false).unwrap_err();
+        assert!(err_default.to_string().contains("Reserved bits"));
+        let err_allowed = validate_attrs(&report, false, true).unwrap_err();
+        assert!(err_allowed.to_string().contains("Reserved bits"));
+    }
+
+    #[test]
+    fn test_td10_clean_attrs_pass() {
+        let report = Report::TD10(make_td10_report([0x00, 0, 0, 0x10, 0, 0, 0, 0]));
+        validate_attrs(&report, false, false).unwrap();
+        validate_attrs(&report, false, true).unwrap();
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -91,6 +91,7 @@ pub struct VerifiedReport {
 pub struct QuoteVerifier {
     root_ca_der: Vec<u8>,
     allow_service_td: bool,
+    allow_debug: bool,
 }
 
 impl QuoteVerifier {
@@ -99,6 +100,7 @@ impl QuoteVerifier {
         Self {
             root_ca_der,
             allow_service_td: false,
+            allow_debug: false,
         }
     }
 
@@ -111,6 +113,12 @@ impl QuoteVerifier {
     /// Default is `false` — existing callers are unaffected.
     pub fn allow_service_td(mut self, allow: bool) -> Self {
         self.allow_service_td = allow;
+        self
+    }
+
+    /// Allow debug-mode enclaves (SGX debug bit, TDX `TUD.DEBUG`). Default `false`.
+    pub fn allow_debug(mut self, allow: bool) -> Self {
+        self.allow_debug = allow;
         self
     }
 
@@ -140,6 +148,7 @@ impl QuoteVerifier {
             now_secs,
             &self.root_ca_der,
             self.allow_service_td,
+            self.allow_debug,
             #[cfg(feature = "danger-allow-tcb-override")]
             None::<fn(_) -> _>,
         )
@@ -179,6 +188,7 @@ impl QuoteVerifier {
             now_secs,
             &self.root_ca_der,
             self.allow_service_td,
+            self.allow_debug,
             Some(override_tcb_info),
         )
     }
@@ -812,6 +822,7 @@ fn verify_impl<C: Config>(
     now_secs: u64,
     root_ca_der: &[u8],
     allow_service_td: bool,
+    allow_debug: bool,
     #[cfg(feature = "danger-allow-tcb-override")] override_tcb_info: Option<
         impl FnOnce(TcbInfo) -> TcbInfo,
     >,
@@ -927,7 +938,7 @@ fn verify_impl<C: Config>(
     }
 
     // Validate report attributes (debug mode check, etc.)
-    validate_attrs(&quote.report, allow_service_td)?;
+    validate_attrs(&quote.report, allow_service_td, allow_debug)?;
 
     Ok(VerifiedReport {
         status: final_status.status.to_string(),
@@ -939,19 +950,19 @@ fn verify_impl<C: Config>(
     })
 }
 
-fn validate_sgx_attrs(report: &EnclaveReport) -> Result<()> {
+fn validate_sgx_attrs(report: &EnclaveReport, allow_debug: bool) -> Result<()> {
     let is_debug = report.attributes[0] & 0x02 != 0;
-    if is_debug {
+    if is_debug && !allow_debug {
         bail!("Debug mode is enabled");
     }
     Ok(())
 }
 
-fn validate_attrs(report: &Report, allow_service_td: bool) -> Result<()> {
-    fn validate_td10(report: &TDReport10) -> Result<()> {
+fn validate_attrs(report: &Report, allow_service_td: bool, allow_debug: bool) -> Result<()> {
+    fn validate_td10(report: &TDReport10, allow_debug: bool) -> Result<()> {
         let td_attrs =
             TDAttributes::parse(report.td_attributes).context("Failed to parse TD attributes")?;
-        if td_attrs.tud != 0 {
+        if td_attrs.tud != 0 && !allow_debug {
             bail!("Debug mode is enabled");
         }
         if td_attrs.sec.reserved_lower != 0
@@ -965,16 +976,16 @@ fn validate_attrs(report: &Report, allow_service_td: bool) -> Result<()> {
         }
         Ok(())
     }
-    fn validate_td15(report: &TDReport15, allow_service_td: bool) -> Result<()> {
+    fn validate_td15(report: &TDReport15, allow_service_td: bool, allow_debug: bool) -> Result<()> {
         if !allow_service_td && report.mr_service_td != [0u8; 48] {
             bail!("Invalid MR service TD");
         }
-        validate_td10(&report.base)
+        validate_td10(&report.base, allow_debug)
     }
     match &report {
-        Report::TD15(report) => validate_td15(report, allow_service_td),
-        Report::TD10(report) => validate_td10(report),
-        Report::SgxEnclave(report) => validate_sgx_attrs(report),
+        Report::TD15(report) => validate_td15(report, allow_service_td, allow_debug),
+        Report::TD10(report) => validate_td10(report, allow_debug),
+        Report::SgxEnclave(report) => validate_sgx_attrs(report, allow_debug),
     }
 }
 
@@ -1142,7 +1153,8 @@ fn verify_qe_identity_policy(
         );
     }
 
-    validate_sgx_attrs(qe_report).context("QE report validation failed")?;
+    // QE must always be production-mode; `allow_debug` only governs the workload.
+    validate_sgx_attrs(qe_report, false).context("QE report validation failed")?;
 
     // Verify ISVPRODID
     if qe_report.isv_prod_id != qe_identity.isvprodid {


### PR DESCRIPTION
## Summary

Adds an opt-in `allow_debug` flag to both the Rust and pure-JS bindings, allowing callers to verify quotes from debug-mode enclaves (SGX debug bit, TDX `TUD.DEBUG`) when explicitly requested. Default behavior is unchanged: debug-mode quotes are rejected.

### Rust (`src/verify.rs`)
- Add `QuoteVerifier::allow_debug(bool)` builder, mirroring `allow_service_td`. Defaults to `false`.
- Thread the flag through `verify_impl` -> `validate_attrs`, gating the SGX debug bit and TDX `TUD.DEBUG` (bit 0).
- TUD bits 7:1 are reserved and always rejected, even with `allow_debug = true` (per Intel TDX Module spec A.3.4).
- QE report check passes `allow_debug = false` unconditionally; the Quoting Enclave is Intel signing infrastructure and must always run in production mode regardless of the workload setting.
- Unit tests cover SGX/TDX debug gating in both directions and the reserved-TUD-bit invariant.

### JavaScript (`dcap-qvl-js/src/verify.js`)
- Port `QuoteVerifier.allowDebug(allow)` to the pure-JS binding with matching semantics.
- Update `index.d.ts` typings.
- Existing integration test suite (`./test_suite.sh js`) passes 54/54 against the generated `tdx_debug_enabled`, `debug_sgx_v3`, `qe_debug_enabled`, and `tdx_reserved_bits_set` samples.

Resolves #160