### PR TITLE
feat(js): port `QuoteVerifier.allowServiceTd()` to pure-JS binding

### DIFF
--- a/dcap-qvl-js/src/index.d.ts
+++ b/dcap-qvl-js/src/index.d.ts
@@ -281,6 +281,11 @@ export class QuoteVerifier {
   allowDebug(allow: boolean): QuoteVerifier;
 
   /**
+   * Allow non-zero `mr_service_td` in TDX 1.5 quotes (opt-in). Default false.
+   */
+  allowServiceTd(allow: boolean): QuoteVerifier;
+
+  /**
    * Verify a quote
    * @param rawQuote - Raw quote bytes
    * @param collateral - Quote collateral

--- a/dcap-qvl-js/src/verify.js
+++ b/dcap-qvl-js/src/verify.js
@@ -33,6 +33,7 @@ class QuoteVerifier {
     constructor(rootCaDer) {
         this.rootCaDer = rootCaDer || TRUSTED_ROOT_CA_DER;
         this.allowDebugFlag = false;
+        this.allowServiceTdFlag = false;
     }
 
     static newProd() {
@@ -49,12 +50,25 @@ class QuoteVerifier {
         return this;
     }
 
+    // Allow non-zero mr_service_td in TDX 1.5 quotes (opt-in). Default false.
+    allowServiceTd(allow) {
+        this.allowServiceTdFlag = !!allow;
+        return this;
+    }
+
     verify(rawQuote, collateral, nowSecs) {
-        return verifyImpl(rawQuote, collateral, nowSecs, this.rootCaDer, this.allowDebugFlag);
+        return verifyImpl(
+            rawQuote,
+            collateral,
+            nowSecs,
+            this.rootCaDer,
+            this.allowDebugFlag,
+            this.allowServiceTdFlag,
+        );
     }
 }
 
-function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer, allowDebug = false) {
+function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer, allowDebug = false, allowServiceTd = false) {
     const now = new Date(nowSecs * 1000);
 
     // Parse quote
@@ -338,7 +352,7 @@ function verifyImpl(rawQuote, collateral, nowSecs, rootCaDer, allowDebug = false
     }
 
     // Validate attributes
-    validateAttrs(quote.report, allowDebug);
+    validateAttrs(quote.report, allowDebug, allowServiceTd);
 
     return new VerifiedReport(finalStatus.status, finalStatus.advisoryIds, quote.report, ppid);
 }
@@ -465,13 +479,13 @@ function compareSvnArrays(actual, required) {
 }
 
 // Validate report attributes
-function validateAttrs(report, allowDebug = false) {
+function validateAttrs(report, allowDebug = false, allowServiceTd = false) {
     if (report.type === 'sgx') {
         validateSgx(report.data, allowDebug);
     } else if (report.type === 'td10') {
         validateTd10(report.data, allowDebug);
     } else if (report.type === 'td15') {
-        validateTd15(report.data, allowDebug);
+        validateTd15(report.data, allowDebug, allowServiceTd);
     }
 }
 
@@ -503,11 +517,12 @@ function validateTd10(report, allowDebug = false) {
     }
 }
 
-function validateTd15(report, allowDebug = false) {
-    // Check mr_service_td is all zeros
-    const allZero = report.mrServiceTd.every(b => b === 0);
-    if (!allZero) {
-        throw new Error('Invalid mr service td');
+function validateTd15(report, allowDebug = false, allowServiceTd = false) {
+    if (!allowServiceTd) {
+        const allZero = report.mrServiceTd.every(b => b === 0);
+        if (!allZero) {
+            throw new Error('Invalid mr service td');
+        }
     }
 
     validateTd10(report.base, allowDebug);


### PR DESCRIPTION
## Summary

Mirror the Rust `QuoteVerifier::allow_service_td()` builder (added in #162) to the pure-JS port. The Rust side already lets callers opt in to verifying TDX 1.5 quotes with a non-zero `mr_service_td`; without this change, the JS binding rejects those quotes unconditionally and has no escape hatch.

### Changes
- `dcap-qvl-js/src/verify.js`: add `QuoteVerifier.allowServiceTd(allow)` builder, default `false`. Thread the flag through `verifyImpl` → `validateAttrs` → `validateTd15`. When opted in, the `mr_service_td` all-zero check is skipped (matching `!allow_service_td && report.mr_service_td != [0u8; 48]` in `src/verify.rs`).
- `dcap-qvl-js/src/index.d.ts`: add the typing.

### Behavior
- Default unchanged — existing callers still reject non-zero `mr_service_td`.
- Opt-in: `QuoteVerifier.newProd().allowServiceTd(true).verify(...)` skips the check, exactly like the Rust counterpart.

## Test plan
- [x] `./tests/test_suite.sh js` — 54/54 pass (default-reject behavior unchanged).
- [ ] If maintainers want a positive opt-in sample, can add a TDX 1.5 service-TD quote sample in a follow-up.

Follow-up to #165, which surfaced the API divergence.