### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 description = "This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Command line interface for Intel SGX DCAP Quote Verification Library"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5.27", features = ["derive"] }
-dcap-qvl = { version = "0.4.0", path = "../" }
+dcap-qvl = { version = "0.4.1", path = "../" }
 hex = "0.4.3"
 ring = "0.17"
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## Summary
Version bump to **0.4.1** for `dcap-qvl` and `dcap-qvl-cli` crates.

## Changes since v0.4.0
**Features**
- `feat(js)`: port `QuoteVerifier.allowServiceTd()` to pure-JS binding
- `feat`: opt-in `QuoteVerifier::allow_debug()` (#165)
- `feat`: expose `CollateralClient::fetch_for_fmspc_without_pck_chain()`
- `feat(collateral)`: abstract HTTP transport behind `HttpClient` trait (#156)
- `perf(verify)`: add optional `serde-json-core` JSON parser via `json-core` feature

**Fixes**
- `fix`: restore `mr_service_td` check with opt-in flag for TDX 1.5
- `fix`: allow non-zero `mr_service_td` in TDX 1.5 quotes
- `fix(verify)`: validate TCB component count before zip comparison
- `fix(verify)`: use `str::get` instead of slicing in `from_json_core_str`
- `fix(verify)`: reject trailing non-whitespace in `json-core` JSON parser

**Chore / CI / deps**
- `chore(deps)`: bump reqwest 0.12 → 0.13 + compatible upgrades (#157)
- CI: `json-core` feature matrix in `rust.yml`; drop `--find-interpreter` on Windows for python-wheels
- `build(deps)`: bump github-actions group

## Test plan
- [x] `cargo build --release` (root + cli)
- [x] `cargo test --all-features` (52 passed, 2 ignored)
- [ ] After merge: push `v0.4.1` tag to trigger `release.yml` (GitHub Release + crates.io + python wheels + CLI binaries)