### PR TITLE
ci(npm): tolerate pre-bumped package.json on tag publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -124,10 +124,14 @@ jobs:
         working-directory: dcap-qvl-js
         run: |
           VERSION="${{ steps.npm-meta.outputs.version }}"
-          echo "Updating package.json version to $VERSION"
-          npm version "$VERSION" --no-git-tag-version
-          echo "Updated version:"
-          node -e "console.log(require('./package.json').version)"
+          CURRENT=$(node -e "console.log(require('./package.json').version)")
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "package.json already at $VERSION — skipping npm version bump"
+          else
+            echo "Updating package.json version: $CURRENT -> $VERSION"
+            npm version "$VERSION" --no-git-tag-version
+          fi
+          echo "Final version: $(node -e "console.log(require('./package.json').version)")"
 
       - name: Publish to npm (Dry Run)
         if: steps.npm-meta.outputs.dry_run == 'true'
@@ -188,8 +192,12 @@ jobs:
             echo "Current branch: $CURRENT_BRANCH"
           fi
 
-          # Commit and push
+          # Commit and push (skip if package.json was already at $VERSION on the target branch)
           git add dcap-qvl-js/package.json dcap-qvl-js/package-lock.json
+          if git diff --cached --quiet; then
+            echo "No version changes to commit — package.json already at $VERSION"
+            exit 0
+          fi
           git commit -m "chore(npm): bump version to $VERSION" \
             -m "Published @phala/dcap-qvl@$VERSION to npm" \
             -m "Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -192,6 +192,15 @@ jobs:
             echo "Current branch: $CURRENT_BRANCH"
           fi
 
+          # Ensure the target branch's package.json reflects $VERSION, in case the
+          # tag commit had been pre-bumped (and the bump on the tag commit's tree
+          # didn't carry over because we skipped `npm version`).
+          TARGET_CURRENT=$(node -e "console.log(require('./dcap-qvl-js/package.json').version)")
+          if [ "$TARGET_CURRENT" != "$VERSION" ]; then
+            echo "Target branch package.json at $TARGET_CURRENT — bumping to $VERSION"
+            (cd dcap-qvl-js && npm version "$VERSION" --no-git-tag-version)
+          fi
+
           # Commit and push (skip if package.json was already at $VERSION on the target branch)
           git add dcap-qvl-js/package.json dcap-qvl-js/package-lock.json
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
Make the npm publish workflow idempotent when `package.json` has already been bumped to the target version before the `npm-v*` tag push.

## Background
The previous `npm-v0.4.1` tag (Jan 2026) failed because the tagged commit already had `package.json` at `0.4.1`, and the workflow ran `npm version 0.4.1 --no-git-tag-version`, which refuses no-op bumps. Publish was skipped and the tag became a dead marker (had to be deleted + re-tagged to actually ship `0.4.1`).

## Change
- "Update package version" step: skip `npm version` when the current version already equals the target.
- "Commit version changes" step: exit cleanly when there's nothing staged.

Lets either flow work:
- Bump-in-tag: edit `package.json` first, tag, push (no rebot commit needed)
- Tag-only: tag any commit, let the bot bump + commit back

## Test plan
- [ ] Future `npm-v*` tag with pre-bumped `package.json` should publish successfully without the workflow failing on `npm version`
- [ ] Future `npm-v*` tag with unchanged `package.json` (current default flow) still bumps and commits as before