### PR TITLE
ci(mobile/android): Maven Central release workflow + Sonatype onboarding

### DIFF
--- a/.github/workflows/android-aar.yml
+++ b/.github/workflows/android-aar.yml
@@ -1,0 +1,120 @@
+name: Build and Publish Android AAR
+
+on:
+  push:
+    tags:
+      - "android-v*"        # e.g. android-v0.5.0 → publishes 0.5.0
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.5.0). Leave empty to use Cargo.toml version.'
+        required: false
+        type: string
+      publish_target:
+        description: 'Where to publish'
+        required: true
+        type: choice
+        options:
+          - none           # build only, no publish (smoke test)
+          - sonatype       # Maven Central via central.sonatype.com
+        default: 'none'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-publish:
+    name: Build AAR + publish to Maven Central
+    runs-on: ubuntu-latest
+    environment: maven-central     # gates secrets behind environment approval
+    steps:
+      - uses: actions/checkout@v6
+
+      # Derive the version: explicit input > tag > Cargo.toml fallback
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          elif [[ "$GITHUB_REF" == refs/tags/android-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/android-v}"
+          else
+            VERSION="$(grep -E '^version\s*=' dcap-qvl-mobile/Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Setup Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26b
+
+      - name: Setup Rust + Android targets
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+
+      - name: Build AAR
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: ./dcap-qvl-mobile/scripts/build_android.sh
+
+      # Override the in-tree version with the release version so the published
+      # POM and artifact filename both reflect the tag we're publishing.
+      - name: Patch Gradle version
+        working-directory: dcap-qvl-mobile/android
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.ver.outputs.version }}'
+          sed -i -E "s/^(version = )\"[^\"]+\"/\1\"${VERSION}\"/" build.gradle.kts
+          grep '^version' build.gradle.kts
+
+      - name: Run JVM unit tests
+        working-directory: dcap-qvl-mobile/android
+        run: gradle --no-daemon test
+
+      # ----- Publish step (gated by input / tag) -----
+      # Secrets required (in the `maven-central` GitHub Environment):
+      #   OSSRH_USERNAME      — Sonatype Central user token name
+      #   OSSRH_TOKEN         — Sonatype Central user token value
+      #   SIGNING_KEY         — ASCII-armored GPG private key (whole armored block)
+      #   SIGNING_KEY_ID      — 8-char short GPG key id (for `signing.keyId`)
+      # Optional:
+      #   SIGNING_PASSWORD    — GPG key passphrase. Omit for an unprotected key
+      #                         (an unset secret resolves to "", which Gradle
+      #                         treats as no passphrase).
+      - name: Publish to Maven Central
+        if: |
+          startsWith(github.ref, 'refs/tags/android-v')
+          || github.event.inputs.publish_target == 'sonatype'
+        working-directory: dcap-qvl-mobile/android
+        env:
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+        run: gradle --no-daemon publishReleasePublicationToMavenCentralRepository
+
+      - name: Upload AAR as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dcap-qvl-android-${{ steps.ver.outputs.version }}
+          path: dcap-qvl-mobile/android/build/outputs/aar/*.aar
+          if-no-files-found: error

--- a/dcap-qvl-mobile/SONATYPE_ONBOARDING.md
+++ b/dcap-qvl-mobile/SONATYPE_ONBOARDING.md
@@ -1,0 +1,160 @@
+# Maven Central / Sonatype Onboarding Checklist
+
+This is a one-time setup the maintainers need to complete before the
+`.github/workflows/android-aar.yml` workflow can publish to Maven Central.
+Once done, every push of an `android-v<X.Y.Z>` tag will publish the AAR.
+
+## 1. Claim the `com.phala` namespace
+
+1. Sign in at **https://central.sonatype.com** (Google or GitHub auth is fine).
+2. Open **Namespaces → Add Namespace**.
+3. Enter `com.phala` and select **I'd like to verify by DNS**.
+4. Sonatype shows a verification code like `1a2b3c4d-...`.
+5. Add it to the **phala.com** DNS as a `TXT` record on the apex:
+
+   ```
+   phala.com.   IN   TXT   "sonatype-verify:1a2b3c4d-..."
+   ```
+
+6. Wait for the record to propagate (a few minutes), then click **Verify**.
+7. Approval is usually instant once DNS matches.
+
+After approval, you can publish anything under `com.phala.*`.
+
+## 2. Generate a PGP key for signing
+
+Maven Central requires every artifact to be PGP-signed. (Sigstore keyless
+signing is now *accepted* by the Central Portal but remains optional and
+additive — PGP is still mandatory, so we can't skip the key.)
+
+```bash
+gpg --batch --gen-key <<'EOF'        # RSA 4096, no expiry, no passphrase
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Key-Usage: sign,cert
+Name-Real: Phala Release Signing
+Name-Email: dev@phala.com
+Expire-Date: 0
+%commit
+EOF
+gpg --list-secret-keys --keyid-format=long
+# Note the long key id, e.g. ABCDEF0123456789
+
+# Publish the public half so Maven Central can verify the signature.
+gpg --keyserver keyserver.ubuntu.com --send-keys ABCDEF0123456789
+gpg --keyserver keys.openpgp.org    --send-keys ABCDEF0123456789
+
+# Export the private half for CI (ASCII-armored).
+gpg --armor --export-secret-keys ABCDEF0123456789 > signing-key.asc
+```
+
+We generate the key **without a passphrase**: the `maven-central` GitHub
+Environment is the trust boundary, and a passphrase stored next to the key
+in the same environment adds nothing. If instead you keep the key in a
+plaintext backup, set a passphrase (`gpg --change-passphrase <id>`, re-export,
+add the `SIGNING_PASSWORD` secret) — the build script treats it as optional.
+
+Keep `signing-key.asc` out of git — it goes into a GitHub secret below.
+Store it (and the revocation cert `gpg` wrote under
+`~/.gnupg/openpgp-revocs.d/`) in an encrypted backup.
+
+## 3. Mint a Central user token
+
+1. On https://central.sonatype.com, open **Account → Generate User Token**.
+2. Copy both the token **name** and **value** — you'll only see the value once.
+
+## 4. Wire up GitHub repository secrets
+
+Create a GitHub **Environment** called `maven-central` (Settings →
+Environments → New environment). Optionally protect it with required
+reviewers so each release needs explicit approval.
+
+Add these four secrets to the environment:
+
+| Secret name        | Value                                                                |
+| ------------------ | -------------------------------------------------------------------- |
+| `OSSRH_USERNAME`   | User token **name** from step 3                                      |
+| `OSSRH_TOKEN`      | User token **value** from step 3                                     |
+| `SIGNING_KEY_ID`   | The 8- or 16-char short id of the PGP key (last digits of the long id) |
+| `SIGNING_KEY`      | Contents of `signing-key.asc` (paste the whole ASCII-armored block)   |
+
+Optional fifth secret — only if you protected the key with a passphrase:
+
+| Secret name        | Value                                                                |
+| ------------------ | -------------------------------------------------------------------- |
+| `SIGNING_PASSWORD` | The passphrase. Omit entirely for an unprotected key.                |
+
+The workflow consumes these via `ORG_GRADLE_PROJECT_*` env vars, which
+Gradle automatically exposes as project properties.
+
+## 5. Smoke-test the workflow
+
+```
+gh workflow run android-aar.yml -f publish_target=none
+```
+
+This builds + tests but doesn't publish, confirming the toolchain wiring.
+
+## 6. Cut the first release
+
+```
+git tag android-v0.5.0
+git push origin android-v0.5.0
+```
+
+The workflow:
+
+1. cross-compiles the four Android ABIs via cargo-ndk;
+2. regenerates Kotlin sources via `uniffi-bindgen`;
+3. assembles the AAR;
+4. runs the JVM unit tests;
+5. signs + uploads to Sonatype Central.
+
+After the upload, the Central portal will show the deployment under
+**Deployments**. The first release of a new namespace needs to be
+manually promoted from staging to public (later releases auto-promote
+if you tick the "Auto-publish" checkbox).
+
+Consumers can then add:
+
+```kotlin
+dependencies {
+    implementation("com.phala:dcap-qvl-android:0.5.0")
+}
+```
+
+## Notes / Pitfalls
+
+- **Source of truth for version:** the workflow patches
+  `dcap-qvl-mobile/android/build.gradle.kts` with the tag's version before
+  publishing, so the tag is authoritative. The committed value just needs
+  to be a valid SemVer.
+- **Pre-releases:** Sonatype accepts SemVer pre-release markers
+  (`0.5.0-rc.1`, `0.5.0-beta.1`); tag them `android-v0.5.0-rc.1`.
+- **Forgotten DNS verify:** once verified, leave the TXT record in place —
+  Sonatype may re-check periodically.
+- **Key rotation:** to rotate the PGP key, generate a new one, publish it,
+  update the `SIGNING_*` secrets. Old releases stay valid because the
+  signature is verified against the published key, not the current one.
+
+## Reducing raw-key exposure (optional hardening)
+
+The CI needs the raw PGP private key because Maven Central mandates a PGP
+signature and there's no token-less "trusted publishing" for Maven Central
+yet (unlike npm/PyPI). Ways to shrink the blast radius, in increasing effort:
+
+1. **GitHub Environment + required reviewers** (already wired) — the key
+   secret is only readable from the gated `maven-central` environment, and a
+   release can require human approval before the job runs.
+2. **Dedicated signing subkey, master kept offline** — generate a signing
+   *subkey*, export only that to CI, and keep the certifying master key
+   offline. If the CI secret leaks you revoke the subkey, not the whole
+   identity. Best effort-to-payoff ratio.
+3. **Cloud KMS / HSM signing** — the private key never leaves a hardware
+   module; CI calls a "sign this digest" API authenticated via GitHub OIDC
+   (no stored cloud creds). Strongest, but GPG-over-KMS tooling is fiddly —
+   usually overkill for a single library.
+4. **Sigstore keyless signatures** — can be *added* alongside PGP (the Central
+   Portal validates `.sigstore.json` files) for OIDC-based provenance, but
+   cannot *replace* the mandatory PGP signature today.

--- a/dcap-qvl-mobile/android/build.gradle.kts
+++ b/dcap-qvl-mobile/android/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library") version "8.7.0"
     id("org.jetbrains.kotlin.android") version "2.0.20"
     `maven-publish`
+    signing
 }
 
 group = "com.phala"
@@ -88,7 +89,53 @@ publishing {
                         url.set("https://opensource.org/licenses/MIT")
                     }
                 }
+                developers {
+                    developer {
+                        id.set("phala-network")
+                        name.set("Phala Network")
+                        url.set("https://phala.com")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/Phala-Network/dcap-qvl")
+                    connection.set("scm:git:https://github.com/Phala-Network/dcap-qvl.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/Phala-Network/dcap-qvl.git")
+                }
             }
         }
+    }
+
+    // Sonatype Central staging endpoint. Credentials are supplied via
+    // `ORG_GRADLE_PROJECT_ossrhUsername` / `ORG_GRADLE_PROJECT_ossrhPassword`
+    // environment variables (see `.github/workflows/android-aar.yml`). The
+    // repo block is registered unconditionally; uploads simply fail with a
+    // clear auth error if creds aren't set.
+    repositories {
+        maven {
+            name = "MavenCentral"
+            url = uri("https://central.sonatype.com/api/v1/publisher/upload")
+            credentials {
+                username = (findProperty("ossrhUsername") as String?) ?: ""
+                password = (findProperty("ossrhPassword") as String?) ?: ""
+            }
+        }
+    }
+}
+
+// Sign every Maven publication when the signing key is present.
+// The Sonatype Central portal requires PGP signatures on all artifacts.
+//
+// The passphrase is optional: our release key is unprotected (it lives in the
+// `maven-central` GitHub Environment, which is the trust boundary — a
+// passphrase stored next to the key in the same environment adds nothing).
+// `useInMemoryPgpKeys` accepts an empty string for unprotected keys, so a
+// missing `signingPassword` property is treated as "no passphrase".
+signing {
+    val keyId = findProperty("signingKeyId") as String?
+    val signingKey = findProperty("signingKey") as String?
+    val signingPassword = (findProperty("signingPassword") as String?).orEmpty()
+    if (keyId != null && signingKey != null) {
+        useInMemoryPgpKeys(keyId, signingKey, signingPassword)
+        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
**Draft — stacks on top of #172. Do not merge until #172 lands; this PR will then re-target master automatically.**

## Summary

Adds the publish infrastructure for the Android binding. Two artifacts:

1. **`.github/workflows/android-aar.yml`** — release workflow modeled on
   `python-wheels.yml`. Fires on `android-v*` tags or manual dispatch.
   Builds + tests the AAR; publishes to Sonatype Central when the secrets
   are present (gated behind a `maven-central` GitHub Environment so
   reviewer approval can be required per release).

2. **`dcap-qvl-mobile/SONATYPE_ONBOARDING.md`** — one-time setup checklist:
   claim `com.phala` namespace via DNS verification of `phala.com`,
   generate a PGP signing key, mint a Sonatype user token, wire five
   GitHub secrets, smoke-test, then tag.

3. **`dcap-qvl-mobile/android/build.gradle.kts`** — Maven-Central-required
   bits: `signing` plugin with in-memory PGP key (conditional on secrets
   present), Central staging repository, developer + scm POM metadata.

## Why a separate PR

Keeps #172 focused on the binding surface (which is what reviewers care
about). Publish infra has its own surface area: Sonatype account, DNS
record, secret rotation policy, manual first-release promotion. Worth a
dedicated review pass.

## What's still TODO before the first release

These are external to this PR:

- [ ] Claim `com.phala` namespace on https://central.sonatype.com (DNS verify)
- [ ] Generate the PGP key + publish the public half
- [ ] Mint a Central user token
- [ ] Create the `maven-central` GitHub Environment + add the five secrets
- [ ] `gh workflow run android-aar.yml -f publish_target=none` to smoke-test
- [ ] `git tag android-v0.5.0 && git push origin android-v0.5.0`

The first release of a new namespace needs to be manually promoted from
staging to public in the Central portal — every subsequent release can
auto-promote.

## Test plan

- [ ] Workflow YAML lints (GitHub validates on push)
- [ ] `gradle build` still passes locally with the new signing block
      (signing is conditional on secrets, so it's a no-op without them)
- [ ] Smoke-test via `workflow_dispatch` once secrets land

🤖 Generated with [Claude Code](https://claude.com/claude-code)