### PR TITLE
fix(js): decode X.509 issuer/subject DN properly so getCertIssuer thus getCollateral works

### DIFF
--- a/dcap-qvl-js/package.json
+++ b/dcap-qvl-js/package.json
@@ -15,7 +15,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "echo \"Error: no test command specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/dcap-qvl-js/src/intel.js
+++ b/dcap-qvl-js/src/intel.js
@@ -3,7 +3,6 @@
 
 const utils = require('./utils');
 const oids = require('./oids');
-const asn1 = require('asn1.js');
 const { PROCESSOR_ISSUER, PLATFORM_ISSUER, PROCESSOR_ISSUER_ID, PLATFORM_ISSUER_ID } = require('./constants');
 
 class PckExtension {
@@ -76,8 +75,7 @@ function getCa(quote) {
             throw new Error('Invalid certificate');
         }
 
-        const cert = utils.Certificate.decode(certs[0], 'der');
-        const issuerStr = formatDistinguishedName(cert.tbsCertificate.issuer);
+        const issuerStr = utils.getCertIssuer(certs[0]);
 
         if (issuerStr.includes(PROCESSOR_ISSUER)) {
             return PROCESSOR_ISSUER_ID;
@@ -89,20 +87,6 @@ function getCa(quote) {
     } catch (e) {
         return PROCESSOR_ISSUER_ID; // default
     }
-}
-
-// Format X.509 Distinguished Name to string
-function formatDistinguishedName(name) {
-    // The 'name' is an ASN.1 encoded RDNSequence
-    // For simplicity, we'll decode it as a buffer and convert to string
-    // In production, you'd want to properly parse the RDNSequence structure
-
-    const DistinguishedName = asn1.define('DistinguishedName', function () {
-        this.any();
-    });
-
-    const encoded = DistinguishedName.encode(name, 'der');
-    return encoded.toString('hex'); // Simple hex representation for matching
 }
 
 // Get FMSPC from quote

--- a/dcap-qvl-js/src/utils.js
+++ b/dcap-qvl-js/src/utils.js
@@ -432,7 +432,7 @@ function extractCrlUrl(certDer) {
 // Extract issuer string from certificate
 function getCertIssuer(certDer) {
     const cert = Certificate.decode(certDer, 'der');
-    // Convert issuer RDNs to a comma seperated string
+    // Convert issuer RDNs to a comma separated string
     const parts = [];
     for (const rdn of cert.tbsCertificate.issuer) {
         for (const attr of rdn) {

--- a/dcap-qvl-js/src/utils.js
+++ b/dcap-qvl-js/src/utils.js
@@ -28,6 +28,32 @@ const Extension = asn1.define('Extension', function () {
     );
 });
 
+const DirectoryString = asn1.define('DirectoryString', function () {
+    this.choice({
+        utf8String: this.utf8str(),
+        printableString: this.printstr(),
+        ia5String: this.ia5str(),
+        teletexString: this.t61str(),
+        universalString: this.unistr(),
+        bmpString: this.bmpstr()
+    });
+});
+
+const AttributeTypeAndValue = asn1.define('AttributeTypeAndValue', function () {
+    this.seq().obj(
+        this.key('type').objid(),
+        this.key('value').use(DirectoryString)
+    );
+});
+
+const RelativeDistinguishedName = asn1.define('RelativeDistinguishedName', function () {
+    this.setof(AttributeTypeAndValue);
+});
+
+const Name = asn1.define('Name', function () {
+    this.seqof(RelativeDistinguishedName);
+});
+
 const TBSCertificate = asn1.define('TBSCertificate', function () {
     this.seq().obj(
         this.key('version').explicit(0).int().optional(),
@@ -36,9 +62,9 @@ const TBSCertificate = asn1.define('TBSCertificate', function () {
             this.key('algorithm').objid(),
             this.key('parameters').optional().any()
         ),
-        this.key('issuer').any(),
+        this.key('issuer').use(Name),
         this.key('validity').any(),
-        this.key('subject').any(),
+        this.key('subject').use(Name),
         this.key('subjectPublicKeyInfo').any(),
         this.key('issuerUniqueID').implicit(1).bitstr().optional(),
         this.key('subjectUniqueID').implicit(2).bitstr().optional(),
@@ -405,24 +431,17 @@ function extractCrlUrl(certDer) {
 
 // Extract issuer string from certificate
 function getCertIssuer(certDer) {
-    try {
-        const cert = Certificate.decode(certDer, 'der');
-        const issuer = cert.tbsCertificate.issuer;
-
-        // Convert issuer RDNs to a string
-        const parts = [];
-        for (const rdn of issuer.value) {
-            for (const attr of rdn) {
-                // attr.type is the OID, attr.value is the ASN1 value
-                const value = attr.value.toString();
-                parts.push(value);
+    const cert = Certificate.decode(certDer, 'der');
+    // Convert issuer RDNs to a comma seperated string
+    const parts = [];
+    for (const rdn of cert.tbsCertificate.issuer) {
+        for (const attr of rdn) {
+            if (attr.value && typeof attr.value.value === 'string') {
+                parts.push(attr.value.value);
             }
         }
-
-        return parts.join(', ');
-    } catch (e) {
-        return '';
     }
+    return parts.join(', ');
 }
 
 module.exports = {

--- a/dcap-qvl-js/tests/get-ca.test.js
+++ b/dcap-qvl-js/tests/get-ca.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { Quote } = require('../src');
+const utils = require('../src/utils');
+const intel = require('../src/intel');
+
+const SAMPLE = path.join(__dirname, '..', '..', 'sample');
+const SGX_QUOTE = fs.readFileSync(path.join(SAMPLE, 'sgx_quote'));
+const TDX_QUOTE = fs.readFileSync(path.join(SAMPLE, 'tdx_quote'));
+
+test('intel.getCa returns "processor" for a Processor-signed quote', () => {
+    assert.equal(intel.getCa(Quote.parse(SGX_QUOTE)), 'processor');
+});
+
+test('intel.getCa returns "platform" for a Platform-signed quote', () => {
+    assert.equal(intel.getCa(Quote.parse(TDX_QUOTE)), 'platform');
+});
+
+test('utils.getCertIssuer surfaces the actual CA common name', () => {
+    const procLeaf = utils.extractCerts(Quote.parse(SGX_QUOTE).rawCertChain())[0];
+    const platLeaf = utils.extractCerts(Quote.parse(TDX_QUOTE).rawCertChain())[0];
+    assert.match(utils.getCertIssuer(procLeaf), /Intel SGX PCK Processor CA/);
+    assert.match(utils.getCertIssuer(platLeaf), /Intel SGX PCK Platform CA/);
+});
+
+test('utils.getCertIssuer throws on invalid DER', () => {
+    assert.throws(() => utils.getCertIssuer(Buffer.from([0x00, 0x01])));
+});


### PR DESCRIPTION
## Bug

`utils.getCertIssuer` always returned `''` — its ASN.1 schema decoded `tbsCertificate.issuer` as opaque bytes, but the function iterated it as a parsed `RDNSequence`, threw, and the `try/catch` swallowed it. That made `extractFmspcAndCa` (and `intel.getCa`) silently default to `ca = "processor"` for every cert, so Platform-CA platforms received Processor-CA collateral, and downstream chain verification failed.

## Fix

- Add ASN.1 types (`Name`, `RDN`, `AttributeTypeAndValue`, `DirectoryString`) and change `TBSCertificate.issuer` / `.subject` from `.any()` to `.use(Name)`.
- Rewrite `getCertIssuer` to walk the structured DN; throw on decode failure instead of returning `''`.
- `intel.getCa` had the same root-cause bug via dead `formatDistinguishedName` + missing `utils.Certificate` export — replace with a direct `utils.getCertIssuer(certs[0])` call.

## Verification

- Decodes real Intel certs (Processor leaf, Platform/Processor intermediates, Root) to the expected DN strings.
- JS routing matches Rust on shared inputs: `TEST_PCK_CHAIN_PROCESSOR` → `ca = "processor"` (same as `test_extract_fmspc_and_ca_processor`); `sample/sgx_quote` → `"processor"`; `sample/tdx_quote` → `"platform"`.
- Cross-checked against `@peculiar/asn1-x509`: identical output on the same DER.

## Tests 
- Added simple unit tests to test the changes presented in this PR. Used node:test since no testing framework is currently configured. 