### PR TITLE
refactor(x509): revert default `pck_ca` / `extension` impls to readable form

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -86,6 +86,12 @@ pub const PLATFORM_MANIFEST: u16 = 7;
 pub const PROCESSOR_ISSUER_ID: &str = "processor";
 pub const PLATFORM_ISSUER_ID: &str = "platform";
 
+// Substrings matched against the issuer DN to classify a PCK leaf as
+// Processor- or Platform-issued. Crate-private; see
+// `X509CertParsed::pck_ca`.
+pub(crate) const PROCESSOR_ISSUER: &str = "Processor";
+pub(crate) const PLATFORM_ISSUER: &str = "Platform";
+
 // The root cert is downloaded from `https://certificates.trustedservices.intel.com/Intel_SGX_Provisioning_Certification_RootCA.cer`.
 // See https://api.portal.trustedservices.intel.com/content/documentation.html#pcs for more details
 pub static TRUSTED_ROOT_CA_DER: &[u8] = include_bytes!("TrustedRootCA.der");

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -3,11 +3,12 @@
 //! Selected by [`crate::configs::RingConfig`] / [`crate::configs::RustCryptoConfig`]
 //! / [`crate::configs::DefaultConfig`].
 
+use alloc::string::ToString;
 use alloc::vec::Vec;
-use anyhow::{bail, Context, Result};
-use der::{Tag, Tagged};
+use anyhow::{anyhow, bail, Context, Result};
 
 use crate::config::{ParsedCert, PckCa, X509Codec};
+use crate::constants;
 
 /// Audited default [`X509Codec`] implementation, built on `x509-cert` + `der`.
 ///
@@ -34,65 +35,36 @@ impl X509Codec for X509CertBackend {
 
 impl ParsedCert for X509CertParsed {
     fn pck_ca(&self) -> Option<PckCa> {
-        // Intel PCK issuer CNs are UTF8String; we also accept Printable / IA5 /
-        // Teletex for robustness. BMP/Universal and non-string ATVs are skipped
-        // — an ASCII substring match against wide-char encodings is meaningless,
-        // matching the historic `Display::contains` behaviour (`x509-cert`'s
-        // `Display` hex-encodes non-byte-string ATVs).
-        for rdn in self.cert.tbs_certificate.issuer.0.iter() {
-            for atv in rdn.0.iter() {
-                if !matches!(
-                    atv.value.tag(),
-                    Tag::PrintableString | Tag::Utf8String | Tag::Ia5String | Tag::TeletexString
-                ) {
-                    continue;
-                }
-                let v = atv.value.value();
-                if v.windows(b"Processor".len())
-                    .any(|w| w == b"Processor".as_slice())
-                {
-                    return Some(PckCa::Processor);
-                }
-                if v.windows(b"Platform".len())
-                    .any(|w| w == b"Platform".as_slice())
-                {
-                    return Some(PckCa::Platform);
-                }
-            }
+        let issuer_dn = self.cert.tbs_certificate.issuer.to_string();
+        if issuer_dn.contains(constants::PROCESSOR_ISSUER) {
+            return Some(PckCa::Processor);
+        }
+        if issuer_dn.contains(constants::PLATFORM_ISSUER) {
+            return Some(PckCa::Platform);
         }
         None
     }
 
     fn extension(&self, oid: &[u8]) -> Result<Option<Vec<u8>>> {
-        // Compare raw DER-encoded OID bodies byte-for-byte. Callers pass the
-        // body of a `const_oid`-constructed OID, so there is nothing left to
-        // validate at runtime. (The parse itself would not add footprint —
-        // `der::Decode<ObjectIdentifier>` is already reachable via cert
-        // parsing — but it is pure runtime cost for no benefit.)
-        let mut found: Option<&[u8]> = None;
-        for ext in self
+        let oid = const_oid::ObjectIdentifier::from_bytes(oid)
+            .map_err(|_| anyhow!("Invalid OID encoding"))?;
+        let mut iter = self
             .cert
             .tbs_certificate
             .extensions
             .as_deref()
             .unwrap_or(&[])
-        {
-            if ext.extn_id.as_bytes() == oid {
-                if found.is_some() {
-                    // NOTE: would be friendlier to include the offending OID here
-                    // (e.g. `"extension {} appears more than once", ext.extn_id`),
-                    // but using `<ObjectIdentifier as Display>` from this call
-                    // site adds ~60–100 B of format-args setup to the stripped
-                    // contract wasm (measured on wasm32 `opt-level=z` + `lto=fat`
-                    // + `wasm-opt -O -Oz`). The duplicate-extension path is only
-                    // reachable on a malformed cert, which Intel-signed chains
-                    // never produce, so the ergonomics aren't worth the binary
-                    // cost. Revisit if a maintainer pushes back.
-                    bail!("extension appears more than once");
-                }
-                found = Some(ext.extn_value.as_bytes());
-            }
+            .iter()
+            .filter(|e| e.extn_id == oid)
+            .map(|e| e.extn_value.clone());
+
+        let extension = match iter.next() {
+            Some(ext) => ext,
+            None => return Ok(None),
+        };
+        if iter.next().is_some() {
+            bail!("extension {} appears more than once", oid);
         }
-        Ok(found.map(<[u8]>::to_vec))
+        Ok(Some(extension.into_bytes()))
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #158. The audited default `X509CertParsed` picked up two byte-level optimisations in #158 (carried over from the closed #154):

- `pck_ca` walked the parsed `RdnSequence` ATV-by-ATV with a tag allowlist and `windows`-based substring match.
- `extension` rolled its own duplicate-detection loop over raw OID byte comparisons.

Revert both to the readable form. The `PckCa` trait surface from #158 is unchanged.

- `src/x509.rs::pck_ca`: `issuer.to_string().contains(...)` against `constants::PROCESSOR_ISSUER` / `PLATFORM_ISSUER`.
- `src/x509.rs::extension`: parse the needle as `const_oid::ObjectIdentifier` once, then `iter().filter(|e| e.extn_id == oid).map(|e| e.extn_value.clone())`. Duplicate-extension error keeps the OID in its `Display` form.
- `src/constants.rs`: reintroduces `PROCESSOR_ISSUER` / `PLATFORM_ISSUER` as `pub(crate)` (they were `pub` before #158, but `constants` is not a publicly re-exported module, so not a public API change).

## Behaviour parity

Identical results on Intel-signed certs. `x509-cert`'s `Display for AttributeTypeAndValue` hex-encodes non-byte-string ATVs (BMP/Universal/non-string), so an ASCII substring search matches the same RDNs either way — exactly what the byte-walk's tag allowlist was reproducing. `ObjectIdentifier::from_bytes` is already reachable via certificate decoding, so re-parsing the OID needle costs nothing on top.

Backends that want byte-level perf or want to avoid materialising a `String` / re-parsing the OID can implement `ParsedCert` however they like — the trait surface stays the same.

## Test plan

- [x] `cargo test --features std,ring,default-x509,rustcrypto,borsh` — passes.
- [x] `cargo clippy --features std,ring,default-x509,rustcrypto,borsh -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --features go` / `cargo check --features python` — clean.
- [x] `cargo check --target wasm32-unknown-unknown --features js` — clean.