### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Command line interface for Intel SGX DCAP Quote Verification Library"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5.27", features = ["derive"] }
-dcap-qvl = { version = "0.4.1", path = "../" }
+dcap-qvl = { version = "0.5.0", path = "../" }
 hex = "0.4.3"
 ring = "0.17"
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }

--- a/dcap-qvl-js/package-lock.json
+++ b/dcap-qvl-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/dcap-qvl",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.3.13",

--- a/dcap-qvl-js/package.json
+++ b/dcap-qvl-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Pure JavaScript implementation of DCAP Quote Verification Library",
   "type": "commonjs",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary

Version bump to **0.5.0** for `dcap-qvl`, `dcap-qvl-cli`, and `@phala/dcap-qvl`.

## Why a minor bump

#158 introduced breaking changes to the public Rust API. In 0.x.y semver, breaking → minor:

- `ParsedCert::issuer_dn(&self) -> Result<String>` removed; replaced by `ParsedCert::pck_ca(&self) -> Option<PckCa>`.
- `intel::pck_ca` / `pck_ca_with` / `quote_ca` / `quote_ca_with` return `Result<PckCa>` instead of `Result<&'static str>` — downstream callers need a one-line `.as_id_str()` adjustment.
- New `pub enum PckCa { Processor, Platform }` in `src/config.rs`.
- `pub constants::PROCESSOR_ISSUER` / `PLATFORM_ISSUER` removed from the public surface (the lowercase identifier constants `*_ISSUER_ID` remain).

JS package (`@phala/dcap-qvl`) keeps version parity even though its surface is unchanged this cycle.

## Changes since v0.4.1

**Refactor**
- `refactor(config)`: replace `issuer_contains(&[u8])` with `pck_ca() -> Option<PckCa>` (#158) — see breaking-change summary above.

**Fixes**
- `fix(js)`: decode X.509 issuer/subject DN properly so `getCertIssuer` (and `extractFmspcAndCa` / `intel.getCa`) work — Platform-CA platforms no longer get misclassified as Processor (#175).

## Bumps

- `dcap-qvl` 0.4.1 → 0.5.0
- `dcap-qvl-cli` 0.4.1 → 0.5.0 (and its `dcap-qvl = "0.5.0"` path dep)
- `@phala/dcap-qvl` 0.4.1 → 0.5.0

## Test plan

- [x] `cargo build` — workspace builds with new version.
- [ ] After merge: push `v0.5.0` tag to trigger `release.yml` (GitHub Release + crates.io + python wheels + CLI binaries).

> Note: #177 (small follow-up to #158: revert audited default `pck_ca` / `extension` impls to their readable form) should land before tagging so the release reflects the maintainer-preferred default implementation.