### PR TITLE
fix(mobile/android): publish via Central Portal bundle (Vanniktech plugin)

### DIFF
--- a/.github/workflows/android-aar.yml
+++ b/.github/workflows/android-aar.yml
@@ -90,27 +90,28 @@ jobs:
         run: gradle --no-daemon test
 
       # ----- Publish step (gated by input / tag) -----
+      # Uploads a signed bundle to the Sonatype Central Portal via the
+      # Vanniktech maven-publish plugin (`publishToMavenCentral`). The
+      # deployment lands in the portal as USER_MANAGED (automaticRelease=false),
+      # so it must be promoted to public manually in the Deployments tab.
+      #
       # Secrets required (in the `maven-central` GitHub Environment):
-      #   OSSRH_USERNAME      — Sonatype Central user token name
-      #   OSSRH_TOKEN         — Sonatype Central user token value
-      #   SIGNING_KEY         — ASCII-armored GPG private key (whole armored block)
-      #   SIGNING_KEY_ID      — 8-char short GPG key id (for `signing.keyId`)
-      # Optional:
-      #   SIGNING_PASSWORD    — GPG key passphrase. Omit for an unprotected key
-      #                         (an unset secret resolves to "", which Gradle
-      #                         treats as no passphrase).
+      #   OSSRH_USERNAME — Sonatype Central user token name
+      #   OSSRH_TOKEN    — Sonatype Central user token value
+      #   SIGNING_KEY    — ASCII-armored GPG private key (whole armored block)
+      #   SIGNING_KEY_ID — 8-char short GPG key id
+      # (No signing passphrase — the release key is unprotected.)
       - name: Publish to Maven Central
         if: |
           startsWith(github.ref, 'refs/tags/android-v')
           || github.event.inputs.publish_target == 'sonatype'
         working-directory: dcap-qvl-mobile/android
         env:
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
-        run: gradle --no-daemon publishReleasePublicationToMavenCentralRepository
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+        run: gradle --no-daemon publishToMavenCentral
 
       - name: Upload AAR as workflow artifact
         uses: actions/upload-artifact@v4

--- a/dcap-qvl-mobile/android/build.gradle.kts
+++ b/dcap-qvl-mobile/android/build.gradle.kts
@@ -7,7 +7,11 @@ plugins {
     // `maven-publish` PUT to the Portal returns 404 — new namespaces no longer
     // get a Nexus/OSSRH staging repo, so artifacts must be uploaded as a
     // zipped bundle, which this plugin handles.
-    id("com.vanniktech.maven.publish") version "0.36.0"
+    //
+    // Pinned to 0.35.0: it's the last release supporting our AGP 8.7.0
+    // (0.36.0 requires AGP >= 8.13.0). The `publishToMavenCentral(...)` DSL
+    // below is unchanged — `SonatypeHost` was already dropped before 0.35.0.
+    id("com.vanniktech.maven.publish") version "0.35.0"
 }
 
 group = "com.phala"

--- a/dcap-qvl-mobile/android/build.gradle.kts
+++ b/dcap-qvl-mobile/android/build.gradle.kts
@@ -1,8 +1,13 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
     id("com.android.library") version "8.7.0"
     id("org.jetbrains.kotlin.android") version "2.0.20"
-    `maven-publish`
-    signing
+    // Speaks the Sonatype Central Portal bundle-upload protocol. A plain
+    // `maven-publish` PUT to the Portal returns 404 — new namespaces no longer
+    // get a Nexus/OSSRH staging repo, so artifacts must be uploaded as a
+    // zipped bundle, which this plugin handles.
+    id("com.vanniktech.maven.publish") version "0.36.0"
 }
 
 group = "com.phala"
@@ -48,12 +53,6 @@ android {
             )
         }
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
@@ -68,74 +67,43 @@ dependencies {
     testImplementation("org.json:json:20240303")
 }
 
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = "com.phala"
-            artifactId = "dcap-qvl-android"
-            version = project.version.toString()
+mavenPublishing {
+    // Publish the single Android `release` variant with sources + javadoc jars.
+    configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
 
-            afterEvaluate {
-                from(components["release"])
-            }
+    // Upload to the Sonatype Central Portal. `automaticRelease = false` leaves
+    // the deployment in the portal for manual promotion — required for the
+    // first release of a new namespace; later releases can flip this to true.
+    publishToMavenCentral(automaticRelease = false)
 
-            pom {
-                name.set("dcap-qvl for Android")
-                description.set("Native DCAP quote verification for Android (Kotlin)")
-                url.set("https://github.com/Phala-Network/dcap-qvl")
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("phala-network")
-                        name.set("Phala Network")
-                        url.set("https://phala.com")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/Phala-Network/dcap-qvl")
-                    connection.set("scm:git:https://github.com/Phala-Network/dcap-qvl.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/Phala-Network/dcap-qvl.git")
-                }
+    // PGP-sign all artifacts. Credentials come from the
+    // `ORG_GRADLE_PROJECT_signingInMemoryKey*` env vars (see the workflow).
+    // The key is unprotected, so no key password is supplied.
+    signAllPublications()
+
+    coordinates("com.phala", "dcap-qvl-android", version.toString())
+
+    pom {
+        name.set("dcap-qvl for Android")
+        description.set("Native DCAP quote verification for Android (Kotlin)")
+        url.set("https://github.com/Phala-Network/dcap-qvl")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
-    }
-
-    // Sonatype Central staging endpoint. Credentials are supplied via
-    // `ORG_GRADLE_PROJECT_ossrhUsername` / `ORG_GRADLE_PROJECT_ossrhPassword`
-    // environment variables (see `.github/workflows/android-aar.yml`). The
-    // repo block is registered unconditionally; uploads simply fail with a
-    // clear auth error if creds aren't set.
-    repositories {
-        maven {
-            name = "MavenCentral"
-            url = uri("https://central.sonatype.com/api/v1/publisher/upload")
-            credentials {
-                username = (findProperty("ossrhUsername") as String?) ?: ""
-                password = (findProperty("ossrhPassword") as String?) ?: ""
+        developers {
+            developer {
+                id.set("phala-network")
+                name.set("Phala Network")
+                url.set("https://phala.com")
             }
         }
-    }
-}
-
-// Sign every Maven publication when the signing key is present.
-// The Sonatype Central portal requires PGP signatures on all artifacts.
-//
-// The passphrase is optional: our release key is unprotected (it lives in the
-// `maven-central` GitHub Environment, which is the trust boundary — a
-// passphrase stored next to the key in the same environment adds nothing).
-// `useInMemoryPgpKeys` accepts an empty string for unprotected keys, so a
-// missing `signingPassword` property is treated as "no passphrase".
-signing {
-    val keyId = findProperty("signingKeyId") as String?
-    val signingKey = findProperty("signingKey") as String?
-    val signingPassword = (findProperty("signingPassword") as String?).orEmpty()
-    if (keyId != null && signingKey != null) {
-        useInMemoryPgpKeys(keyId, signingKey, signingPassword)
-        sign(publishing.publications)
+        scm {
+            url.set("https://github.com/Phala-Network/dcap-qvl")
+            connection.set("scm:git:https://github.com/Phala-Network/dcap-qvl.git")
+            developerConnection.set("scm:git:ssh://git@github.com/Phala-Network/dcap-qvl.git")
+        }
     }
 }


### PR DESCRIPTION
## Problem

The first `android-v0.5.0` publish run failed at upload:

\`\`\`
> Task :signReleasePublication                              ✅
> Task :publishReleasePublicationToMavenCentralRepository FAILED
   > Could not PUT '.../api/v1/publisher/upload/com/phala/.../dcap-qvl-android-0.5.0.aar'
     Received status code 404 from server: Not Found
\`\`\`

Signing worked — the failure is the upload transport. The workflow used
`maven-publish` with a per-file `PUT`, but the Sonatype **Central Portal is
not a Maven repository**: it accepts a single zipped *bundle* via `POST`. New
namespaces like `com.phala` no longer get a Nexus/OSSRH staging repo, so the
per-file PUT resource doesn't exist → 404.

## Fix

Switch to the [Vanniktech maven-publish plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/central/)
(0.36.0), which speaks the Portal bundle protocol:

- `mavenPublishing { publishToMavenCentral(automaticRelease = false); signAllPublications(); ... }`
- `AndroidSingleVariantLibrary` with sources + javadoc jars
- workflow maps the existing secrets to the plugin's env vars
  (`mavenCentralUsername/Password`, `signingInMemoryKey/KeyId`) and runs
  `publishToMavenCentral`

`automaticRelease = false` → the deployment lands in the portal staging area
for manual promotion (required for a new namespace's first release).

No secret changes needed — same `maven-central` environment secrets, just
remapped to the plugin's property names.

## Validation

PR CI builds + tests the AAR (the publish workflow only runs on `android-v*`
tags). After merge, re-tagging `android-v0.5.0` triggers the real upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)