### PR TITLE
ci(mobile/android): auto-publish releases (automaticRelease = true)

### DIFF
--- a/.github/workflows/android-aar.yml
+++ b/.github/workflows/android-aar.yml
@@ -91,9 +91,9 @@ jobs:
 
       # ----- Publish step (gated by input / tag) -----
       # Uploads a signed bundle to the Sonatype Central Portal via the
-      # Vanniktech maven-publish plugin (`publishToMavenCentral`). The
-      # deployment lands in the portal as USER_MANAGED (automaticRelease=false),
-      # so it must be promoted to public manually in the Deployments tab.
+      # Vanniktech maven-publish plugin (`publishToMavenCentral`). With
+      # `automaticRelease = true` the deployment auto-publishes to Maven
+      # Central once validation passes — no manual promotion needed.
       #
       # Secrets required (in the `maven-central` GitHub Environment):
       #   OSSRH_USERNAME — Sonatype Central user token name

--- a/dcap-qvl-mobile/SONATYPE_ONBOARDING.md
+++ b/dcap-qvl-mobile/SONATYPE_ONBOARDING.md
@@ -111,16 +111,19 @@ The workflow:
 4. runs the JVM unit tests;
 5. signs + uploads to Sonatype Central.
 
-After the upload, the Central portal will show the deployment under
-**Deployments**. The first release of a new namespace needs to be
-manually promoted from staging to public (later releases auto-promote
-if you tick the "Auto-publish" checkbox).
+The build uses `publishToMavenCentral(automaticRelease = true)`, so the
+deployment auto-publishes to Maven Central once it passes validation — no
+manual step. (The first two releases, 0.5.0 and 0.5.1, were promoted by hand
+while the namespace was new; the flag was flipped to auto afterwards.) You can
+still watch progress under **Deployments** in the portal, and flip the flag
+back to `false` in `android/build.gradle.kts` if you ever want to stage a
+release for manual review.
 
 Consumers can then add:
 
 ```kotlin
 dependencies {
-    implementation("com.phala:dcap-qvl-android:0.5.0")
+    implementation("com.phala:dcap-qvl-android:0.5.1")
 }
 ```
 

--- a/dcap-qvl-mobile/android/build.gradle.kts
+++ b/dcap-qvl-mobile/android/build.gradle.kts
@@ -83,10 +83,12 @@ mavenPublishing {
     // Publish the single Android `release` variant with sources + javadoc jars.
     configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
 
-    // Upload to the Sonatype Central Portal. `automaticRelease = false` leaves
-    // the deployment in the portal for manual promotion — required for the
-    // first release of a new namespace; later releases can flip this to true.
-    publishToMavenCentral(automaticRelease = false)
+    // Upload to the Sonatype Central Portal and auto-publish once the
+    // deployment passes validation — a tag push goes live with no manual
+    // promotion. The `com.phala` namespace's first releases (0.5.0/0.5.1)
+    // were promoted by hand; now that it's established this is hands-off.
+    // (Flip back to `false` to stage for manual review if ever needed.)
+    publishToMavenCentral(automaticRelease = true)
 
     // PGP-sign all artifacts. Credentials come from the
     // `ORG_GRADLE_PROJECT_signingInMemoryKey*` env vars (see the workflow).


### PR DESCRIPTION
Now that `com.phala` is an established namespace (0.5.0 + 0.5.1 published and
manually promoted), flip `publishToMavenCentral(automaticRelease = true)` so
future `android-v*` tags publish to Maven Central with **no manual promotion**
— the deployment auto-publishes once it passes Sonatype validation.

- `android/build.gradle.kts`: `automaticRelease = false → true`
- workflow + `SONATYPE_ONBOARDING.md` comments updated to match

Flip back to `false` to stage a release for manual review if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)