### PR TITLE
feat(mobile/ios): Swift Package release pipeline via dcap-qvl-swift satellite

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,147 @@
+name: Release iOS Swift Package
+
+# Fires on the unified release tag (e.g. v0.6.0) — the same tag that releases
+# the Rust crate / npm / Android. Builds the XCFramework, attaches it to the
+# GitHub Release, and pushes the matching version to the dcap-qvl-swift
+# distribution repo with the checksum filled in.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.6.0). For a dry run without a real tag."
+        required: true
+        type: string
+      push_satellite:
+        description: "Push to the dcap-qvl-swift repo (off = build + checksum only)"
+        required: true
+        type: boolean
+        default: false
+
+env:
+  SATELLITE_REPO: Phala-Network/dcap-qvl-swift
+
+jobs:
+  release-swift:
+    name: Build XCFramework + publish Swift package
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve tag / version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${TAG#v}"            # strip leading v → SwiftPM semver
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tag=$TAG Version=$VERSION"
+
+      - name: Setup Rust + Apple targets
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Build XCFramework + generated Swift sources
+        run: ./dcap-qvl-mobile/scripts/build_ios.sh
+
+      - name: Package XCFramework + compute checksum
+        id: pkg
+        working-directory: dcap-qvl-mobile/ios
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `ditto` preserves the framework's symlinks/structure; SwiftPM
+          # expects the .xcframework at the zip root.
+          ditto -c -k --sequesterRsrc --keepParent DcapQvlFFI.xcframework DcapQvlFFI.xcframework.zip
+          CHECKSUM="$(swift package compute-checksum DcapQvlFFI.xcframework.zip)"
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+          echo "Checksum: $CHECKSUM"
+          ls -lh DcapQvlFFI.xcframework.zip
+
+      - name: Attach XCFramework to the GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        working-directory: dcap-qvl-mobile/ios
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Idempotent: create the release if another job hasn't already.
+          gh release view "$TAG" >/dev/null 2>&1 \
+            || gh release create "$TAG" --title "$TAG" --notes "Automated release. iOS XCFramework attached." --verify-tag
+          gh release upload "$TAG" DcapQvlFFI.xcframework.zip --clobber
+
+      # ----- Push the rendered package to the dcap-qvl-swift satellite -----
+      # Requires a SWIFT_REPO_TOKEN secret (a PAT / fine-grained token with
+      # contents:write on Phala-Network/dcap-qvl-swift). Without it, the build
+      # + checksum still run; only this push is skipped.
+      - name: Publish to dcap-qvl-swift
+        if: |
+          (github.event_name == 'push') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.push_satellite == 'true')
+        env:
+          SWIFT_REPO_TOKEN: ${{ secrets.SWIFT_REPO_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          CHECKSUM: ${{ steps.pkg.outputs.checksum }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${SWIFT_REPO_TOKEN:-}" ]]; then
+            echo "::warning::SWIFT_REPO_TOKEN not set — skipping satellite push. Build + checksum succeeded."
+            exit 0
+          fi
+          URL="https://github.com/Phala-Network/dcap-qvl/releases/download/${TAG}/DcapQvlFFI.xcframework.zip"
+
+          git clone "https://x-access-token:${SWIFT_REPO_TOKEN}@github.com/${SATELLITE_REPO}.git" sat
+          cd sat
+          git config user.name  "phala-release-bot"
+          git config user.email "dev@phala.com"
+
+          # Replace the generated Swift sources.
+          rm -rf Sources/DcapQvl
+          mkdir -p Sources/DcapQvl
+          cp "$GITHUB_WORKSPACE/dcap-qvl-mobile/ios/Sources/DcapQvl/DcapQvl.swift" Sources/DcapQvl/DcapQvl.swift
+
+          # Render the release manifest with the remote binary target.
+          cat > Package.swift <<EOF
+          // swift-tools-version:5.7
+          import PackageDescription
+
+          let package = Package(
+              name: "DcapQvl",
+              platforms: [
+                  .iOS(.v13),
+                  .macOS(.v11),
+              ],
+              products: [
+                  .library(name: "DcapQvl", targets: ["DcapQvl"]),
+              ],
+              targets: [
+                  .binaryTarget(
+                      name: "DcapQvlFFI",
+                      url: "${URL}",
+                      checksum: "${CHECKSUM}"
+                  ),
+                  .target(name: "DcapQvl", dependencies: ["DcapQvlFFI"], path: "Sources/DcapQvl"),
+              ]
+          )
+          EOF
+
+          git add -A
+          git commit -m "release: ${VERSION} (DcapQvlFFI.xcframework ${CHECKSUM})"
+          git tag "${VERSION}"
+          git push origin HEAD:master
+          git push origin "${VERSION}"
+          echo "Pushed ${SATELLITE_REPO}@${VERSION}"

--- a/dcap-qvl-mobile/RELEASING.md
+++ b/dcap-qvl-mobile/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing the mobile bindings
+
+## Android (Maven Central)
+
+Tag `android-v<X.Y.Z>` → `.github/workflows/android-aar.yml` builds, signs, and
+auto-publishes `com.phala:dcap-qvl-android:<X.Y.Z>` to Maven Central (the
+deployment auto-releases once it passes validation — no manual promotion).
+
+One-time setup is documented in [`SONATYPE_ONBOARDING.md`](SONATYPE_ONBOARDING.md)
+(namespace, signing key, and the `maven-central` environment secrets).
+
+## iOS / macOS (Swift Package)
+
+Tag `v<X.Y.Z>` (the unified release tag) → `.github/workflows/ios-release.yml`:
+
+1. builds `DcapQvlFFI.xcframework` (device + simulator + macOS slices) via
+   `scripts/build_ios.sh`;
+2. zips it and computes the SwiftPM checksum;
+3. attaches the zip to the `v<X.Y.Z>` GitHub Release on this repo;
+4. pushes a matching `<X.Y.Z>` tag to the
+   [`dcap-qvl-swift`](https://github.com/Phala-Network/dcap-qvl-swift)
+   distribution repo, with a `Package.swift` whose `.binaryTarget` points at the
+   release asset and pins its checksum.
+
+Consumers then resolve `https://github.com/Phala-Network/dcap-qvl-swift` at the
+matching version — the same `X.Y.Z` as crates.io / npm / Maven.
+
+### Required secret (one-time)
+
+The satellite push needs write access to a second repo, which the default
+`GITHUB_TOKEN` can't grant. Add a repository (or `release`-environment) secret:
+
+| Secret             | Value                                                                 |
+| ------------------ | --------------------------------------------------------------------- |
+| `SWIFT_REPO_TOKEN` | A fine-grained PAT with **Contents: read/write** on `Phala-Network/dcap-qvl-swift` |
+
+Without it the workflow still builds the XCFramework and computes the checksum
+(handy for a dry run), and just skips the satellite push with a warning.
+
+### Dry run (no tag, no publish)
+
+```
+gh workflow run ios-release.yml -f tag=v0.0.0-test -f push_satellite=false
+```
+
+Builds the XCFramework and prints the checksum without touching any release or
+the satellite repo.
+
+## Unified versioning
+
+`crates.io`, `npm`, Maven Central, and SwiftPM all share one `X.Y.Z`. The iOS
+pipeline keys on the bare `v<X.Y.Z>` tag; Android keeps its `android-v*` trigger
+for now. Consolidating every ecosystem onto a single `v*` tag is a follow-up —
+it only needs the existing per-ecosystem workflows' triggers pointed at `v*`.

--- a/dcap-qvl-mobile/ios/README.md
+++ b/dcap-qvl-mobile/ios/README.md
@@ -6,19 +6,21 @@ backed by `DcapQvlFFI.xcframework` (Rust static libs for `arm64` device +
 
 ## Install
 
-The Swift Package lives at `dcap-qvl-mobile/ios/` inside the dcap-qvl
-monorepo — SwiftPM doesn't resolve sub-directory packages from a URL, so until
-a dedicated `dcap-qvl-swift` repo or a tagged release ships, consume it via a
-local path:
+Released versions are published to the **[`dcap-qvl-swift`](https://github.com/Phala-Network/dcap-qvl-swift)**
+distribution repo (SwiftPM can't resolve a sub-directory package, so the
+`ios-release` workflow mirrors each `v*` release there with the XCFramework URL
++ checksum filled in). The version numbers match the unified `dcap-qvl` release.
 
 ```swift
 // Package.swift
-.package(path: "../dcap-qvl/dcap-qvl-mobile/ios")
+.package(url: "https://github.com/Phala-Network/dcap-qvl-swift", from: "0.6.0")
 ```
 
-or in Xcode: **File → Add Package Dependencies… → Add Local…** and pick the
-`dcap-qvl-mobile/ios` directory. A standalone published SwiftPM artifact is
-tracked as a follow-up.
+or in Xcode: **File → Add Package Dependencies…** and paste the URL.
+
+For local development against an unreleased checkout, point at this directory
+instead: `.package(path: "../dcap-qvl/dcap-qvl-mobile/ios")` (run
+`scripts/build_ios.sh` first to produce the local `DcapQvlFFI.xcframework`).
 
 ## Use
 


### PR DESCRIPTION
## Summary

Makes the iOS Swift bindings actually distributable. SwiftPM has no central
registry and can't resolve a sub-directory package, so iOS distribution goes
through a generated **satellite repo**, [`Phala-Network/dcap-qvl-swift`](https://github.com/Phala-Network/dcap-qvl-swift)
(already created + bootstrapped), whose root `Package.swift` carries a
`.binaryTarget(url:checksum:)` for the XCFramework.

Adds `.github/workflows/ios-release.yml`, triggered on the **unified `v*`
release tag**:

1. builds `DcapQvlFFI.xcframework` (device + sim + macOS) via `build_ios.sh`
2. zips it + computes the SwiftPM checksum
3. attaches the zip to the `v<X.Y.Z>` GitHub Release
4. pushes a matching `<X.Y.Z>` tag to the satellite with the binaryTarget
   url + checksum filled in

### Unified versioning

One `v<X.Y.Z>` tag → same `X.Y.Z` on crates.io / npm / Maven / SwiftPM. The
satellite is generated and never hand-edited. (Android keeps its `android-v*`
trigger for now; pointing every ecosystem at a single `v*` tag is a small
follow-up — see RELEASING.md.)

### Why the checksum sequencing works here

A remote binary `Package.swift` must pin the checksum of the XCFramework zip
for that release — but the zip is built by CI after the tag. The satellite
solves it: CI builds the zip first, then writes the checksum into the
satellite's `Package.swift` and tags **that** repo, decoupled from the main
tag.

## One-time setup required

A `SWIFT_REPO_TOKEN` secret (fine-grained PAT, **Contents: read/write** on
`dcap-qvl-swift`). Without it the build + checksum still run and the push is
skipped with a warning — so the workflow is safe to land before the secret
exists. See [`RELEASING.md`](../blob/feat/ios-release-pipeline/dcap-qvl-mobile/RELEASING.md).

## Validation

PR CI doesn't exercise this workflow (it only runs on `v*` tags). It can be
dry-run after merge without publishing:

```
gh workflow run ios-release.yml -f tag=v0.0.0-test -f push_satellite=false
```

which builds the XCFramework on a macOS runner and prints the checksum,
touching no release or repo. (I can't run `build_ios.sh` locally — no macOS —
so the macOS build path gets its first real exercise in that dry run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)