### PR TITLE
ci(mobile/ios): auth satellite push via deploy key, not PAT

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -91,20 +91,27 @@ jobs:
           (github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.push_satellite == 'true')
         env:
-          SWIFT_REPO_TOKEN: ${{ secrets.SWIFT_REPO_TOKEN }}
+          SWIFT_REPO_SSH_KEY: ${{ secrets.SWIFT_REPO_SSH_KEY }}
           TAG: ${{ steps.ver.outputs.tag }}
           VERSION: ${{ steps.ver.outputs.version }}
           CHECKSUM: ${{ steps.pkg.outputs.checksum }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${SWIFT_REPO_TOKEN:-}" ]]; then
-            echo "::warning::SWIFT_REPO_TOKEN not set — skipping satellite push. Build + checksum succeeded."
+          if [[ -z "${SWIFT_REPO_SSH_KEY:-}" ]]; then
+            echo "::warning::SWIFT_REPO_SSH_KEY not set — skipping satellite push. Build + checksum succeeded."
             exit 0
           fi
           URL="https://github.com/Phala-Network/dcap-qvl/releases/download/${TAG}/DcapQvlFFI.xcframework.zip"
 
-          git clone "https://x-access-token:${SWIFT_REPO_TOKEN}@github.com/${SATELLITE_REPO}.git" sat
+          # Auth via the write-enabled deploy key on dcap-qvl-swift (scoped to
+          # that one repo — no user-level PAT).
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SWIFT_REPO_SSH_KEY" > ~/.ssh/swift_deploy
+          chmod 600 ~/.ssh/swift_deploy
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/swift_deploy -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+          git clone "git@github.com:${SATELLITE_REPO}.git" sat
           cd sat
           git config user.name  "phala-release-bot"
           git config user.email "dev@phala.com"

--- a/dcap-qvl-mobile/RELEASING.md
+++ b/dcap-qvl-mobile/RELEASING.md
@@ -25,17 +25,19 @@ Tag `v<X.Y.Z>` (the unified release tag) → `.github/workflows/ios-release.yml`
 Consumers then resolve `https://github.com/Phala-Network/dcap-qvl-swift` at the
 matching version — the same `X.Y.Z` as crates.io / npm / Maven.
 
-### Required secret (one-time)
+### Cross-repo auth (already set up)
 
 The satellite push needs write access to a second repo, which the default
-`GITHUB_TOKEN` can't grant. Add a repository (or `release`-environment) secret:
+`GITHUB_TOKEN` can't grant. Instead of a user-level PAT, this uses a
+**write-enabled deploy key** scoped to just `dcap-qvl-swift`:
 
-| Secret             | Value                                                                 |
-| ------------------ | --------------------------------------------------------------------- |
-| `SWIFT_REPO_TOKEN` | A fine-grained PAT with **Contents: read/write** on `Phala-Network/dcap-qvl-swift` |
+- the public half is a read-write **deploy key** on `Phala-Network/dcap-qvl-swift`;
+- the private half is the `SWIFT_REPO_SSH_KEY` secret on this repo.
 
-Without it the workflow still builds the XCFramework and computes the checksum
-(handy for a dry run), and just skips the satellite push with a warning.
+Both were provisioned with the `gh` CLI (`gh repo deploy-key add --allow-write`
++ `gh secret set`). To rotate: `ssh-keygen` a new pair, replace the deploy key
+and the secret. Without the secret the workflow still builds + checksums and
+just skips the push with a warning.
 
 ### Dry run (no tag, no publish)
 


### PR DESCRIPTION
Switches the dcap-qvl-swift satellite push from a user-level PAT to a
**write-enabled deploy key** scoped to that one repo — provisioned entirely
with the `gh` CLI (no web-UI token creation):

- public half: read-write deploy key on `Phala-Network/dcap-qvl-swift`
- private half: `SWIFT_REPO_SSH_KEY` secret on this repo

The push step now clones/pushes over SSH via `GIT_SSH_COMMAND`. RELEASING.md
updated. After merge I'll validate the full push path with a throwaway
`workflow_dispatch` run and clean up the test tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)