### PR TITLE
release: unify all versions at 0.5.2

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -77,7 +77,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Idempotent: create the release if another job hasn't already.
+          # The `release.yml` workflow owns release creation (via
+          # actions/create-release, which errors if the release already
+          # exists). To avoid a race on the shared `v*` tag, wait for that
+          # release to appear, then only upload — never create it here.
+          for i in $(seq 1 30); do
+            if gh release view "$TAG" >/dev/null 2>&1; then break; fi
+            echo "Waiting for release $TAG to be created… ($i/30)"
+            sleep 10
+          done
+          # Fallback: if release.yml didn't run (e.g. a non-v tag), create it.
           gh release view "$TAG" >/dev/null 2>&1 \
             || gh release create "$TAG" --title "$TAG" --notes "Automated release. iOS XCFramework attached." --verify-tag
           gh release upload "$TAG" DcapQvlFFI.xcframework.zip --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.4.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl"
-version = "0.4.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 description = "This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-cli"
-version = "0.4.1"
+version = "0.5.2"
 edition = "2021"
 description = "Command line interface for Intel SGX DCAP Quote Verification Library"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5.27", features = ["derive"] }
-dcap-qvl = { version = "0.4.1", path = "../" }
+dcap-qvl = { version = "0.5.2", path = "../" }
 hex = "0.4.3"
 ring = "0.17"
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }

--- a/dcap-qvl-js/package-lock.json
+++ b/dcap-qvl-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.4.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/dcap-qvl",
-      "version": "0.4.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.3.13",

--- a/dcap-qvl-js/package.json
+++ b/dcap-qvl-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.4.1",
+  "version": "0.5.2",
   "description": "Pure JavaScript implementation of DCAP Quote Verification Library",
   "type": "commonjs",
   "main": "src/index.js",

--- a/dcap-qvl-mobile/Cargo.toml
+++ b/dcap-qvl-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-mobile"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 description = "UniFFI-powered Kotlin and Swift bindings for dcap-qvl"


### PR DESCRIPTION
## Summary

Prep for a single unified **`v0.5.2`** release tag. Bumps every manifest to
0.5.2 and fixes the GitHub-Release race so one tag cleanly releases the
ecosystems wired to `v*`.

### Version bumps → 0.5.2
- root `dcap-qvl` (was 0.4.1)
- `dcap-qvl-cli` (was 0.4.1) + its `dcap-qvl` dependency requirement
- `@phala/dcap-qvl` JS package (was 0.4.1)
- `dcap-qvl-mobile` (was 0.5.1)
- Cargo.lock + package-lock.json synced (`cargo metadata --locked` verified)

### Release-race fix
`release.yml` creates the GitHub Release via `actions/create-release` (which
**errors if it already exists**), and its crate-publish job depends on it.
`ios-release.yml` also tried to create the release → a race on the shared
`v*` tag that could fail the crate publish. Now ios **waits** for the release
and only **uploads** the XCFramework.

## ⚠️ What pushing `v0.5.2` will publish (irreversible)

| Trigger (`v*`) | Publishes |
| --- | --- |
| `release.yml` | `dcap-qvl` + `dcap-qvl-cli` → **crates.io**, GitHub Release, CLI binaries |
| `python-wheels.yml` | `dcap-qvl` wheels → **PyPI** |
| `ios-release.yml` | Swift package → `dcap-qvl-swift` + XCFramework asset |

**Not** on `v*`: Android (`android-v*`, currently 0.5.1) and npm (`npm-v*`).
Bringing those onto the unified tag is a follow-up (their version-extraction
logic is keyed to their own tag prefixes).

## Plan

Merge this, then push `v0.5.2` **only on explicit go-ahead** — crates.io and
PyPI publishes can't be undone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)