### PR TITLE
ci: fire Android + npm publishes on the unified v* tag too

### DIFF
--- a/.github/workflows/android-aar.yml
+++ b/.github/workflows/android-aar.yml
@@ -3,7 +3,8 @@ name: Build and Publish Android AAR
 on:
   push:
     tags:
-      - "android-v*"        # e.g. android-v0.5.0 → publishes 0.5.0
+      - "v*"               # unified release tag, e.g. v0.5.3 → publishes 0.5.3
+      - "android-v*"       # android-only release, e.g. android-v0.5.3
   workflow_dispatch:
     inputs:
       version:
@@ -40,6 +41,8 @@ jobs:
             VERSION="${{ github.event.inputs.version }}"
           elif [[ "$GITHUB_REF" == refs/tags/android-v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/android-v}"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
           else
             VERSION="$(grep -E '^version\s*=' dcap-qvl-mobile/Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
           fi
@@ -103,7 +106,7 @@ jobs:
       # (No signing passphrase — the release key is unprotected.)
       - name: Publish to Maven Central
         if: |
-          startsWith(github.ref, 'refs/tags/android-v')
+          startsWith(github.ref, 'refs/tags/')
           || github.event.inputs.publish_target == 'sonatype'
         working-directory: dcap-qvl-mobile/android
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,7 +3,8 @@ name: Publish npm Package
 on:
   push:
     tags:
-      - "npm-v*"  # Trigger on tags like npm-v0.0.1
+      - "v*"      # unified release tag, e.g. v0.5.3
+      - "npm-v*"  # npm-only release, e.g. npm-v0.0.1
   workflow_dispatch:
     inputs:
       version:
@@ -37,12 +38,21 @@ jobs:
         id: npm-meta
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            # Tag push: npm-v0.1.0 -> version=0.1.0, npm_tag=latest
             NPM_TAG="latest"
-            VERSION=${GITHUB_REF#refs/tags/npm-v}
-            UPDATE_VERSION="true"  # Update package.json to match tag
-            COMMIT_VERSION="true"  # Commit back to keep repository in sync
-            echo "Triggered by tag push: npm-v$VERSION"
+            if [[ "$GITHUB_REF" == refs/tags/npm-v* ]]; then
+              # npm-only tag: npm-v0.1.0 -> 0.1.0; patch package.json + commit back.
+              VERSION=${GITHUB_REF#refs/tags/npm-v}
+              UPDATE_VERSION="true"
+              COMMIT_VERSION="true"
+              echo "Triggered by npm-only tag push: npm-v$VERSION"
+            else
+              # Unified tag: v0.5.3 -> 0.5.3. package.json was already bumped in
+              # the release commit, so don't commit back from a tag build.
+              VERSION=${GITHUB_REF#refs/tags/v}
+              UPDATE_VERSION="true"
+              COMMIT_VERSION="false"
+              echo "Triggered by unified tag push: v$VERSION"
+            fi
           else
             # Manual dispatch
             NPM_TAG="${{ github.event.inputs.npm_tag || 'beta' }}"

--- a/dcap-qvl-mobile/RELEASING.md
+++ b/dcap-qvl-mobile/RELEASING.md
@@ -50,7 +50,19 @@ the satellite repo.
 
 ## Unified versioning
 
-`crates.io`, `npm`, Maven Central, and SwiftPM all share one `X.Y.Z`. The iOS
-pipeline keys on the bare `v<X.Y.Z>` tag; Android keeps its `android-v*` trigger
-for now. Consolidating every ecosystem onto a single `v*` tag is a follow-up —
-it only needs the existing per-ecosystem workflows' triggers pointed at `v*`.
+A single **`v<X.Y.Z>`** tag releases every ecosystem at the same version:
+
+| Workflow | Publishes |
+| --- | --- |
+| `release.yml` | `dcap-qvl` + `dcap-qvl-cli` → crates.io, CLI binaries, GitHub Release |
+| `python-wheels.yml` | `dcap-qvl` wheels → PyPI |
+| `android-aar.yml` | `com.phala:dcap-qvl-android` → Maven Central |
+| `publish-npm.yml` | `@phala/dcap-qvl` → npm |
+| `ios-release.yml` | Swift package → `dcap-qvl-swift` |
+
+Bump every manifest to the new version first (root `Cargo.toml`,
+`cli/Cargo.toml` + its `dcap-qvl` dep, `dcap-qvl-js/package.json`,
+`dcap-qvl-mobile/Cargo.toml`), commit, then push the `v<X.Y.Z>` tag.
+
+The per-ecosystem prefixes (`android-v*`, `npm-v*`) still work for releasing a
+single ecosystem out of band, but the normal path is one `v*` tag for all.


### PR DESCRIPTION
Completes the unified release tag: a single `v<X.Y.Z>` push now releases
**every** ecosystem at one version.

- `android-aar.yml`: add `v*` trigger (keeps `android-v*` for out-of-band
  releases), resolve version from a `v*` tag, publish gate fires on any tag.
- `publish-npm.yml`: add `v*` trigger, parse `v<X.Y.Z>` vs `npm-v*`; on a
  unified tag, patch package.json for the build but don't commit back (the
  release commit already bumped it).
- `RELEASING.md`: documents the one-tag-for-everything table.

After this, pushing `v0.5.3` publishes crates.io + PyPI + Maven Central + npm +
SwiftPM together.

## Ordering decision for v0.5.2

This determines what the **next** tag publishes:

- **Merge this before tagging v0.5.2** → `v0.5.2` releases *everything* incl.
  Android 0.5.1→0.5.2 and npm.
- **Tag v0.5.2 first, merge this after** → `v0.5.2` is crates.io + PyPI + iOS
  (as prepped in #184); `v0.5.3` becomes the first all-in-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)