### PR TITLE
fix(ci/npm): don't run npm version on unified v* tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,10 +46,11 @@ jobs:
               COMMIT_VERSION="true"
               echo "Triggered by npm-only tag push: npm-v$VERSION"
             else
-              # Unified tag: v0.5.3 -> 0.5.3. package.json was already bumped in
-              # the release commit, so don't commit back from a tag build.
+              # Unified tag: v0.5.3 -> 0.5.3. package.json was already bumped to
+              # this version in the release commit, so don't run `npm version`
+              # (it errors "Version not changed") and don't commit back.
               VERSION=${GITHUB_REF#refs/tags/v}
-              UPDATE_VERSION="true"
+              UPDATE_VERSION="false"
               COMMIT_VERSION="false"
               echo "Triggered by unified tag push: v$VERSION"
             fi


### PR DESCRIPTION
On a unified `v<X.Y.Z>` tag the release commit already bumped package.json, so `npm version` errored 'Version not changed' (failed the v0.5.2 npm publish). Set UPDATE_VERSION=false on the unified-tag path. npm 0.5.2 itself was published out-of-band via workflow_dispatch.