### PR TITLE
docs: revamp all READMEs from first principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,195 +1,156 @@
-
-<!-- cargo-rdme start -->
-
 # dcap-qvl
 
-This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust. It supports both SGX (Software Guard Extensions) and TDX (Trust Domain Extensions) quotes.
+[![CI](https://github.com/Phala-Network/dcap-qvl/actions/workflows/rust.yml/badge.svg)](https://github.com/Phala-Network/dcap-qvl/actions/workflows/rust.yml)
+[![crates.io](https://img.shields.io/crates/v/dcap-qvl.svg)](https://crates.io/crates/dcap-qvl)
+[![docs.rs](https://img.shields.io/docsrs/dcap-qvl)](https://docs.rs/dcap-qvl)
+[![PyPI](https://img.shields.io/pypi/v/dcap-qvl)](https://pypi.org/project/dcap-qvl/)
+[![npm](https://img.shields.io/npm/v/@phala/dcap-qvl)](https://www.npmjs.com/package/@phala/dcap-qvl)
+[![Maven Central](https://img.shields.io/maven-central/v/com.phala/dcap-qvl-android)](https://central.sonatype.com/artifact/com.phala/dcap-qvl-android)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-# Features
-- Verify SGX and TDX quotes
-- Get collateral from PCCS or Intel PCS
-- Extract information from quotes
-- Default PCCS: Phala Network (`https://pccs.phala.network`) - recommended for better availability and lower rate limits
+**Verify Intel SGX and TDX attestation quotes.** `dcap-qvl` is a small, pure-Rust
+library that verifies DCAP (Data Center Attestation Primitives) quotes, with
+native bindings for Python, Go, Kotlin, and Swift — plus a standalone
+pure-JavaScript implementation for the web.
 
-# Usage
-Add the following dependency to your `Cargo.toml` file to use this crate:
-```toml
-[dependencies]
-dcap-qvl = "0.1.0"
-```
+## What it does
 
-# Crypto Backend Selection
+- **Verifies SGX and TDX quotes** against Intel's trust chain.
+- **Gets collateral for you** from a PCCS or Intel PCS — or verifies fully
+  **offline** with collateral you already have.
+- **Extracts report fields** from a quote: measurements, report data, TCB
+  status, and advisory IDs.
+- **Runs everywhere.** The pure-Rust core works on servers, mobile,
+  WebAssembly, and on-chain (`no_std`).
 
-This crate supports two crypto backends: **ring** (optimized, uses assembly) and **rustcrypto** (pure Rust).
+By default it uses Phala Network's PCCS (`https://pccs.phala.network`) for
+better availability and lower rate limits.
 
-## Gas/Performance Comparison (NEAR Contract)
+## Languages
 
-| Backend | Gas Consumption |
-|---------|-----------------|
-| ring | ~175 Tgas |
-| rustcrypto | ~288 Tgas |
+| Language | Package | Install | Guide |
+|---|---|---|---|
+| **Rust** | [`dcap-qvl`](https://crates.io/crates/dcap-qvl) | `cargo add dcap-qvl` | [docs.rs](https://docs.rs/dcap-qvl) |
+| **Python** | [`dcap-qvl`](https://pypi.org/project/dcap-qvl/) | `pip install dcap-qvl` | [python-bindings/](python-bindings/) |
+| **JavaScript** (pure JS) | [`@phala/dcap-qvl`](https://www.npmjs.com/package/@phala/dcap-qvl) | `npm i @phala/dcap-qvl` | [dcap-qvl-js/](dcap-qvl-js/) |
+| **Go** | `github.com/Phala-Network/dcap-qvl/golang-bindings` | `go get github.com/Phala-Network/dcap-qvl/golang-bindings` | [golang-bindings/](golang-bindings/) |
+| **Android** (Kotlin/Java) | [`com.phala:dcap-qvl-android`](https://central.sonatype.com/artifact/com.phala/dcap-qvl-android) | Gradle | [dcap-qvl-mobile/android/](dcap-qvl-mobile/android/) |
+| **Swift** (iOS/macOS) | [`dcap-qvl-swift`](https://swiftpackageindex.com/Phala-Network/dcap-qvl-swift) | SwiftPM | [dcap-qvl-mobile/ios/](dcap-qvl-mobile/ios/) |
 
-Ring saves ~113 Tgas (~39%) compared to rustcrypto.
+The JavaScript package is a standalone pure-JS port that runs in Node and the
+browser with no native dependencies. WebAssembly builds of the Rust core are
+also published as [`@phala/dcap-qvl-web`](https://www.npmjs.com/package/@phala/dcap-qvl-web)
+and [`@phala/dcap-qvl-node`](https://www.npmjs.com/package/@phala/dcap-qvl-node).
 
-## Feature Flags
+There's also a command-line tool, [`dcap-qvl-cli`](cli/) (`cargo install dcap-qvl-cli`).
 
-```toml
-# Default: both backends enabled, ring takes priority
-dcap-qvl = "0.3.11"
+## How verification works
 
-# For WASM/NEAR (recommended for gas efficiency):
-dcap-qvl = { version = "0.3.11", default-features = false, features = ["std", "ring"] }
+To verify a quote you need three things:
 
-# For pure Rust / no-assembly environments:
-dcap-qvl = { version = "0.3.11", default-features = false, features = ["std", "rustcrypto"] }
-```
+1. the **quote** bytes,
+2. the **collateral** for it — the certificates, CRLs, and TCB info that prove
+   the quote against Intel's trust chain, served by a PCCS, and
+3. the **current time**, to check the collateral hasn't expired.
 
-## Backend Selection Rules for `verify()`
+`verify()` checks the signature chain and TCB status and returns the report plus
+a status string. If you don't already have collateral, the library can fetch it
+from a PCCS for you in one step.
 
-The top-level `verify()` function selects backend based on enabled features:
+## Quick start
 
-| `ring` enabled | `rustcrypto` enabled | `verify()` uses |
-|----------------|----------------------|-----------------|
-| ✓ | ✓ | ring |
-| ✓ | ✗ | ring |
-| ✗ | ✓ | rustcrypto |
-| ✗ | ✗ | compile error |
-
-⚠️ **Important**: Due to Cargo's additive feature model, if **any** crate in your dependency tree enables the `ring` feature, the top-level `verify()` will use ring. This can lead to unexpected behavior in complex projects.
-
-## Explicit Backend Selection (Recommended)
-
-For predictable behavior, especially in complex projects, use explicit backend modules:
-
-```rust
-// Explicitly use ring backend
-use dcap_qvl::verify::ring::verify;
-
-// Explicitly use rustcrypto backend
-use dcap_qvl::verify::rustcrypto::verify;
-```
-
-# Example
+### Rust
 
 ```rust
-use dcap_qvl::collateral::get_collateral;
-// Use explicit backend for predictable behavior
-use dcap_qvl::verify::ring::verify;
+use dcap_qvl::collateral::CollateralClient;
+use dcap_qvl::verify::verify;
 use dcap_qvl::PHALA_PCCS_URL;
 
-#[tokio::main]
-async fn main() {
-    let quote = std::fs::read("quote").expect("quote file not found");
-
-    // Use default Phala PCCS, or override with custom URL
-    let pccs_url = std::env::var("PCCS_URL").unwrap_or_else(|_| PHALA_PCCS_URL.to_string());
-    let collateral = get_collateral(&pccs_url, &quote).await.expect("failed to get collateral");
-
-    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    let report = verify(&quote, &collateral, now).expect("failed to verify quote");
-    println!("{:?}", report);
-}
+let quote = std::fs::read("quote.bin")?;
+let collateral = CollateralClient::with_default_http(PHALA_PCCS_URL)?
+    .fetch(&quote)
+    .await?;
+let now = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)?
+    .as_secs();
+let report = verify(&quote, &collateral, now)?;
+println!("status = {}", report.status);
 ```
 
-<!-- cargo-rdme end -->
+See the [docs.rs page](https://docs.rs/dcap-qvl) for crypto-backend selection,
+feature flags, `no_std`, and offline verification.
 
-# Python Bindings
-
-Python bindings are available for this crate, providing a Pythonic interface to the DCAP quote verification functionality.
-
-## Quick Start
-
-```bash
-# Build and test Python bindings
-make build_python
-make test_python
-
-# Test across Python versions (3.8-3.13)
-make test_python_versions
-```
-
-## Usage
+### Python
 
 ```python
-import asyncio
-import dcap_qvl
+import asyncio, dcap_qvl
 
 async def main():
-    quote_data = open("quote.bin", "rb").read()
-
-    # Get collateral and verify in one step (defaults to Phala PCCS)
-    result = await dcap_qvl.get_collateral_and_verify(quote_data)
-    print(f"Status: {result.status}")
+    quote = open("quote.bin", "rb").read()
+    result = await dcap_qvl.get_collateral_and_verify(quote)  # defaults to Phala PCCS
+    print(result.status)
 
 asyncio.run(main())
 ```
 
-See [python-bindings/](python-bindings/) for complete documentation, examples, and testing information.
+### JavaScript
 
-# Android (Kotlin / Java) Bindings
+```javascript
+import { getCollateralAndVerify } from '@phala/dcap-qvl';
 
-Native Android bindings, generated from the same Rust core via [UniFFI](https://mozilla.github.io/uniffi-rs/)
-and published to Maven Central as `com.phala:dcap-qvl-android`.
-
-## Quick Start
-
-```kotlin
-// app/build.gradle.kts
-dependencies {
-    implementation("com.phala:dcap-qvl-android:0.5.2")
-}
+const result = await getCollateralAndVerify(quoteBuffer); // defaults to Phala PCCS
+console.log(result.status);
 ```
 
-## Usage
+### Android (Kotlin)
 
 ```kotlin
 import com.phala.dcapqvl.*
 
-// `collateralJson` is the raw PCCS response body — fetch it with your own
-// HTTP stack (OkHttp / Ktor) and pass the bytes straight in.
-val collateralJson: ByteArray = httpClient.get(pccsUrl).body()
-val quote = parseQuote(rawQuote)
-val report = verify(rawQuote, collateralJson, (System.currentTimeMillis() / 1000).toULong())
-println("status=${report.status} advisories=${report.advisoryIds}")
+// collateralJson is the raw PCCS response body — fetch it with OkHttp / Ktor.
+val report = verify(rawQuote, collateralJson, nowSecs)
+println(report.status)
 ```
 
-Java callers use the same package via the generated types. Verification is
-synchronous; wrap in `withContext(Dispatchers.IO)` off the main thread.
-
-See [dcap-qvl-mobile/android/](dcap-qvl-mobile/android/) for complete documentation.
-
-# Swift (iOS / macOS) Bindings
-
-Native Swift bindings, generated via UniFFI and distributed as a Swift Package
-backed by an `XCFramework`.
-
-## Quick Start
-
-```swift
-// Package.swift
-.package(url: "https://github.com/Phala-Network/dcap-qvl-swift", from: "0.5.2")
-```
-
-or in Xcode: **File → Add Package Dependencies…** and paste the URL.
-
-## Usage
+### Swift
 
 ```swift
 import DcapQvl
 
-// `collateralJson` is the raw PCCS response body — fetch it via URLSession.
-let (collateralJson, _) = try await URLSession.shared.data(from: pccsURL)
-let quote = try parseQuote(rawQuote: rawQuote)
-let report = try verify(
-    rawQuote: rawQuote,
-    collateralJson: collateralJson,
-    nowSecs: UInt64(Date().timeIntervalSince1970)
-)
-print(report.status, report.advisoryIds)
+let report = try verify(rawQuote: rawQuote, collateralJson: collateralJson, nowSecs: nowSecs)
+print(report.status)
 ```
 
-See [dcap-qvl-mobile/ios/](dcap-qvl-mobile/ios/) for complete documentation.
+### Go
 
-# License
+```go
+import dcap "github.com/Phala-Network/dcap-qvl/golang-bindings"
 
-This crate is licensed under the MIT license. See the LICENSE file for details.
+report, _ := dcap.GetCollateralAndVerify(rawQuote, dcap.PhalaPCCSURL)
+fmt.Println(report.Status)
+```
+
+Each binding's directory (linked in the table above) has full documentation and
+runnable examples.
+
+## Building and testing
+
+Common tasks are in the [Makefile](Makefile):
+
+```bash
+cargo test              # test the Rust core
+make build_python       # build + test the Python bindings
+make test_wasm          # test the WASM packages
+make build_mobile_android  # build the Android AAR
+make build_mobile_ios      # build the iOS XCFramework (macOS only)
+```
+
+## Releasing
+
+A single `v<X.Y.Z>` tag publishes every ecosystem at one version — crates.io,
+PyPI, npm, Maven Central, and the Swift Package Index. See
+[dcap-qvl-mobile/RELEASING.md](dcap-qvl-mobile/RELEASING.md).
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,11 +1,60 @@
 # dcap-qvl-cli
 
-A CLI tool to decode TDX/SGX quote files.
+Command-line tool to **decode and verify** Intel SGX and TDX (DCAP) attestation quotes.
 
-## Usage
+> Part of [**dcap-qvl**](../) — a pure-Rust verifier for SGX/TDX quotes. See the
+> [main README](../README.md) for the library and the other language bindings.
 
+## Install
+
+```bash
+cargo install dcap-qvl-cli
 ```
+
+This installs a binary named **`dcap-qvl`**.
+
+## Commands
+
+The tool has three subcommands. Each takes a quote file, and `--hex` if that file
+is hex-encoded rather than raw bytes.
+
+### `verify` — fetch collateral and verify a quote
+
+```bash
+dcap-qvl verify quote.bin
+```
+
+Collateral is fetched from Phala's PCCS by default. Point it at another PCCS with
+the `PCCS_URL` environment variable:
+
+```bash
+PCCS_URL=https://your-pccs/sgx/certification/v4/ dcap-qvl verify quote.bin
+```
+
+The verified report is printed as JSON on stdout; progress goes to stderr.
+
+### `decode` — parse a quote into JSON
+
+```bash
+dcap-qvl decode quote.bin           # full parsed quote as JSON
+dcap-qvl decode --hex quote.hex     # hex-encoded input
+dcap-qvl decode --fmspc quote.bin   # print just the FMSPC
+```
+
+### `pckinfo` — extract Intel identifiers from the PCK certificate
+
+```bash
+dcap-qvl pckinfo quote.bin
+```
+
+## Run from source
+
+```bash
 git clone https://github.com/Phala-Network/dcap-qvl.git
-cd dcap-qvl/cli
-cargo run -- decode-quote --hex ../sample/tdx-quote.hex | jq .
+cd dcap-qvl
+cargo run -p dcap-qvl-cli --bin dcap-qvl -- decode --hex sample/tdx-quote.hex | jq .
 ```
+
+## License
+
+MIT — see [../LICENSE](../LICENSE).

--- a/dcap-qvl-js/README.md
+++ b/dcap-qvl-js/README.md
@@ -1,6 +1,11 @@
-# dcap-qvl-js
+# dcap-qvl for JavaScript
 
-Pure JavaScript implementation of Intel SGX DCAP Quote Verification Library.
+Pure-JavaScript implementation of Intel SGX and TDX (DCAP) quote verification.
+Runs in Node and the browser with no native dependencies.
+
+> Part of [**dcap-qvl**](../) — see the [main README](../README.md) for the Rust
+> core and the other language bindings. (For a WebAssembly build of the Rust core
+> instead of this pure-JS port, use `@phala/dcap-qvl-web` / `@phala/dcap-qvl-node`.)
 
 ## Description
 

--- a/dcap-qvl-mobile/README.md
+++ b/dcap-qvl-mobile/README.md
@@ -1,5 +1,9 @@
 # dcap-qvl Mobile Bindings
 
+> Part of [**dcap-qvl**](../) — see the [main README](../README.md) for all
+> language bindings. Per-platform usage is in
+> [android/](android/) and [ios/](ios/).
+
 Native Kotlin and Swift bindings for [`dcap-qvl`](../), built with
 [UniFFI](https://mozilla.github.io/uniffi-rs/). A single Rust crate
 (`dcap-qvl-mobile`) defines the FFI surface; `uniffi-bindgen` emits idiomatic

--- a/dcap-qvl-mobile/android/README.md
+++ b/dcap-qvl-mobile/android/README.md
@@ -1,5 +1,8 @@
 # dcap-qvl for Android
 
+> Part of [**dcap-qvl**](../../) — see the [main README](../../README.md) for the
+> library and the other language bindings.
+
 Native Android binding for [`dcap-qvl`](../../). Published as an AAR
 (`com.phala:dcap-qvl-android`) that bundles:
 

--- a/dcap-qvl-mobile/ios/README.md
+++ b/dcap-qvl-mobile/ios/README.md
@@ -1,5 +1,8 @@
 # dcap-qvl for iOS / macOS
 
+> Part of [**dcap-qvl**](../../) — see the [main README](../../README.md) for the
+> library and the other language bindings.
+
 Native Swift Package for [`dcap-qvl`](../../). Distributed as a SwiftPM module
 backed by `DcapQvlFFI.xcframework` (Rust static libs for `arm64` device +
 `arm64`/`x86_64` simulator).

--- a/golang-bindings/README.md
+++ b/golang-bindings/README.md
@@ -1,6 +1,10 @@
-# DCAP-QVL Go Bindings
+# dcap-qvl for Go
 
-Go bindings for `dcap-qvl` (DCAP Quote Verification Library) via CGO + Rust FFI.
+Verify Intel SGX and TDX (DCAP) attestation quotes from Go, via CGO over the
+Rust [`dcap-qvl`](../) core.
+
+> Part of [**dcap-qvl**](../) — see the [main README](../README.md) for the
+> library and the other language bindings.
 
 ## Install
 

--- a/python-bindings/README.md
+++ b/python-bindings/README.md
@@ -1,142 +1,79 @@
-# DCAP-QVL Python Bindings
+# dcap-qvl for Python
 
-This directory contains the Python bindings for the DCAP-QVL (Data Center Attestation Primitives Quote Verification Library) implemented in Rust.
+Verify Intel SGX and TDX (DCAP) attestation quotes from Python, with a clean
+async API. Built on the Rust [`dcap-qvl`](../) core via [PyO3](https://pyo3.rs/).
 
-## Directory Structure
+> Part of [**dcap-qvl**](../) — see the [main README](../README.md) for the
+> library and the other language bindings.
 
-```
-python-bindings/
-├── README.md                    # This file
-├── pyproject.toml              # Python project configuration
-├── uv.lock                     # uv lock file
-├── python/                     # Python package source
-│   └── dcap_qvl/
-│       ├── __init__.py         # Main package with async API
-├── examples/                   # Example scripts
-│   ├── basic_test.py          # Basic functionality test
-│   └── python_example.py      # Real-world usage example
-├── tests/                      # All test files
-│   ├── test_python_bindings.py      # Basic Python binding tests
-│   ├── test_collateral_api.py       # Async collateral API tests
-│   ├── test_all_async_functions.py  # Comprehensive async tests
-│   ├── test_with_samples.py         # Tests with real sample data
-│   ├── test_async_collateral.py     # Basic async collateral tests
-│   ├── test_python_versions.sh      # Multi-version testing script
-│   ├── test_cross_versions.sh       # Cross-version compatibility
-│   └── test_installation.py         # Installation verification
-├── scripts/                    # Build scripts
-│   ├── build_wheels.py        # Wheel building script
-│   └── build_wheels.sh         # Wheel building shell script
-└── docs/                       # Documentation
-    ├── README_Python.md        # Main Python bindings documentation
-    ├── PYTHON_TESTING.md        # Python version testing guide
-    └── BUILDING.md              # Build instructions
-```
-
-## Quick Start
-
-### Building and Testing
+## Install
 
 ```bash
-# From the project root directory
-make build_python                    # Build Python bindings
-make test_python                     # Test basic functionality
-make test_python_versions            # Test across Python versions
-
-# Or directly from this directory
-cd python-bindings
-uv run maturin develop --features python
-uv run python examples/basic_test.py
+pip install dcap-qvl
 ```
 
-### Installation
+Wheels are published for CPython 3.8–3.13 on Linux, macOS, and Windows.
 
-```bash
-# Using uv (recommended)
-cd python-bindings
-uv sync
-uv run maturin develop --features python
-
-# Using pip with maturin
-pip install maturin
-cd python-bindings
-maturin develop --features python
-```
-
-## Features
-
-- **Python 3.8+ Support**: Compatible with Python 3.8 through 3.13
-- **Async API**: Full async/await support for collateral fetching and verification
-- **Modern Tooling**: Uses uv for package management and maturin for building
-- **Comprehensive Testing**: Automated testing across all supported Python versions
-- **Clean API**: Pythonic async interface to the Rust library
-- **Type Safety**: Proper error handling and type annotations with async support
-
-## API Overview
+## Quick start
 
 ```python
 import asyncio
 import dcap_qvl
 
 async def main():
-    # Get collateral from Intel PCS (async)
-    quote_data = open("quote.bin", "rb").read()
-    collateral = await dcap_qvl.get_collateral_from_pcs(quote_data)
+    quote = open("quote.bin", "rb").read()
 
-    # Or fetch from a custom PCCS URL
-    collateral = await dcap_qvl.get_collateral(
-        "https://pccs.phala.network", quote_data
-    )
+    # Fetch collateral and verify in one step (defaults to Phala's PCCS).
+    result = await dcap_qvl.get_collateral_and_verify(quote)
+    print("status:", result.status)
+    print("advisories:", result.advisory_ids)
 
-    # Verify quote with collateral
-    result = dcap_qvl.verify(quote_data, collateral, timestamp)
-    print(f"Status: {result.status}")
-
-    # Or get collateral and verify in one step (async)
-    result = await dcap_qvl.get_collateral_and_verify(quote_data)
-    print(f"Advisory IDs: {result.advisory_ids}")
-
-# Run async code
 asyncio.run(main())
 ```
 
-## Documentation
+## API
 
-- **[README_Python.md](docs/README_Python.md)**: Complete API documentation and usage guide
-- **[PYTHON_TESTING.md](docs/PYTHON_TESTING.md)**: Python version compatibility testing guide
+```python
+# One-step: fetch collateral from a PCCS and verify.
+result = await dcap_qvl.get_collateral_and_verify(quote, pccs_url=None)
 
-## Development
+# Or do it in two steps.
+collateral = await dcap_qvl.get_collateral("https://pccs.phala.network", quote)
+collateral = await dcap_qvl.get_collateral_from_pcs(quote)   # Intel PCS
+result = dcap_qvl.verify(quote, collateral, timestamp)        # synchronous
 
-The Python bindings are built using:
+# Parse a quote without verifying.
+quote_obj = dcap_qvl.parse_quote(raw_quote)
+```
 
-- **[PyO3](https://pyo3.rs/)**: Rust bindings for Python
-- **[maturin](https://github.com/PyO3/maturin)**: Build tool for Rust-based Python extensions
-- **[uv](https://github.com/astral-sh/uv)**: Modern Python package management
+`result` is a `VerifiedReport` with `status`, `advisory_ids`, `report`, and
+`ppid`. Collateral fetching is async; `verify()` itself is synchronous.
 
-### Adding New Features
+See [docs/README_Python.md](docs/README_Python.md) for the complete API
+reference.
 
-1. Add Rust implementation in `../src/python.rs`
-2. Update Python package in `python/dcap_qvl/__init__.py`
-3. Add tests in `tests/` directory (use appropriate test file)
-4. Update documentation in `docs/`
+## Develop
 
-### Testing
+Build the extension locally and run the tests:
 
-The project includes comprehensive testing:
+```bash
+# From the repo root
+make build_python      # build the extension in-place
+make test_python       # run the test suite (incl. multiple Python versions)
 
-- **Unit tests**: Basic functionality testing with pytest
-- **Async tests**: Full async/await testing with pytest-asyncio
-- **Integration tests**: Real-world usage scenarios with sample data
-- **Version compatibility**: Testing across Python 3.8-3.13
-- **Cross-version testing**: Automated testing across multiple Python versions
-- **CI/CD**: Automated testing in GitHub Actions
+# Or directly, with uv
+cd python-bindings
+uv sync
+uv run maturin develop --features python
+uv run python examples/basic_test.py
+```
 
-## Requirements
-
-- Python 3.8+
-- Rust toolchain (for building)
-- uv (recommended) or pip with maturin
+Layout: Rust glue in [`../src/python.rs`](../src/python.rs), the Python package
+in [`python/dcap_qvl/`](python/dcap_qvl/), tests in [`tests/`](tests/), and
+build scripts in [`scripts/`](scripts/). Build details are in
+[docs/BUILDING.md](docs/BUILDING.md); version-compatibility testing is in
+[docs/PYTHON_TESTING.md](docs/PYTHON_TESTING.md).
 
 ## License
 
-MIT License - see [../LICENSE](../LICENSE) for details.
+MIT — see [../LICENSE](../LICENSE).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,21 @@
 //! # dcap-qvl
 //!
-//! This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust. It supports both SGX (Software Guard Extensions) and TDX (Trust Domain Extensions) quotes.
+//! Verify Intel SGX and TDX (DCAP — Data Center Attestation Primitives)
+//! attestation quotes, in pure Rust. Supports both SGX (Software Guard
+//! Extensions) and TDX (Trust Domain Extensions).
 //!
-//! # Features
-//! - Verify SGX and TDX quotes
-//! - Get collateral from PCCS
-//! - Extract information from quotes
+//! # What it does
+//! - Verify SGX and TDX quotes against Intel's trust chain
+//! - Fetch collateral from a PCCS or Intel PCS, or verify fully offline
+//! - Extract report fields (measurements, report data, TCB status) from a quote
 //!
-//! # Usage
-//! Add the following dependency to your `Cargo.toml` file to use this crate:
-//! ```toml
-//! [dependencies]
-//! dcap-qvl = "0.1.0"
-//! ```
+//! By default the collateral client uses Phala Network's PCCS
+//! (`https://pccs.phala.network`).
+//!
+//! Native bindings for Python, JavaScript, Go, Kotlin, and Swift are published
+//! from the same core — see the [project README][readme].
+//!
+//! [readme]: https://github.com/Phala-Network/dcap-qvl
 //!
 //! # Example
 //!
@@ -35,9 +38,40 @@
 //!
 //!     let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 //!     let report = verify(&quote, &collateral, now).expect("failed to verify quote");
-//!     println!("{:?}", report);
+//!     println!("{report:?}");
 //! }
 //! ```
+//!
+//! # Crypto backends
+//!
+//! Two backends are available: **ring** (optimized, uses assembly) and
+//! **rustcrypto** (pure Rust). Both are enabled by default and `ring` takes
+//! priority. For predictable behavior, call an explicit backend module:
+//!
+//! ```ignore
+//! use dcap_qvl::verify::ring::verify;        // always ring
+//! use dcap_qvl::verify::rustcrypto::verify;  // always rustcrypto
+//! ```
+//!
+//! The top-level [`verify::verify`] selects the backend from enabled features:
+//! `ring` wins when both are on, `rustcrypto` is used when only it is enabled,
+//! and enabling neither is a compile error. Because Cargo features are additive,
+//! any crate in your dependency tree that enables `ring` makes the top-level
+//! `verify()` use ring — reach for the explicit modules to avoid surprises.
+//!
+//! # Feature flags
+//!
+//! ```toml
+//! # Default: both backends, std, the PCCS collateral client, and x509 parsing.
+//! dcap-qvl = "0.5"
+//!
+//! # Minimal verifier for WASM / on-chain (smaller, ring only, no_std-friendly):
+//! dcap-qvl = { version = "0.5", default-features = false, features = ["std", "ring"] }
+//! ```
+//!
+//! `no_std` builds are supported by disabling default features. The `report`
+//! feature pulls in the async PCCS collateral client (`reqwest` + `tokio`); drop
+//! it for offline verification on size-constrained targets.
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 


### PR DESCRIPTION
Revamps **every README** in the repo for consistency and quality, treating each
as "what does a reader need in the first screen?"

## Main README (project landing)
Was auto-generated from `lib.rs` via `cargo-rdme` and led with Rust internals
(backends, NEAR gas table, feature matrices) before saying what the library is;
Go and JS weren't mentioned; versions were stale.

- Now a hand-authored landing: value prop, "what it does", a one-stop
  **Languages** table (Rust · Python · JavaScript · Go · Android · Swift + CLI),
  per-language quick starts, "how verification works", and badges.
- Decoupled: `lib.rs` (→ docs.rs / crates.io) now owns the Rust depth (example,
  crypto backends, feature flags); fixed the stale version.
- JavaScript shown correctly as a standalone **pure-JS port**, with the
  Rust-core **WASM** builds noted separately.

## Binding READMEs
- **cli** — was a 3-line stub. Now: install (`cargo install dcap-qvl-cli` →
  `dcap-qvl` binary), all three subcommands (`verify` / `decode` / `pckinfo`)
  with flags verified from `--help`, and the `PCCS_URL` override. (Old README
  referenced a `decode-quote` subcommand that no longer exists.)
- **python** — led with a directory tree and `maturin develop`, never mentioned
  PyPI. Now leads with `pip install dcap-qvl` + quick start + API; dev/build
  moved below.
- **go / js** — already solid; clearer titles + project backlink, and the
  pure-JS-vs-WASM distinction spelled out.
- **mobile** (hub + android + ios) — consistent project backlink.

Every internal relative link was verified to resolve. `cargo test --doc` passes.
(The `tests/*` fixtures' READMEs are internal test-harness docs and left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)