### PR TITLE
[codex] update pyo3 to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1199,15 +1199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,15 +1391,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1696,28 +1678,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -1726,20 +1706,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
- "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1747,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1759,24 +1737,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2045,7 +2013,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2102,7 +2070,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2364,7 +2332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2475,7 +2443,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2731,12 +2699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,7 +2918,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,12 @@ serde_bytes = { package = "serde-human-bytes", version = "0.1" }
 serde-json-core = { version = "0.6", default-features = false, optional = true }
 
 # Python bindings
-pyo3 = { version = "0.25", optional = true, features = [
+pyo3 = { version = "0.29.0", optional = true, features = [
     "extension-module",
     "abi3-py38",
     "generate-import-lib",
 ] }
-pyo3-async-runtimes = { version = "0.25", optional = true, features = [
+pyo3-async-runtimes = { version = "0.29.0", optional = true, features = [
     "tokio-runtime",
 ] }
 tokio = { version = "1.52.1", optional = true, features = ["full"] }

--- a/python-bindings/README.md
+++ b/python-bindings/README.md
@@ -54,7 +54,8 @@ reference.
 
 ## Develop
 
-Build the extension locally and run the tests:
+Building the extension from source requires Rust 1.83 or newer. Build the
+extension locally and run the tests:
 
 ```bash
 # From the repo root

--- a/python-bindings/docs/BUILDING.md
+++ b/python-bindings/docs/BUILDING.md
@@ -38,7 +38,7 @@ python3 scripts/build_wheels.py --platforms linux-x86_64 linux-aarch64 --zig --i
 
 ## Prerequisites
 
-1. **Rust toolchain** with cross-compilation targets:
+1. **Rust toolchain 1.83+** with cross-compilation targets:
    ```bash
    # Install additional targets (automatically installed with --install-targets)
    rustup target add x86_64-unknown-linux-gnu

--- a/python-bindings/docs/README_Python.md
+++ b/python-bindings/docs/README_Python.md
@@ -438,7 +438,7 @@ See [PYTHON_TESTING.md](PYTHON_TESTING.md) for detailed information about Python
 
 ### For development (building from source):
 - Python 3.8+
-- Rust toolchain (rustc, cargo)
+- Rust toolchain (rustc, cargo) 1.83+
 - maturin (automatically installed with `uv sync`)
 
 ## License

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,4 +1,4 @@
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3_async_runtimes::tokio::future_into_py;
@@ -12,7 +12,7 @@ use crate::{
     QuoteCollateralV3,
 };
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyQuoteCollateralV3 {
     inner: QuoteCollateralV3,
@@ -20,6 +20,7 @@ pub struct PyQuoteCollateralV3 {
 
 #[pymethods]
 impl PyQuoteCollateralV3 {
+    #[allow(clippy::too_many_arguments)]
     #[new]
     fn new(
         pck_crl_issuer_chain: String,
@@ -54,13 +55,13 @@ impl PyQuoteCollateralV3 {
     }
 
     #[getter]
-    fn root_ca_crl(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.root_ca_crl).into()
+    fn root_ca_crl(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.root_ca_crl).unbind()
     }
 
     #[getter]
-    fn pck_crl(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.pck_crl).into()
+    fn pck_crl(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.pck_crl).unbind()
     }
 
     #[getter]
@@ -74,8 +75,8 @@ impl PyQuoteCollateralV3 {
     }
 
     #[getter]
-    fn tcb_info_signature(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.tcb_info_signature).into()
+    fn tcb_info_signature(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.tcb_info_signature).unbind()
     }
 
     #[getter]
@@ -89,8 +90,8 @@ impl PyQuoteCollateralV3 {
     }
 
     #[getter]
-    fn qe_identity_signature(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.qe_identity_signature).into()
+    fn qe_identity_signature(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.qe_identity_signature).unbind()
     }
 
     fn to_json(&self) -> PyResult<String> {
@@ -106,7 +107,7 @@ impl PyQuoteCollateralV3 {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyVerifiedReport {
     inner: VerifiedReport,
@@ -125,8 +126,8 @@ impl PyVerifiedReport {
     }
 
     #[getter]
-    fn ppid(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.ppid).into()
+    fn ppid(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.ppid).unbind()
     }
 
     fn to_json(&self) -> PyResult<String> {
@@ -136,7 +137,7 @@ impl PyVerifiedReport {
 }
 
 /// Quote header parsed from raw quote.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyQuoteHeader {
     inner: Header,
@@ -170,17 +171,17 @@ impl PyQuoteHeader {
     }
 
     #[getter]
-    fn qe_vendor_id(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.qe_vendor_id).into()
+    fn qe_vendor_id(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.qe_vendor_id).unbind()
     }
 
     #[getter]
-    fn user_data(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.user_data).into()
+    fn user_data(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.user_data).unbind()
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyTdReport10 {
     inner: TDReport10,
@@ -189,68 +190,68 @@ pub struct PyTdReport10 {
 #[pymethods]
 impl PyTdReport10 {
     #[getter]
-    fn tee_tcb_svn(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.tee_tcb_svn).into()
+    fn tee_tcb_svn(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.tee_tcb_svn).unbind()
     }
     #[getter]
-    fn mr_seam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_seam).into()
+    fn mr_seam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_seam).unbind()
     }
     #[getter]
-    fn mr_signer_seam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_signer_seam).into()
+    fn mr_signer_seam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_signer_seam).unbind()
     }
     #[getter]
-    fn seam_attributes(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.seam_attributes).into()
+    fn seam_attributes(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.seam_attributes).unbind()
     }
     #[getter]
-    fn td_attributes(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.td_attributes).into()
+    fn td_attributes(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.td_attributes).unbind()
     }
     #[getter]
-    fn xfam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.xfam).into()
+    fn xfam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.xfam).unbind()
     }
     #[getter]
-    fn mr_td(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_td).into()
+    fn mr_td(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_td).unbind()
     }
     #[getter]
-    fn mr_config_id(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_config_id).into()
+    fn mr_config_id(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_config_id).unbind()
     }
     #[getter]
-    fn mr_owner(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_owner).into()
+    fn mr_owner(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_owner).unbind()
     }
     #[getter]
-    fn mr_owner_config(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_owner_config).into()
+    fn mr_owner_config(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_owner_config).unbind()
     }
     #[getter]
-    fn rt_mr0(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.rt_mr0).into()
+    fn rt_mr0(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.rt_mr0).unbind()
     }
     #[getter]
-    fn rt_mr1(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.rt_mr1).into()
+    fn rt_mr1(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.rt_mr1).unbind()
     }
     #[getter]
-    fn rt_mr2(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.rt_mr2).into()
+    fn rt_mr2(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.rt_mr2).unbind()
     }
     #[getter]
-    fn rt_mr3(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.rt_mr3).into()
+    fn rt_mr3(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.rt_mr3).unbind()
     }
     #[getter]
-    fn report_data(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.report_data).into()
+    fn report_data(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.report_data).unbind()
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyTdReport15 {
     inner: TDReport15,
@@ -260,79 +261,79 @@ pub struct PyTdReport15 {
 impl PyTdReport15 {
     // Flatten fields from base TDReport10
     #[getter]
-    fn tee_tcb_svn(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.tee_tcb_svn).into()
+    fn tee_tcb_svn(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.tee_tcb_svn).unbind()
     }
     #[getter]
-    fn mr_seam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_seam).into()
+    fn mr_seam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_seam).unbind()
     }
     #[getter]
-    fn mr_signer_seam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_signer_seam).into()
+    fn mr_signer_seam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_signer_seam).unbind()
     }
     #[getter]
-    fn seam_attributes(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.seam_attributes).into()
+    fn seam_attributes(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.seam_attributes).unbind()
     }
     #[getter]
-    fn td_attributes(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.td_attributes).into()
+    fn td_attributes(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.td_attributes).unbind()
     }
     #[getter]
-    fn xfam(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.xfam).into()
+    fn xfam(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.xfam).unbind()
     }
     #[getter]
-    fn mr_td(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_td).into()
+    fn mr_td(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_td).unbind()
     }
     #[getter]
-    fn mr_config_id(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_config_id).into()
+    fn mr_config_id(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_config_id).unbind()
     }
     #[getter]
-    fn mr_owner(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_owner).into()
+    fn mr_owner(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_owner).unbind()
     }
     #[getter]
-    fn mr_owner_config(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.mr_owner_config).into()
+    fn mr_owner_config(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.mr_owner_config).unbind()
     }
     #[getter]
-    fn rt_mr0(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.rt_mr0).into()
+    fn rt_mr0(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.rt_mr0).unbind()
     }
     #[getter]
-    fn rt_mr1(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.rt_mr1).into()
+    fn rt_mr1(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.rt_mr1).unbind()
     }
     #[getter]
-    fn rt_mr2(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.rt_mr2).into()
+    fn rt_mr2(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.rt_mr2).unbind()
     }
     #[getter]
-    fn rt_mr3(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.rt_mr3).into()
+    fn rt_mr3(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.rt_mr3).unbind()
     }
     #[getter]
-    fn report_data(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.base.report_data).into()
+    fn report_data(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.base.report_data).unbind()
     }
 
     // TD15 extra fields
     #[getter]
-    fn tee_tcb_svn2(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.tee_tcb_svn2).into()
+    fn tee_tcb_svn2(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.tee_tcb_svn2).unbind()
     }
 
     #[getter]
-    fn mr_service_td(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_service_td).into()
+    fn mr_service_td(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_service_td).unbind()
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PySgxEnclaveReport {
     inner: EnclaveReport,
@@ -341,32 +342,32 @@ pub struct PySgxEnclaveReport {
 #[pymethods]
 impl PySgxEnclaveReport {
     #[getter]
-    fn cpu_svn(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.cpu_svn).into()
+    fn cpu_svn(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.cpu_svn).unbind()
     }
 
     #[getter]
-    fn attributes(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.attributes).into()
+    fn attributes(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.attributes).unbind()
     }
 
     #[getter]
-    fn mr_enclave(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_enclave).into()
+    fn mr_enclave(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_enclave).unbind()
     }
 
     #[getter]
-    fn mr_signer(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.mr_signer).into()
+    fn mr_signer(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.mr_signer).unbind()
     }
 
     #[getter]
-    fn report_data(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.report_data).into()
+    fn report_data(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.report_data).unbind()
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPckExtension {
     inner: intel::PckExtension,
@@ -375,13 +376,13 @@ pub struct PyPckExtension {
 #[pymethods]
 impl PyPckExtension {
     #[getter]
-    fn ppid(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.ppid).into()
+    fn ppid(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.ppid).unbind()
     }
 
     #[getter]
-    fn cpu_svn(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.cpu_svn).into()
+    fn cpu_svn(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.cpu_svn).unbind()
     }
 
     #[getter]
@@ -390,13 +391,13 @@ impl PyPckExtension {
     }
 
     #[getter]
-    fn pce_id(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.pce_id).into()
+    fn pce_id(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.pce_id).unbind()
     }
 
     #[getter]
-    fn fmspc(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new(py, &self.inner.fmspc).into()
+    fn fmspc(&self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, &self.inner.fmspc).unbind()
     }
 
     #[getter]
@@ -405,19 +406,19 @@ impl PyPckExtension {
     }
 
     #[getter]
-    fn platform_instance_id(&self, py: Python<'_>) -> Option<PyObject> {
+    fn platform_instance_id(&self, py: Python<'_>) -> Option<Py<PyBytes>> {
         self.inner
             .platform_instance_id
             .as_ref()
-            .map(|v| PyBytes::new(py, v).into())
+            .map(|v| PyBytes::new(py, v).unbind())
     }
 
     /// Look up an arbitrary OID inside the raw Intel SGX extension.
-    fn get_value(&self, oid: &str, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_value(&self, oid: &str, py: Python<'_>) -> PyResult<Option<Py<PyBytes>>> {
         let parsed_oid = const_oid::ObjectIdentifier::new(oid)
             .map_err(|e| PyValueError::new_err(format!("Invalid OID '{}': {}", oid, e)))?;
         match self.inner.get_value(&parsed_oid) {
-            Ok(Some(bytes)) => Ok(Some(PyBytes::new(py, &bytes).into())),
+            Ok(Some(bytes)) => Ok(Some(PyBytes::new(py, &bytes).unbind())),
             Ok(None) => Ok(None),
             Err(e) => Err(PyValueError::new_err(format!(
                 "Failed to look up OID: {}",
@@ -427,7 +428,7 @@ impl PyPckExtension {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct PyQuote {
     inner: Quote,
 }
@@ -506,16 +507,16 @@ impl PyQuote {
     /// Get the embedded PCK certificate chain in PEM form, if present.
     ///
     /// Returns bytes instead of str to avoid implicit decoding/copying.
-    fn cert_chain_pem_bytes(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn cert_chain_pem_bytes(&self, py: Python<'_>) -> PyResult<Option<Py<PyBytes>>> {
         let raw = match self.inner.raw_cert_chain() {
             Ok(v) => v,
             Err(_) => return Ok(None),
         };
-        let mut end = raw.len();
-        while end > 0 && raw[end - 1] == 0 {
-            end -= 1;
+        let mut trimmed = raw;
+        while let Some(without_suffix) = trimmed.strip_suffix(&[0]) {
+            trimmed = without_suffix;
         }
-        Ok(Some(PyBytes::new(py, &raw[..end]).into()))
+        Ok(Some(PyBytes::new(py, trimmed).unbind()))
     }
 
     /// Parse the Intel SGX extension from the leaf PCK certificate.
@@ -593,8 +594,13 @@ fn parse_pck_extension_from_pem(pem_bytes: &Bound<'_, PyBytes>) -> PyResult<PyPc
 fn get_collateral_py<'py>(
     py: Python<'py>,
     pccs_url: String,
-    raw_quote: Vec<u8>,
+    raw_quote: &Bound<'_, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
+    let raw_quote = raw_quote
+        .cast::<PyBytes>()
+        .map_err(|_| PyTypeError::new_err("raw_quote must be bytes"))?
+        .as_bytes()
+        .to_vec();
     future_into_py(py, async move {
         let client = CollateralClient::with_default_http(pccs_url)
             .map_err(|e| PyValueError::new_err(format!("Failed to build HTTP client: {}", e)))?;

--- a/src/tcb_info.rs
+++ b/src/tcb_info.rs
@@ -306,6 +306,14 @@ mod tests {
         }
     }
 
+    #[allow(clippy::expect_used)]
+    fn first_component_svn(components: &[TcbComponents]) -> u8 {
+        components
+            .first()
+            .expect("expected at least one TCB component")
+            .svn
+    }
+
     #[test]
     fn test_canonicalize_sgx_sorts_by_cpu_svn_desc() {
         let mut info = make_tcb_info(
@@ -320,7 +328,7 @@ mod tests {
         let svns: Vec<u8> = info
             .tcb_levels
             .iter()
-            .map(|l| l.tcb.sgx_components[0].svn)
+            .map(|l| first_component_svn(&l.tcb.sgx_components))
             .collect();
         assert_eq!(svns, vec![5, 3, 2]);
     }
@@ -354,7 +362,7 @@ mod tests {
         let tdx_svns: Vec<u8> = info
             .tcb_levels
             .iter()
-            .map(|l| l.tcb.tdx_components[0].svn)
+            .map(|l| first_component_svn(&l.tcb.tdx_components))
             .collect();
         assert_eq!(tdx_svns, vec![3, 2, 1]);
     }
@@ -373,7 +381,7 @@ mod tests {
         let tdx_svns: Vec<u8> = info
             .tcb_levels
             .iter()
-            .map(|l| l.tcb.tdx_components[0].svn)
+            .map(|l| first_component_svn(&l.tcb.tdx_components))
             .collect();
         assert_eq!(tdx_svns, vec![1, 9]);
     }

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -143,16 +143,17 @@ fn verify_with_custom_config_matches_default() {
     // care that the generic plumbing reaches the same outcome as the default
     // entry point. Either both succeed with equal reports, or both fail with
     // equal error strings.
-    let now = chrono::DateTime::parse_from_rfc3339(
-        &serde_json::from_str::<serde_json::Value>(&collateral.tcb_info).expect("tcb json")
-            ["nextUpdate"]
-            .as_str()
-            .expect("nextUpdate")
-            .to_string(),
-    )
-    .expect("nextUpdate parse")
-    .timestamp() as u64
-        - 1;
+    let tcb_info_json =
+        serde_json::from_str::<serde_json::Value>(&collateral.tcb_info).expect("tcb json");
+    let next_update = tcb_info_json
+        .get("nextUpdate")
+        .and_then(serde_json::Value::as_str)
+        .expect("nextUpdate");
+    let now = (chrono::DateTime::parse_from_rfc3339(next_update)
+        .expect("nextUpdate parse")
+        .timestamp() as u64)
+        .checked_sub(1)
+        .expect("nonzero nextUpdate timestamp");
 
     let default_result = verify(raw_quote, &collateral, now);
     let custom_result = verify_with::<ForwardingConfig>(raw_quote, &collateral, now);

--- a/tests/verify_quote.rs
+++ b/tests/verify_quote.rs
@@ -25,8 +25,14 @@ pub fn verify(
 fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
     fn parse_issue_next(json_str: &str) -> (u64, u64) {
         let value: Value = serde_json::from_str(json_str).expect("valid JSON");
-        let issue = value["issueDate"].as_str().expect("issueDate string");
-        let next = value["nextUpdate"].as_str().expect("nextUpdate string");
+        let issue = value
+            .get("issueDate")
+            .and_then(Value::as_str)
+            .expect("issueDate string");
+        let next = value
+            .get("nextUpdate")
+            .and_then(Value::as_str)
+            .expect("nextUpdate string");
         let issue_ts = chrono::DateTime::parse_from_rfc3339(issue)
             .expect("issueDate parse")
             .timestamp() as u64;
@@ -64,7 +70,7 @@ fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
         "collateral validity window invalid"
     );
     if not_after > not_before {
-        not_after - 1
+        not_after.checked_sub(1).expect("nonzero not_after")
     } else {
         not_after
     }

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -88,8 +88,14 @@ mod tests {
     fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
         fn parse_issue_next(json_str: &str) -> (u64, u64) {
             let value: Value = serde_json::from_str(json_str).expect("valid JSON");
-            let issue = value["issueDate"].as_str().expect("issueDate string");
-            let next = value["nextUpdate"].as_str().expect("nextUpdate string");
+            let issue = value
+                .get("issueDate")
+                .and_then(Value::as_str)
+                .expect("issueDate string");
+            let next = value
+                .get("nextUpdate")
+                .and_then(Value::as_str)
+                .expect("nextUpdate string");
             let issue_ts = chrono::DateTime::parse_from_rfc3339(issue)
                 .expect("issueDate parse")
                 .timestamp() as u64;
@@ -127,7 +133,7 @@ mod tests {
             "collateral validity window invalid"
         );
         if not_after > not_before {
-            not_after - 1
+            not_after.checked_sub(1).expect("nonzero not_after")
         } else {
             not_after
         }


### PR DESCRIPTION
## Summary

- Update `pyo3` and `pyo3-async-runtimes` to 0.29.0.
- Migrate Python binding byte-return APIs to PyO3 0.29-compatible `Py<PyBytes>` returns and explicit `#[pyclass(...)]` extraction behavior.
- Document Rust 1.83+ as the source-build requirement for Python bindings.
- Clean up strict clippy findings in the touched binding/test paths.

## Validation

- `cargo check`
- `cargo check --features python`
- `cargo clippy --features python --all-targets -- -D warnings`
- `cargo test --features python`
- `cargo test --features 'python danger-allow-tcb-override'`