### PR TITLE
fix(ci/npm): use Node 24 for latest npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support


### PR DESCRIPTION
The npm publish workflow installs `npm@latest`, but npm 12 no longer supports Node 20. This updates the publish job to Node 24 so npm-only releases can run.

The failed `npm-v0.5.3` release will be retried after this merges.