### PR TITLE
fix(tests): use CA chain for generated PCK CRLs

### DIFF
--- a/cli/src/bin/generate_all_samples.rs
+++ b/cli/src/bin/generate_all_samples.rs
@@ -486,6 +486,11 @@ fn generate_base_collateral() -> Result<serde_json::Value> {
         fs::read_to_string(format!("{}/tcb_chain.pem", CERT_DIR)).unwrap_or_else(|_| {
             String::from("-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n")
         });
+    let pck_crl_issuer_chain = fs::read_to_string(format!(
+        "{}/pck_crl_issuer_chain.pem",
+        CERT_DIR
+    ))
+    .unwrap_or_else(|_| tcb_chain.clone());
 
     // Load CRLs
     let root_crl = fs::read(format!("{}/root_ca.crl.der", CERT_DIR))
@@ -551,7 +556,7 @@ fn generate_base_collateral() -> Result<serde_json::Value> {
     let qe_identity_signature = sign_data(&key_pair, qe_identity_json.as_bytes())?;
 
     Ok(json!({
-        "pck_crl_issuer_chain": tcb_chain,
+        "pck_crl_issuer_chain": pck_crl_issuer_chain,
         "root_ca_crl": hex::encode(&root_crl),
         "pck_crl": hex::encode(&pck_crl),
         "tcb_info_issuer_chain": tcb_chain.clone(),

--- a/tests/generate_test_certs.sh
+++ b/tests/generate_test_certs.sh
@@ -106,6 +106,9 @@ cat "$CERTS_DIR/tcb_signing.pem" "$CERTS_DIR/tcb_signing_ca.pem" "$CERTS_DIR/roo
 # This chain uses the CA cert as the signing cert (wrong!)
 cat "$CERTS_DIR/tcb_signing_ca.pem" "$CERTS_DIR/root_ca.pem" > "$CERTS_DIR/tcb_chain_ca_only.pem"
 
+# Create PCK CRL issuer chain (CRL-signing CA + Root CA)
+cat "$CERTS_DIR/tcb_signing_ca.pem" "$CERTS_DIR/root_ca.pem" > "$CERTS_DIR/pck_crl_issuer_chain.pem"
+
 # Create PCK chain (PCK + TCB Signing CA + Root CA)
 cat "$CERTS_DIR/pck.pem" "$CERTS_DIR/tcb_signing_ca.pem" "$CERTS_DIR/root_ca.pem" > "$CERTS_DIR/pck_chain.pem"
 


### PR DESCRIPTION
The pure-JS verifier now authenticates collateral CRLs, but the sample generator incorrectly populated `pck_crl_issuer_chain` with the TCB end-entity signer first. The generated PCK CRL is actually signed by the intermediate CA.

Generate and use the matching CA + root chain so the cross-binding test suite exercises valid authenticated CRL collateral.