### PR TITLE
feat: add detailed quote claims and optional quote policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ default-x509 = ["dep:der", "dep:x509-cert"]
 # `report` (PCCS client + collateral fetch) parses CRL distribution
 # points with `x509-cert`, so it pulls in the audited backend bundle too.
 report = ["std", "tracing", "futures", "reqwest", "default-x509"]
-js = ["getrandom/js", "serde-wasm-bindgen", "wasm-bindgen"]
+js = ["getrandom/js", "serde-wasm-bindgen", "wasm-bindgen", "rustcrypto", "default-x509"]
 python = ["pyo3", "pyo3-async-runtimes", "tokio", "std", "report", "ring"]
 # The `go` FFI surface concretizes on `DefaultConfig`, so it pulls in the
 # audited backend bundle.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ fmt.Println(report.Status)
 Each binding's directory (linked in the table above) has full documentation and
 runnable examples.
 
+## Detailed claims and optional policy validation
+
+Applications can request detailed serializable claims and optionally apply the built-in policy:
+
+```rust
+use dcap_qvl::{QuoteVerifier, QuotePolicy, TcbStatus};
+
+let policy = QuotePolicy::strict(now)
+    .allow_status(TcbStatus::SWHardeningNeeded)
+    .reject_advisory("INTEL-SA-00334");
+
+let claims = QuoteVerifier::new_prod()
+    .verify_with_policy(&quote, collateral, now, &policy)?;
+```
+
+For downstream appraisal, use `QuotePolicy::claims_only(now)`. It skips local business-policy checks while verification still uses the explicit `now` argument. Applications can serialize those claims and feed them to a
+shared downstream policy engine that also handles other TEE platforms. See
+[docs/policy.md](docs/policy.md) for the claims schema and `QuotePolicy`.
+Existing one-shot `verify()` entry points remain available.
+
 ## Building and testing
 
 Common tasks are in the [Makefile](Makefile):

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,9 @@ is hex-encoded rather than raw bytes.
 
 ```bash
 dcap-qvl verify quote.bin
+
+# Require a strict UpToDate policy appraisal
+dcap-qvl verify --strict quote.bin
 ```
 
 Collateral is fetched from Phala's PCCS by default. Point it at another PCCS with
@@ -29,6 +32,9 @@ the `PCCS_URL` environment variable:
 
 ```bash
 PCCS_URL=https://your-pccs/sgx/certification/v4/ dcap-qvl verify quote.bin
+
+# Require a strict UpToDate policy appraisal
+dcap-qvl verify --strict quote.bin
 ```
 
 The verified report is printed as JSON on stdout; progress goes to stderr.

--- a/cli/src/bin/test_case.rs
+++ b/cli/src/bin/test_case.rs
@@ -101,17 +101,22 @@ fn run_verify(quote_file: PathBuf, collateral_file: PathBuf, root_ca_file: Optio
         .expect("Invalid system time")
         .as_secs();
 
-    use dcap_qvl::configs::{RingConfig, RustCryptoConfig};
-    let verifier = match root_ca_der {
+    let ring_verifier = match root_ca_der.clone() {
+        Some(root_ca_der) => QuoteVerifier::new(root_ca_der),
+        None => QuoteVerifier::new_prod(),
+    };
+    let rustcrypto_verifier = match root_ca_der {
         Some(root_ca_der) => QuoteVerifier::new(root_ca_der),
         None => QuoteVerifier::new_prod(),
     };
 
-    let ring_result = verifier
-        .verify_with::<RingConfig>(&quote_bytes, &collateral, now)
+    let ring_result = ring_verifier
+        .with_config::<dcap_qvl::configs::RingConfig>()
+        .verify(&quote_bytes, &collateral, now)
         .map_err(|e| format!("{e:#}"));
-    let rustcrypto_result = verifier
-        .verify_with::<RustCryptoConfig>(&quote_bytes, &collateral, now)
+    let rustcrypto_result = rustcrypto_verifier
+        .with_config::<dcap_qvl::configs::RustCryptoConfig>()
+        .verify(&quote_bytes, &collateral, now)
         .map_err(|e| format!("{e:#}"));
     if ring_result != rustcrypto_result {
         eprintln!("Verification results differ between ring and rustcrypto");
@@ -120,20 +125,14 @@ fn run_verify(quote_file: PathBuf, collateral_file: PathBuf, root_ca_file: Optio
         return 1;
     }
 
-    let ring_result1 = verifier.verify_with::<RingConfig>(&quote_bytes, &collateral, now);
-    match ring_result1 {
-        Ok(verified_report) => {
+    match ring_result {
+        Ok(report) => {
             println!("Verification successful");
-            println!("Status: {:?}", verified_report.status);
+            println!("Status: {}", report.status);
             0
         }
         Err(e) => {
-            eprintln!("Verification failed: {}", e);
-            let mut source = e.source();
-            while let Some(err) = source {
-                eprintln!("  Caused by: {}", err);
-                source = err.source();
-            }
+            eprintln!("Verification failed: {e}");
             1
         }
     }
@@ -158,20 +157,12 @@ fn run_get_collateral(pccs_url: String, quote_file: PathBuf) -> i32 {
             }
         };
 
-        // Build HTTP client
-        let client = match CollateralClient::with_default_http(pccs_url) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Failed to build HTTP client: {}", e);
-                return 2;
-            }
-        };
-
         // Fetch collateral
-        let result = client
-            .fetch(&quote_bytes)
-            .await
-            .and_then(|collateral| {
+        let result = match CollateralClient::with_default_http(pccs_url) {
+            Ok(client) => client.fetch(&quote_bytes).await,
+            Err(error) => Err(error),
+        }
+        .and_then(|collateral| {
                 serde_json::to_string(&collateral).context("Failed to serialize collateral")
             });
         match result {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,8 @@ use clap::{Args, Parser, Subcommand};
 use dcap_qvl::collateral::{CollateralClient, PHALA_PCCS_URL};
 use dcap_qvl::intel;
 use dcap_qvl::quote::Quote;
-use dcap_qvl::verify::verify;
+use dcap_qvl::verify::QuoteVerifier;
+use dcap_qvl::QuotePolicy;
 use der::Decode;
 use serde::Serialize;
 use x509_cert::Certificate;
@@ -48,6 +49,9 @@ struct VerifyQuoteArgs {
     /// Indicate the quote file is in hex format
     #[arg(long)]
     hex: bool,
+    /// Apply QuotePolicy::strict(now) after cryptographic verification
+    #[arg(long)]
+    strict: bool,
     /// The quote file
     quote_file: PathBuf,
 }
@@ -106,12 +110,25 @@ async fn command_verify_quote(args: VerifyQuoteArgs) -> Result<()> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();
-    let report = verify(&quote, &collateral, now).context("Failed to verify quote")?;
-    println!(
-        "{}",
-        serde_json::to_string(&report).context("Failed to serialize report")?
-    );
-    eprintln!("Quote verified");
+    let verifier = QuoteVerifier::new_prod();
+    let output = if args.strict {
+        let claims = verifier
+            .verify_with_policy(&quote, collateral, now, &QuotePolicy::strict(now))
+            .context("Strict policy validation failed")?;
+        serde_json::to_string(&claims).context("Failed to serialize claims")?
+    } else {
+        let report = verifier
+            .verify(&quote, &collateral, now)
+            .context("Failed to verify quote")?;
+        serde_json::to_string(&report)
+            .context("Failed to serialize report")?
+    };
+    println!("{output}");
+    if args.strict {
+        eprintln!("Quote verified under strict policy");
+    } else {
+        eprintln!("Quote verified");
+    }
     Ok(())
 }
 

--- a/dcap-qvl-mobile/src/lib.rs
+++ b/dcap-qvl-mobile/src/lib.rs
@@ -51,9 +51,7 @@ pub fn verify(
     now_secs: u64,
 ) -> Result<VerifiedReport, DcapError> {
     let collateral = parse_collateral(&collateral_json)?;
-    let verifier = QuoteVerifier::new_prod();
-    let report = verifier
-        .verify(&raw_quote, &collateral, now_secs)
+    let report = dcap_qvl::verify::verify(&raw_quote, &collateral, now_secs)
         .map_err(DcapError::from_anyhow)?;
     Ok(VerifiedReport::from_core(report))
 }

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,0 +1,149 @@
+# Policy Validation
+
+After cryptographic verification, `dcap-qvl` supports a **policy validation** phase that checks the platform's TCB (Trusted Computing Base) status, advisory IDs, collateral freshness, and platform configuration flags.
+
+## Claims API
+
+```
+verify_with_policy(QuotePolicy) ────────────────► QuoteClaims
+
+The serializable `QuoteClaims` value is the boundary between DCAP verification
+and application policy. A downstream service can combine claims from SGX, TDX,
+or other TEE verifiers and evaluate them with its own policy engine.
+```
+
+- **`verify_with_policy()`** — uses the explicit verification time for cryptographic checks, applies the policy, and returns detailed `QuoteClaims`.
+- **`QuotePolicy::claims_only(now)`** — supplies trusted time while leaving business-policy appraisal to a downstream engine.
+- **`verify()`** — remains the backwards-compatible one-shot API returning `VerifiedReport`.
+
+## QuotePolicy
+
+The built-in policy with 9 checks from Intel's Appraisal framework. Strict by default — only `UpToDate` status, no grace period, no advisory blacklist.
+
+### Basic Usage
+
+```rust
+use dcap_qvl::verify::QuoteVerifier;
+use dcap_qvl::QuotePolicy;
+
+let verifier = QuoteVerifier::new_prod();
+// Strict: only UpToDate, collateral must not be expired
+let claims = verifier.verify_with_policy(
+    &quote, collateral, now, &QuotePolicy::strict(now),
+)?;
+```
+
+### Builder Methods
+
+```rust
+use dcap_qvl::{QuotePolicy, TcbStatus};
+use core::time::Duration;
+
+let policy = QuotePolicy::strict(now)
+    // Accept additional TCB statuses
+    .allow_status(TcbStatus::SWHardeningNeeded)
+    .allow_status(TcbStatus::ConfigurationNeeded)
+    // Reject specific advisory IDs (case-insensitive)
+    .reject_advisory("INTEL-SA-00334")
+    .reject_advisory("INTEL-SA-00615")
+    .reject_advisories(&["INTEL-SA-00809", "INTEL-SA-00820"])
+    // Collateral freshness: accept expired collateral within grace window
+    .collateral_grace_period(Duration::from_secs(30 * 24 * 3600)) // 30 days
+    // Minimum TCB evaluation data number
+    .min_tcb_eval_data_number(17)
+    // Platform flags (default: reject True)
+    .allow_dynamic_platform(true)
+    .allow_cached_keys(true)
+    .allow_smt(true)
+    // SGX type whitelist (default: skip check)
+    .accepted_sgx_types(&[0, 1]); // Standard + Scalable
+```
+
+### The 9 Checks
+
+| # | Check | Default | Builder |
+|---|-------|---------|---------|
+| 1 | **TCB status whitelist** | Only `UpToDate` | `.allow_status(...)` |
+| 2 | **Advisory ID blacklist** | Empty set (allow all) | `.reject_advisory(...)` |
+| 3 | **Collateral expiration** | `earliest_expiration >= now` | `.collateral_grace_period(Duration)` |
+| 4 | **Platform TCB freshness** | Only for OutOfDate statuses | `.platform_grace_period(Duration)` |
+| 4b | **QE TCB freshness** | Only for QE `OutOfDate` | `.qe_grace_period(Duration)` |
+| 5 | **Min TCB eval data number** | Skip | `.min_tcb_eval_data_number(n)` |
+| 6 | **Dynamic platform flag** | Reject `True` | `.allow_dynamic_platform(true)` |
+| 7 | **Cached keys flag** | Reject `True` | `.allow_cached_keys(true)` |
+| 8 | **SMT flag** | Reject `True` | `.allow_smt(true)` |
+| 9 | **SGX type whitelist** | Skip | `.accepted_sgx_types(&[0, 1, 2])` |
+
+### Grace Period Behavior
+
+**Collateral grace** (`collateral_grace_period`): Extends the collateral expiration window. If `earliest_expiration + grace >= now`, the quote is accepted.
+
+**Platform grace** (`platform_grace_period`): Applies only to the **platform** TCB level. For `OutOfDate` / `OutOfDateConfigurationNeeded`, checks `platform.tcb_date_tag + grace >= now`. For pure `OutOfDate`, only the **platform** advisories are skipped during the grace window. For `OutOfDateConfigurationNeeded`, platform advisories are still checked.
+
+**QE grace** (`qe_grace_period`): Applies only to the **QE** TCB level. For QE `OutOfDate`, checks `qe.tcb_level.tcb_date + grace >= now`. QE advisories are skipped only while this QE grace is active.
+
+`collateral_grace_period` is **mutually exclusive** with the TCB grace windows — setting it together with `platform_grace_period` or `qe_grace_period` causes a validation error.
+
+### Platform Flags (Three-State)
+
+Platform flags (`dynamic_platform`, `cached_keys`, `smt_enabled`) use `PckCertFlag` with three values:
+
+| Value | Meaning | Default behavior |
+|-------|---------|-----------------|
+| `True` | Flag is set | **Rejected** |
+| `False` | Flag is explicitly unset | Accepted |
+| `Undefined` | Not present (Processor CA certs) | Accepted |
+
+Only `True` is rejected by default. `False` and `Undefined` always pass.
+
+## Custom Policy
+
+For logic that `QuotePolicy` cannot express, implement the `Policy` trait directly:
+
+```rust
+use dcap_qvl::{Policy, QuoteClaims, TcbStatus};
+use anyhow::{bail, Result};
+
+struct MyPolicy {
+    now: u64,
+    grace_secs: u64,
+}
+
+impl Policy for MyPolicy {
+    fn validate(&self, data: &QuoteClaims) -> Result<()> {
+        let in_grace = data.platform.tcb_date_tag
+            .saturating_add(self.grace_secs) >= self.now;
+
+        // Conditional logic based on grace window
+        if !in_grace && data.tcb.status != TcbStatus::UpToDate {
+            bail!("Only UpToDate accepted outside grace period");
+        }
+
+        // Check specific advisories even during grace
+        for id in &data.tcb.advisory_ids {
+            if id == "INTEL-SA-00220" {
+                bail!("Critical advisory {id} always rejected");
+            }
+        }
+
+        Ok(())
+    }
+}
+```
+
+## Downstream policy engines
+
+`dcap-qvl` intentionally does not embed a Rego runtime. Export claims as JSON
+and pass them to the application-wide policy layer:
+
+```rust
+let claims = verifier.verify_with_policy(
+    &quote, collateral, now, &QuotePolicy::claims_only(now),
+)?;
+let input_json = serde_json::to_value(&claims)?;
+// Evaluate `input_json` with the application's policy engine.
+```
+
+This keeps cryptographic quote verification independent from business policy and
+allows one policy engine to consume normalized claims from multiple TEE platforms.
+The top-level `claims_version` field versions the serialized schema.

--- a/python-bindings/python/dcap_qvl/__init__.py
+++ b/python-bindings/python/dcap_qvl/__init__.py
@@ -4,12 +4,18 @@ DCAP Quote Verification Library
 This package provides Python bindings for the DCAP (Data Center Attestation Primitives)
 quote verification library implemented in Rust.
 
+Claims API (matches Rust):
+1. verify(quote, collateral, now_secs) -> QuoteClaims
+2. QuoteVerifier.verify_with_policy(...) -> QuoteClaims
+
 Main classes:
 - QuoteCollateralV3: Represents quote collateral data
-- VerifiedReport: Contains verification results
+- VerifiedReport: Legacy one-shot verification result
+- QuotePolicy: Verification policy with builder pattern
+- QuoteClaims: Detailed serializable claims for downstream policy engines
 
 Main functions:
-- verify: Verify a quote with collateral data
+- verify: Verify a quote with collateral data (returns QuoteClaims)
 - get_collateral: Get collateral from PCCS URL
 - get_collateral_from_pcs: Get collateral from Intel PCS
 - get_collateral_and_verify: Get collateral and verify quote
@@ -22,11 +28,14 @@ from typing import Optional
 from ._dcap_qvl import (
     PyQuoteCollateralV3 as QuoteCollateralV3,
     PyVerifiedReport as VerifiedReport,
+    PyQuoteClaims as QuoteClaims,
     PyQuoteHeader as QuoteHeader,
     PyTdReport10 as TdReport10,
     PyTdReport15 as TdReport15,
     PySgxEnclaveReport as SgxEnclaveReport,
     PyPckExtension as PckExtension,
+    PyQuotePolicy as QuotePolicy,
+    PyQuoteVerifier as QuoteVerifier,
     PyQuote as Quote,
     py_verify as verify,
     py_verify_with_root_ca as verify_with_root_ca,
@@ -68,16 +77,17 @@ async def get_collateral_from_pcs(raw_quote: bytes) -> QuoteCollateralV3:
 
 
 async def get_collateral_and_verify(
-    raw_quote: bytes, pccs_url: Optional[str] = None
+    raw_quote: bytes,
+    pccs_url: Optional[str] = None,
 ) -> VerifiedReport:
-    """Get collateral and verify the quote.
+    """Get collateral and verify the quote, returning detailed claims.
 
     Args:
         raw_quote: Raw quote bytes
         pccs_url: Optional PCCS URL (defaults to Phala PCCS)
 
     Returns:
-        VerifiedReport: Verification result
+        VerifiedReport: Legacy verified report
 
     Raises:
         ValueError: If quote is invalid or verification fails
@@ -88,21 +98,22 @@ async def get_collateral_and_verify(
     # Get collateral
     collateral = await get_collateral(url, raw_quote)
 
-    # Get current time
-    now_secs = int(time.time())
-
     # Verify quote
+    now_secs = int(time.time())
     return verify(raw_quote, collateral, now_secs)
 
 
 __all__ = [
     "QuoteCollateralV3",
+    "QuoteClaims",
+    "QuoteVerifier",
     "VerifiedReport",
     "QuoteHeader",
     "TdReport10",
     "TdReport15",
     "SgxEnclaveReport",
     "PckExtension",
+    "QuotePolicy",
     "AttestationKeyType",
     "TeeType",
     "Quote",

--- a/python-bindings/python/dcap_qvl/_dcap_qvl.pyi
+++ b/python-bindings/python/dcap_qvl/_dcap_qvl.pyi
@@ -313,6 +313,96 @@ class PyPckExtension:
         ...
 
 
+class PyQuotePolicy:
+    """Verification policy with builder pattern.
+
+    Use ``QuotePolicy.strict(now_secs)`` to create a strict policy (only UpToDate),
+    then chain builder methods to relax constraints.
+
+    Example::
+
+        policy = QuotePolicy.strict(now_secs) \\
+            .allow_status("SWHardeningNeeded") \\
+            .reject_advisory("INTEL-SA-00334") \\
+            .collateral_grace_period(90 * 24 * 3600) \\
+            .qe_grace_period(7 * 24 * 3600)
+    """
+
+    @staticmethod
+    def strict(now_secs: int) -> "PyQuotePolicy":
+        """Create a strict policy: only UpToDate, no grace, no advisory blacklist."""
+        ...
+
+    @staticmethod
+    def claims_only(now_secs: int) -> "PyQuotePolicy": ...
+
+    def allow_status(self, status: str) -> "PyQuotePolicy":
+        """Allow an additional TCB status (e.g. "SWHardeningNeeded")."""
+        ...
+
+    def reject_advisory(self, advisory_id: str) -> "PyQuotePolicy":
+        """Reject a specific advisory ID (e.g. "INTEL-SA-00334")."""
+        ...
+
+    def reject_advisories(self, advisory_ids: List[str]) -> "PyQuotePolicy":
+        """Reject multiple advisory IDs at once."""
+        ...
+
+    def collateral_grace_period(self, secs: int) -> "PyQuotePolicy":
+        """Set collateral grace period in seconds."""
+        ...
+
+    def platform_grace_period(self, secs: int) -> "PyQuotePolicy":
+        """Set platform grace period in seconds."""
+        ...
+
+    def qe_grace_period(self, secs: int) -> "PyQuotePolicy":
+        """Set QE grace period in seconds."""
+        ...
+
+    def min_tcb_eval_data_number(self, min: int) -> "PyQuotePolicy":
+        """Set minimum TCB evaluation data number."""
+        ...
+
+    def allow_dynamic_platform(self, allow: bool) -> "PyQuotePolicy":
+        """Set whether dynamic platforms are allowed."""
+        ...
+
+    def allow_cached_keys(self, allow: bool) -> "PyQuotePolicy":
+        """Set whether cached keys are allowed."""
+        ...
+
+    def allow_smt(self, allow: bool) -> "PyQuotePolicy":
+        """Set whether SMT (hyperthreading) is allowed."""
+        ...
+
+    def accepted_sgx_types(self, types: List[int]) -> "PyQuotePolicy":
+        """Set accepted SGX types (e.g. [0, 1, 2])."""
+        ...
+
+
+class PyQuoteClaims:
+    """Detailed verified claims suitable for a downstream policy engine."""
+
+    def to_json(self) -> str: ...
+
+
+
+class PyQuoteVerifier:
+    """Quote verifier returning detailed claims directly."""
+
+    def __init__(self, root_ca_der: Optional[bytes] = None) -> None: ...
+
+
+    def verify_with_policy(
+        self,
+        raw_quote: bytes,
+        collateral: PyQuoteCollateralV3,
+        now_secs: int,
+        policy: PyQuotePolicy,
+    ) -> PyQuoteClaims: ...
+
+
 class PyQuote:
     """
     Represents a parsed SGX or TDX quote.
@@ -422,23 +512,20 @@ def py_verify(
     raw_quote: bytes, collateral: PyQuoteCollateralV3, now_secs: int
 ) -> PyVerifiedReport:
     """
-    Verify an SGX or TDX quote with the provided collateral data.
+    Verify an SGX or TDX quote and return the legacy verified report.
 
-    This function performs cryptographic verification of the quote against
-    the provided collateral information, checking certificates, signatures,
-    and revocation status.
+    Performs cryptographic verification against the provided collateral.
 
     Args:
         raw_quote: Raw quote data as bytes (SGX or TDX format)
         collateral: Quote collateral containing certificates and attestation data
-        now_secs: Current timestamp in seconds since Unix epoch for time-based checks
+        now_secs: Current Unix timestamp
 
     Returns:
-        PyVerifiedReport containing verification status and advisory information
+        PyVerifiedReport: verified quote report
 
     Raises:
-        ValueError: If verification fails due to invalid data, expired certificates,
-                   revoked keys, or other verification errors
+        ValueError: If cryptographic verification fails
     """
     ...
 
@@ -446,22 +533,22 @@ def py_verify_with_root_ca(
     raw_quote: bytes,
     collateral: PyQuoteCollateralV3,
     root_ca_der: bytes,
-    now_secs: int
+    now_secs: int,
 ) -> PyVerifiedReport:
     """
-    Verify an SGX or TDX quote with the provided collateral data and custom root CA.
+    Verify an SGX or TDX quote with custom root CA.
 
     Args:
         raw_quote: Raw quote data as bytes (SGX or TDX format)
         collateral: Quote collateral containing certificates and attestation data
         root_ca_der: Custom root CA certificate in DER format
-        now_secs: Current timestamp in seconds since Unix epoch for time-based checks
+        now_secs: Current Unix timestamp
 
     Returns:
-        PyVerifiedReport containing verification status and advisory information
+        PyVerifiedReport: verified quote report
 
     Raises:
-        ValueError: If verification fails
+        ValueError: If cryptographic verification fails
     """
     ...
 
@@ -523,4 +610,3 @@ async def get_collateral(pccs_url: str, raw_quote: bytes) -> PyQuoteCollateralV3
             of this module).
     """
     ...
-

--- a/python-bindings/tests/test_python_bindings.py
+++ b/python-bindings/tests/test_python_bindings.py
@@ -107,10 +107,11 @@ class TestWithSampleData:
 
         collateral = dcap_qvl.QuoteCollateralV3.from_json(json.dumps(collateral_json))
 
-        # Note: We use a timestamp that might make the test pass
-        # In a real scenario, you'd use the current time or a known good time
         result = dcap_qvl.verify(quote_data, collateral, 1234567890)
 
-        assert isinstance(result, dcap_qvl.VerifiedReport)
-        assert isinstance(result.status, str)
-        assert isinstance(result.advisory_ids, list)
+        assert isinstance(result, dcap_qvl.QuoteClaims)
+        claims = json.loads(result.to_json())
+        assert "tcb" in claims
+        assert "platform" in claims
+        assert "qe" in claims
+        assert "report" in claims

--- a/src/collateral.rs
+++ b/src/collateral.rs
@@ -290,7 +290,7 @@ async fn get_pck_chain<H: HttpClient>(client: &H, pccs_url: &str, quote: &Quote)
 /// * [`fetch_for_fmspc`](Self::fetch_for_fmspc) — when the caller already
 ///   has the FMSPC / CA type (skips PCK chain extraction).
 /// * [`fetch_and_verify`](Self::fetch_and_verify) — fetch collateral and
-///   run [`verify_with`](crate::verify::verify_with) in one shot
+///   run [`QuoteVerifier::verify`](crate::verify::QuoteVerifier::verify) in one shot
 ///   (feature-gated on `_anycrypto`).
 ///
 /// # Examples
@@ -519,7 +519,9 @@ impl<C: Config, H: HttpClient> CollateralClient<C, H> {
             .duration_since(SystemTime::UNIX_EPOCH)
             .context("Failed to get current time")?
             .as_secs();
-        crate::verify::verify_with::<C>(quote, &collateral, now)
+        crate::verify::QuoteVerifier::new_prod()
+            .with_config::<C>()
+            .verify(quote, &collateral, now)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,8 @@
 //!     type Crypto     = dcap_qvl::crypto::RingCrypto;
 //! }
 //!
-//! dcap_qvl::verify::verify_with::<MyConfig>(quote, &collateral, now)?;
+//! dcap_qvl::verify::QuoteVerifier::<MyConfig>::new_with_config(root_ca_der)
+//!     .verify(quote, &collateral, now)?;
 //! ```
 //!
 //! ## Auditing
@@ -132,7 +133,8 @@ pub trait EcdsaSigEncoder {
 }
 
 /// Cryptographic primitives required by quote verification: the ECDSA
-/// signature verification algorithm passed to webpki, plus a SHA-256 hash.
+/// signature verification algorithm passed to webpki, plus SHA-256 and
+/// SHA-384 hashes.
 ///
 /// Implementations are typically zero-sized marker types whose methods are
 /// associated functions delegating to a chosen crypto crate (ring, RustCrypto,
@@ -142,6 +144,8 @@ pub trait CryptoProvider {
     fn sig_algo() -> &'static dyn rustls_pki_types::SignatureVerificationAlgorithm;
     /// SHA-256 of `data`.
     fn sha256(data: &[u8]) -> [u8; 32];
+    /// SHA-384 of `data`, used for Intel QAL `root_key_id`.
+    fn sha384(data: &[u8]) -> [u8; 48];
 }
 
 /// Configuration bundle selecting an implementation for each pluggable

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,9 +1,14 @@
 #![allow(dead_code)]
 
+/// MR_SIGNER measurement (32 bytes)
 pub type MrSigner = [u8; 32];
+/// MR_ENCLAVE measurement (32 bytes)
 pub type MrEnclave = [u8; 32];
+/// FMSPC - Firmware Security Version & Package Configuration (6 bytes)
 pub type Fmspc = [u8; 6];
+/// CPU SVN - Security Version Number for CPU microcode (16 bytes)
 pub type CpuSvn = [u8; 16];
+/// SVN - Security Version Number (16-bit)
 pub type Svn = u16;
 
 pub const ATTESTATION_KEY_TYPE_ECDSA256_WITH_P256_CURVE: u16 = 2;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -24,6 +24,13 @@ impl CryptoProvider for RingCrypto {
         out.copy_from_slice(digest.as_ref());
         out
     }
+
+    fn sha384(data: &[u8]) -> [u8; 48] {
+        let digest = ring::digest::digest(&ring::digest::SHA384, data);
+        let mut out = [0u8; 48];
+        out.copy_from_slice(digest.as_ref());
+        out
+    }
 }
 
 /// Audited [`CryptoProvider`] backed by RustCrypto (`sha2` + `p256`, gated by
@@ -40,5 +47,10 @@ impl CryptoProvider for RustCryptoCrypto {
     fn sha256(data: &[u8]) -> [u8; 32] {
         use sha2::Digest;
         sha2::Sha256::digest(data).into()
+    }
+
+    fn sha384(data: &[u8]) -> [u8; 48] {
+        use sha2::Digest as _;
+        sha2::Sha384::digest(data).into()
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -295,11 +295,12 @@ pub unsafe extern "C" fn dcap_parse_quote_cb(
     let quote_type = if parsed.header.is_sgx() { "SGX" } else { "TDX" };
 
     let cert_chain_pem = parsed.raw_cert_chain().ok().map(|raw| {
-        let mut end = raw.len();
-        while end > 0 && raw[end.saturating_sub(1)] == 0 {
-            end = end.saturating_sub(1);
-        }
-        String::from_utf8_lossy(&raw[..end]).into_owned()
+        let trimmed = raw
+            .iter()
+            .rposition(|byte| *byte != 0)
+            .and_then(|end| raw.get(..=end))
+            .unwrap_or_default();
+        String::from_utf8_lossy(trimmed).into_owned()
     });
 
     // For cert_type 5: extract fmspc/ca from embedded cert chain
@@ -496,9 +497,7 @@ pub unsafe extern "C" fn dcap_parse_pck_extension_from_pem_cb(
         pce_id: ext.pce_id.to_vec(),
         fmspc: ext.fmspc.to_vec(),
         sgx_type: ext.sgx_type,
-        platform_instance_id: ext
-            .platform_instance_id
-            .map(|v| serde_bytes::ByteBuf::from(v)),
+        platform_instance_id: ext.platform_instance_id.map(serde_bytes::ByteBuf::from),
         raw_extension: ext.raw_extension,
     };
 

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -14,7 +14,7 @@ use crate::{
     utils,
 };
 
-/// Parsed values from the Intel SGX extension.
+/// Parsed values from the Intel SGX extension in a PCK certificate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PckExtension {
     pub ppid: Vec<u8>,
@@ -25,6 +25,15 @@ pub struct PckExtension {
     pub sgx_type: u64,
     pub platform_instance_id: Option<Vec<u8>>,
     pub raw_extension: Vec<u8>,
+    /// Whether the platform can be extended with additional packages
+    /// (Platform CA certs only; `None` for Processor CA certs)
+    pub dynamic_platform: Option<bool>,
+    /// Whether platform root keys are cached by SGX Registration Backend
+    /// (Platform CA certs only; `None` for Processor CA certs)
+    pub cached_keys: Option<bool>,
+    /// Whether SMT (simultaneous multithreading / hyperthreading) is enabled
+    /// (Platform CA certs only; `None` for Processor CA certs)
+    pub smt_enabled: Option<bool>,
 }
 
 impl PckExtension {
@@ -79,6 +88,20 @@ pub fn parse_pck_extension_with<C: Config>(cert_der: &[u8]) -> Result<PckExtensi
     let sgx_type = decode_enumerated(&find_extension_required(&[oids::SGX_TYPE], &extension)?)?;
     let platform_instance_id = find_extension_optional(&[oids::PLATFORM_INSTANCE_ID], &extension)?;
 
+    // Configuration flags (only present in Platform CA certs, under OID 1.2.840.113741.1.13.1.7)
+    let dynamic_platform =
+        find_extension_optional(&[oids::CONFIGURATION, oids::DYNAMIC_PLATFORM], &extension)?
+            .map(|v| decode_boolean(&v))
+            .transpose()?;
+    let cached_keys =
+        find_extension_optional(&[oids::CONFIGURATION, oids::CACHED_KEYS], &extension)?
+            .map(|v| decode_boolean(&v))
+            .transpose()?;
+    let smt_enabled =
+        find_extension_optional(&[oids::CONFIGURATION, oids::SMT_ENABLED], &extension)?
+            .map(|v| decode_boolean(&v))
+            .transpose()?;
+
     Ok(PckExtension {
         ppid,
         cpu_svn,
@@ -88,6 +111,9 @@ pub fn parse_pck_extension_with<C: Config>(cert_der: &[u8]) -> Result<PckExtensi
         sgx_type,
         platform_instance_id,
         raw_extension: extension,
+        dynamic_platform,
+        cached_keys,
+        smt_enabled,
     })
 }
 
@@ -254,6 +280,14 @@ fn find_recursive<'a>(
         }
     }
     Ok(None)
+}
+
+fn decode_boolean(bytes: &[u8]) -> Result<bool> {
+    match bytes[..] {
+        [0x00] => Ok(false),
+        [_] => Ok(true),
+        _ => bail!("Unexpected BOOLEAN length: {}", bytes.len()),
+    }
 }
 
 fn decode_enumerated(bytes: &[u8]) -> Result<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,12 @@ pub struct QuoteCollateralV3 {
     pub pck_certificate_chain: Option<String>,
 }
 
+impl From<&QuoteCollateralV3> for QuoteCollateralV3 {
+    fn from(value: &QuoteCollateralV3) -> Self {
+        value.clone()
+    }
+}
+
 #[cfg(feature = "report")]
 pub mod collateral;
 
@@ -132,11 +138,18 @@ pub mod x509;
 
 mod constants;
 pub mod intel;
-mod qe_identity;
+pub mod policy;
+pub mod qe_identity;
 pub mod tcb_info;
 mod utils;
 
-pub use constants::INTEL_QE_VENDOR_ID;
+pub use constants::{CpuSvn, Fmspc, MrEnclave, MrSigner, Svn, INTEL_QE_VENDOR_ID};
+pub use policy::{
+    PckCertFlag, PckIdentity, PlatformInfo, Policy, QeInfo, QuoteClaims, QuotePolicy,
+    QuotePolicyConfig, TcbVerdict,
+};
+pub use qe_identity::{QeIdentity, QeTcb, QeTcbLevel};
+pub use tcb_info::{Tcb, TcbComponents, TcbInfo, TcbLevel, TcbStatus, TcbStatusWithAdvisory};
 
 pub mod quote;
 pub mod verify;

--- a/src/oids.rs
+++ b/src/oids.rs
@@ -11,5 +11,13 @@ pub const PCEID: ObjectIdentifier = oid("1.2.840.113741.1.13.1.3");
 pub const FMSPC: ObjectIdentifier = oid("1.2.840.113741.1.13.1.4");
 pub const SGX_TYPE: ObjectIdentifier = oid("1.2.840.113741.1.13.1.5");
 pub const PLATFORM_INSTANCE_ID: ObjectIdentifier = oid("1.2.840.113741.1.13.1.6");
+/// Configuration sequence (Platform CA certs only)
+pub const CONFIGURATION: ObjectIdentifier = oid("1.2.840.113741.1.13.1.7");
+/// Whether platform can be extended with additional packages
+pub const DYNAMIC_PLATFORM: ObjectIdentifier = oid("1.2.840.113741.1.13.1.7.1");
+/// Whether platform root keys are cached by SGX Registration Backend
+pub const CACHED_KEYS: ObjectIdentifier = oid("1.2.840.113741.1.13.1.7.2");
+/// Whether platform has SMT (simultaneous multithreading) enabled
+pub const SMT_ENABLED: ObjectIdentifier = oid("1.2.840.113741.1.13.1.7.3");
 pub const PCESVN: ObjectIdentifier = oid("1.2.840.113741.1.13.1.2.17");
 pub const CPUSVN: ObjectIdentifier = oid("1.2.840.113741.1.13.1.2.18");

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,0 +1,191 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use {
+    crate::constants::*,
+    crate::qe_identity::QeTcbLevel,
+    crate::quote::{EnclaveReport, Header, Report},
+    crate::tcb_info::{TcbLevel, TcbStatus},
+    alloc::string::String,
+    alloc::vec::Vec,
+};
+
+#[cfg(feature = "borsh_schema")]
+use borsh::BorshSchema;
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
+mod simple;
+pub use simple::{QuotePolicy, QuotePolicyConfig};
+
+/// Policy trait for customizing quote verification behavior.
+///
+/// Implement this trait to define custom validation logic for [`QuoteClaims`].
+/// The library provides [`QuotePolicy`] as a comprehensive built-in implementation
+/// that covers all common checks from Intel's Appraisal framework.
+///
+/// For most use cases, [`QuotePolicy`] with its builder methods is sufficient:
+/// ```no_run
+/// use dcap_qvl::QuotePolicy;
+/// use dcap_qvl::TcbStatus;
+/// use core::time::Duration;
+///
+/// let now_unix_secs = 1_700_000_000u64;
+///
+/// let policy = QuotePolicy::strict(now_unix_secs)
+///     .allow_status(TcbStatus::SWHardeningNeeded)
+///     .collateral_grace_period(Duration::from_secs(90 * 24 * 3600))
+///     .reject_advisory("INTEL-SA-00334");
+/// ```
+///
+/// Implement this trait directly only for logic that [`QuotePolicy`] cannot express.
+pub trait Policy {
+    /// Validate verified quote claims against this policy.
+    ///
+    /// Return `Ok(())` to accept, or `Err(...)` to reject.
+    fn validate(&self, data: &QuoteClaims) -> Result<()>;
+}
+
+/// PCK certificate flag, matching Intel's `pck_cert_flag_enum_t`.
+///
+/// These flags are only present in PCK certificates issued by the **Platform CA**.
+/// For Processor CA certificates, the value is [`Undefined`](PckCertFlag::Undefined).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
+#[cfg_attr(feature = "borsh", borsh(use_discriminant = true))]
+pub enum PckCertFlag {
+    /// The flag is explicitly false (ASN.1 BOOLEAN FALSE).
+    False = 0,
+    /// The flag is explicitly true (ASN.1 BOOLEAN TRUE).
+    True = 1,
+    /// The flag is not present in the certificate (Processor CA certs).
+    Undefined = 2,
+}
+
+impl From<Option<bool>> for PckCertFlag {
+    fn from(v: Option<bool>) -> Self {
+        match v {
+            Some(true) => PckCertFlag::True,
+            Some(false) => PckCertFlag::False,
+            None => PckCertFlag::Undefined,
+        }
+    }
+}
+
+/// Detailed, serializable claims produced by cryptographic quote verification.
+///
+/// Organized into structured sub-groups:
+/// - [`tcb`](Self::tcb): Merged TCB verdict
+/// - [`platform`](Self::platform): Platform-level details from PCK certificate and TCB matching
+/// - [`qe`](Self::qe): QE (Quoting Enclave) verification results
+///
+/// Also includes the collateral time window (8 sources: TCBInfo, QEIdentity, 2 CRLs,
+/// 4 certificate chains) and the quote report body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteClaims {
+    /// Version of this claims schema.
+    pub claims_version: u16,
+    /// Authenticated quote header, including quote version, key type, TEE type,
+    /// QE/PCE SVN, QE vendor ID, and user data.
+    pub header: Header,
+    /// TEE type: `0x00000000` for SGX, `0x00000081` for TDX.
+    pub tee_type: u32,
+    /// Merged TCB verdict (worst of platform + QE).
+    pub tcb: TcbVerdict,
+    /// Platform verification details.
+    pub platform: PlatformInfo,
+    /// QE verification details.
+    pub qe: QeInfo,
+    /// `min(issueDate / thisUpdate / notBefore)` across all 8 collateral sources.
+    pub earliest_issue_date: u64,
+    /// `max(issueDate / thisUpdate / notBefore)` across all 8 collateral sources.
+    pub latest_issue_date: u64,
+    /// `min(nextUpdate / notAfter)` across all 8 collateral sources (the "weakest link").
+    pub earliest_expiration_date: u64,
+    /// `min(issueDate / notBefore)` across QE Identity sources (issuer chain + JSON).
+    pub qe_iden_earliest_issue_date: u64,
+    /// `max(issueDate / notBefore)` across QE Identity sources (issuer chain + JSON).
+    pub qe_iden_latest_issue_date: u64,
+    /// `min(nextUpdate / notAfter)` across QE Identity sources (issuer chain + JSON).
+    pub qe_iden_earliest_expiration_date: u64,
+    /// Quote report body (SGX enclave report, TDX TD10/TD15).
+    pub report: Report,
+}
+
+/// Merged TCB verdict from platform and QE status convergence.
+///
+/// Uses Intel's `convergeTcbStatusWithQeTcbStatus` logic to produce the
+/// worst-case status and union of advisory IDs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TcbVerdict {
+    /// Merged TCB status (worst of platform TCB + QE TCB).
+    pub status: TcbStatus,
+    /// Merged advisory IDs (union of platform + QE advisories).
+    pub advisory_ids: Vec<String>,
+    /// Lower of TCBInfo and QEIdentity `tcbEvaluationDataNumber` values.
+    pub eval_data_number: u32,
+}
+
+/// Platform-level verification results.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformInfo {
+    /// The matched platform TCB level (unmerged).
+    pub tcb_level: TcbLevel,
+    /// Platform TCB level date as unix timestamp (precomputed from `tcb_level.tcb_date`).
+    pub tcb_date_tag: u64,
+    /// PCK certificate identity fields.
+    pub pck: PckIdentity,
+    /// SHA-384 of root CA's raw public key bytes, matching Intel's `root_key_id`.
+    pub root_key_id: Vec<u8>,
+    /// CRL number from PCK Certificate Revocation List.
+    pub pck_crl_num: u32,
+    /// CRL number from Root CA Certificate Revocation List.
+    pub root_ca_crl_num: u32,
+}
+
+/// QE (Quoting Enclave) verification results.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QeInfo {
+    /// The matched QE TCB level (unmerged).
+    pub tcb_level: QeTcbLevel,
+    /// The QE's enclave report.
+    pub report: EnclaveReport,
+    /// TCB evaluation data number from QE Identity (unmerged).
+    pub tcb_eval_data_number: u32,
+}
+
+/// PCK certificate identity fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PckIdentity {
+    /// Platform Provisioning ID (PPID).
+    pub ppid: Vec<u8>,
+    /// CPU Security Version Number (16 bytes).
+    pub cpu_svn: CpuSvn,
+    /// PCE ISV Security Version Number.
+    pub pce_svn: Svn,
+    /// PCE ID (raw value from the PCK certificate SGX extension).
+    pub pce_id: Vec<u8>,
+    /// FMSPC (6 bytes).
+    pub fmspc: Fmspc,
+    /// SGX type: 0=Standard, 1=Scalable, 2=ScalableWithIntegrity.
+    pub sgx_type: u8,
+    /// Platform Instance ID (16 bytes, Platform CA only).
+    pub platform_instance_id: Option<[u8; 16]>,
+    /// Dynamic platform flag.
+    pub dynamic_platform: PckCertFlag,
+    /// Cached keys flag.
+    pub cached_keys: PckCertFlag,
+    /// SMT (hyperthreading) flag.
+    pub smt_enabled: PckCertFlag,
+    /// Platform Provider ID (Platform CA only).
+    ///
+    /// Note: Intel's upstream appraisal schema includes this field, but the
+    /// upstream QvE measurement producer currently leaves it unpopulated
+    /// (`//obj_plat_tcb.AddMember("platform_provider_id", , allocator);`).
+    ///
+    /// Upstream references:
+    /// - QvE TODO:
+    ///   <https://github.com/intel/confidential-computing.tee.dcap/blob/main/ae/QvE/qve/qve.cpp>
+    pub platform_provider_id: Option<String>,
+}

--- a/src/policy/simple.rs
+++ b/src/policy/simple.rs
@@ -1,0 +1,856 @@
+use core::time::Duration;
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+use {
+    super::{PckCertFlag, Policy, QuoteClaims},
+    crate::tcb_info::TcbStatus,
+    crate::utils::parse_rfc3339_unix_secs,
+    alloc::string::String,
+    alloc::vec::Vec,
+};
+
+/// Built-in verification policy with builder pattern.
+///
+/// Covers common appraisal checks without embedding a policy engine.
+/// without requiring a Rego engine. Strict by default: only `UpToDate`,
+/// no grace period, no advisory blacklist.
+///
+/// # Example
+/// ```no_run
+/// use dcap_qvl::QuotePolicy;
+/// use dcap_qvl::TcbStatus;
+///
+/// let now = 1_700_000_000u64; // unix timestamp
+///
+/// // Strict: only UpToDate, collateral must not be expired
+/// let policy = QuotePolicy::strict(now);
+///
+/// // With 90-day collateral grace period
+/// use core::time::Duration;
+/// let policy = QuotePolicy::strict(now)
+///     .allow_status(TcbStatus::SWHardeningNeeded)
+///     .collateral_grace_period(Duration::from_secs(90 * 24 * 3600))
+///     .reject_advisory("INTEL-SA-00334");
+/// ```
+#[derive(Clone, Debug)]
+pub struct QuotePolicy {
+    claims_only: bool,
+    acceptable_statuses: u8,
+
+    // Current time + grace periods (mutually exclusive, default 0 = no tolerance)
+    now: u64,
+    collateral_grace_period: u64,
+    platform_grace_period: u64,
+    qe_grace_period: u64,
+
+    // TCB evaluation
+    min_tcb_eval_data_number: Option<u32>,
+
+    // Advisory blacklist (quote is rejected if any advisory is in this set)
+    rejected_advisory_ids: Vec<String>,
+
+    // Platform flags (default false = reject if True)
+    allow_dynamic_platform: bool,
+    allow_cached_keys: bool,
+    allow_smt: bool,
+
+    // SGX type whitelist (None = skip check)
+    accepted_sgx_types: Option<Vec<u8>>,
+}
+
+impl QuotePolicy {
+    const UP_TO_DATE: u8 = 1 << 0;
+    const SW_HARDENING_NEEDED: u8 = 1 << 1;
+    const CONFIGURATION_NEEDED: u8 = 1 << 2;
+    const CONFIGURATION_AND_SW_HARDENING_NEEDED: u8 = 1 << 3;
+    const OUT_OF_DATE: u8 = 1 << 4;
+    const OUT_OF_DATE_CONFIGURATION_NEEDED: u8 = 1 << 5;
+
+    fn status_to_flag(status: TcbStatus) -> u8 {
+        match status {
+            TcbStatus::UpToDate => Self::UP_TO_DATE,
+            TcbStatus::SWHardeningNeeded => Self::SW_HARDENING_NEEDED,
+            TcbStatus::ConfigurationNeeded => Self::CONFIGURATION_NEEDED,
+            TcbStatus::ConfigurationAndSWHardeningNeeded => {
+                Self::CONFIGURATION_AND_SW_HARDENING_NEEDED
+            }
+            TcbStatus::OutOfDate => Self::OUT_OF_DATE,
+            TcbStatus::OutOfDateConfigurationNeeded => Self::OUT_OF_DATE_CONFIGURATION_NEEDED,
+            TcbStatus::Revoked => 0,
+        }
+    }
+
+    fn new_with_statuses(now: u64, acceptable_statuses: u8) -> Self {
+        Self {
+            claims_only: false,
+            acceptable_statuses,
+            now,
+            collateral_grace_period: 0,
+            platform_grace_period: 0,
+            qe_grace_period: 0,
+            min_tcb_eval_data_number: None,
+            rejected_advisory_ids: Vec::new(),
+            allow_dynamic_platform: false,
+            allow_cached_keys: false,
+            allow_smt: false,
+            accepted_sgx_types: None,
+        }
+    }
+
+    /// Create a strict policy: only `UpToDate` status is accepted,
+    /// no grace period, no advisory blacklist.
+    pub fn strict(now_secs: u64) -> Self {
+        Self::new_with_statuses(now_secs, Self::UP_TO_DATE)
+    }
+
+    /// Create a policy that only supplies the trusted verification time.
+    ///
+    /// Use this when policy appraisal is performed by a downstream engine.
+    pub fn claims_only(now_secs: u64) -> Self {
+        let mut policy = Self::new_with_statuses(now_secs, 0);
+        policy.claims_only = true;
+        policy
+    }
+
+    /// Allow an additional TCB status.
+    pub fn allow_status(mut self, status: TcbStatus) -> Self {
+        self.acceptable_statuses |= Self::status_to_flag(status);
+        self
+    }
+
+    /// Set collateral grace period (default: zero). Accepts quotes where
+    /// `earliest_expiration_date + grace_period >= now`.
+    pub fn collateral_grace_period(mut self, duration: Duration) -> Self {
+        self.collateral_grace_period = duration.as_secs();
+        self
+    }
+
+    /// Set platform grace period (default: zero). When TCB status is
+    /// OutOfDate or OutOfDateConfigurationNeeded, accepts quotes where
+    /// `tcb_level_date_tag + grace_period >= now`. Skipped for UpToDate/ConfigNeeded/SWHardening.
+    pub fn platform_grace_period(mut self, duration: Duration) -> Self {
+        self.platform_grace_period = duration.as_secs();
+        self
+    }
+
+    /// Set QE grace period (default: zero). When QE TCB status is `OutOfDate`,
+    /// accepts quotes where `qe_tcb_level.tcb_date + grace_period >= now`.
+    pub fn qe_grace_period(mut self, duration: Duration) -> Self {
+        self.qe_grace_period = duration.as_secs();
+        self
+    }
+
+    /// Set minimum TCB evaluation data number. Rejects quotes with
+    /// `tcb_eval_data_number` below this threshold.
+    pub fn min_tcb_eval_data_number(mut self, min: u32) -> Self {
+        self.min_tcb_eval_data_number = Some(min);
+        self
+    }
+
+    /// Reject a specific advisory ID. Quotes containing any advisory in the
+    /// rejected set fail validation. By default the set is empty, allowing all
+    /// advisory IDs.
+    pub fn reject_advisory(mut self, id: impl Into<String>) -> Self {
+        self.rejected_advisory_ids.push(id.into());
+        self
+    }
+
+    /// Reject multiple advisory IDs at once.
+    pub fn reject_advisories(mut self, ids: &[impl AsRef<str>]) -> Self {
+        self.rejected_advisory_ids
+            .extend(ids.iter().map(|id| id.as_ref().to_string()));
+        self
+    }
+
+    /// Set whether dynamic platforms are allowed. If `false` (default), rejects
+    /// quotes where `dynamic_platform` is `True`.
+    pub fn allow_dynamic_platform(mut self, allow: bool) -> Self {
+        self.allow_dynamic_platform = allow;
+        self
+    }
+
+    /// Set whether cached keys are allowed. If `false` (default), rejects
+    /// quotes where `cached_keys` is `True`.
+    pub fn allow_cached_keys(mut self, allow: bool) -> Self {
+        self.allow_cached_keys = allow;
+        self
+    }
+
+    /// Set whether SMT (simultaneous multithreading / hyperthreading) is allowed.
+    /// If `false` (default), rejects quotes where `smt_enabled` is `True`.
+    pub fn allow_smt(mut self, allow: bool) -> Self {
+        self.allow_smt = allow;
+        self
+    }
+
+    /// Set accepted SGX types (0=Standard, 1=Scalable, 2=ScalableWithIntegrity).
+    /// Rejects quotes with `sgx_type` not in this list. Default: skip check.
+    pub fn accepted_sgx_types(mut self, types: &[u8]) -> Self {
+        self.accepted_sgx_types = Some(types.to_vec());
+        self
+    }
+
+    /// Check if a TCB status is acceptable according to this policy.
+    pub fn is_status_acceptable(&self, status: TcbStatus) -> bool {
+        let flag = Self::status_to_flag(status);
+        (self.acceptable_statuses & flag) != 0
+    }
+}
+
+impl Policy for QuotePolicy {
+    fn validate(&self, data: &QuoteClaims) -> Result<()> {
+        if self.claims_only {
+            return Ok(());
+        }
+        fn within_grace(date_tag: u64, grace_period: u64, now: u64) -> bool {
+            date_tag.saturating_add(grace_period) >= now
+        }
+
+        fn advisory_rejected(rejected_advisory_ids: &[String], id: &str) -> bool {
+            rejected_advisory_ids
+                .iter()
+                .any(|a| a.eq_ignore_ascii_case(id))
+        }
+
+        // 1. TCB status whitelist
+        if !self.is_status_acceptable(data.tcb.status) {
+            bail!(
+                "TCB status {:?} is not acceptable by policy",
+                data.tcb.status
+            );
+        }
+
+        // 3. Collateral expiration: earliest_expiration + grace >= now
+        if data
+            .earliest_expiration_date
+            .saturating_add(self.collateral_grace_period)
+            < self.now
+        {
+            bail!(
+                "Collateral expired: earliest_expiration {} + grace {} < now {}",
+                data.earliest_expiration_date,
+                self.collateral_grace_period,
+                self.now
+            );
+        }
+
+        // 4. Platform TCB freshness: platform tcb_date_tag + grace >= now.
+        let platform_is_out_of_date = matches!(
+            data.platform.tcb_level.tcb_status,
+            TcbStatus::OutOfDate | TcbStatus::OutOfDateConfigurationNeeded
+        );
+        let platform_in_grace = platform_is_out_of_date
+            && within_grace(
+                data.platform.tcb_date_tag,
+                self.platform_grace_period,
+                self.now,
+            );
+        if platform_is_out_of_date && !platform_in_grace {
+            bail!(
+                "Platform TCB too old: tcb_date_tag {} + grace {} < now {}",
+                data.platform.tcb_date_tag,
+                self.platform_grace_period,
+                self.now
+            );
+        }
+
+        // 4b. QE TCB freshness: QE tcb_date + grace >= now.
+        let qe_tcb_date_tag = parse_rfc3339_unix_secs(&data.qe.tcb_level.tcb_date)
+            .map_err(|e| anyhow::anyhow!("Failed to parse QE TCB date: {e}"))?;
+        let qe_is_out_of_date = data.qe.tcb_level.tcb_status == TcbStatus::OutOfDate;
+        let qe_in_grace =
+            qe_is_out_of_date && within_grace(qe_tcb_date_tag, self.qe_grace_period, self.now);
+        if qe_is_out_of_date && !qe_in_grace {
+            bail!(
+                "QE TCB too old: tcb_date_tag {} + grace {} < now {}",
+                qe_tcb_date_tag,
+                self.qe_grace_period,
+                self.now
+            );
+        }
+
+        // 2. Advisory ID blacklist.
+        for id in &data.platform.tcb_level.advisory_ids {
+            if advisory_rejected(&self.rejected_advisory_ids, id) {
+                bail!("Advisory ID {id} is rejected by policy");
+            }
+        }
+        for id in &data.qe.tcb_level.advisory_ids {
+            if advisory_rejected(&self.rejected_advisory_ids, id) {
+                bail!("Advisory ID {id} is rejected by policy");
+            }
+        }
+
+        // 5. Minimum TCB evaluation data number
+        if let Some(min) = self.min_tcb_eval_data_number {
+            if data.tcb.eval_data_number < min {
+                bail!(
+                    "TCB eval data number {} is below minimum {}",
+                    data.tcb.eval_data_number,
+                    min
+                );
+            }
+        }
+
+        // 6. Dynamic platform flag
+        if !self.allow_dynamic_platform && data.platform.pck.dynamic_platform == PckCertFlag::True {
+            bail!("Dynamic platform is not allowed by policy");
+        }
+
+        // 7. Cached keys flag
+        if !self.allow_cached_keys && data.platform.pck.cached_keys == PckCertFlag::True {
+            bail!("Cached keys are not allowed by policy");
+        }
+
+        // 8. SMT flag
+        if !self.allow_smt && data.platform.pck.smt_enabled == PckCertFlag::True {
+            bail!("SMT (hyperthreading) is not allowed by policy");
+        }
+
+        // 9. SGX type whitelist
+        if let Some(ref types) = self.accepted_sgx_types {
+            if !types.contains(&data.platform.pck.sgx_type) {
+                bail!(
+                    "SGX type {} is not in accepted types {:?}",
+                    data.platform.pck.sgx_type,
+                    types
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// JSON-serializable configuration for [`QuotePolicy`].
+///
+/// All fields default to the strict values (zero / empty / false).
+/// Pass as JSON from FFI (Go, Python) to configure verification policy.
+///
+/// ```json
+/// {
+///   "allowed_statuses": ["UpToDate", "SWHardeningNeeded"],
+///   "rejected_advisory_ids": ["INTEL-SA-00334"],
+///   "collateral_grace_period_secs": 2592000,
+///   "allow_smt": true
+/// }
+/// ```
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct QuotePolicyConfig {
+    #[serde(default)]
+    pub allowed_statuses: Vec<TcbStatus>,
+    #[serde(default)]
+    pub rejected_advisory_ids: Vec<String>,
+    #[serde(default)]
+    pub collateral_grace_period_secs: u64,
+    #[serde(default)]
+    pub platform_grace_period_secs: u64,
+    #[serde(default)]
+    pub qe_grace_period_secs: u64,
+    #[serde(default)]
+    pub min_tcb_eval_data_number: u32,
+    #[serde(default)]
+    pub allow_dynamic_platform: bool,
+    #[serde(default)]
+    pub allow_cached_keys: bool,
+    #[serde(default)]
+    pub allow_smt: bool,
+    #[serde(default)]
+    pub accepted_sgx_types: Option<Vec<u8>>,
+}
+
+impl QuotePolicyConfig {
+    /// Build a [`QuotePolicy`] from this config + current timestamp.
+    ///
+    /// Default config (all fields zero/empty) produces `QuotePolicy::strict(now)`.
+    pub fn into_policy(self, now_secs: u64) -> QuotePolicy {
+        let mut policy = if self.allowed_statuses.is_empty() {
+            QuotePolicy::strict(now_secs)
+        } else {
+            let mut p = QuotePolicy::new_with_statuses(now_secs, 0);
+            for status in self.allowed_statuses {
+                p = p.allow_status(status);
+            }
+            p
+        };
+        for id in self.rejected_advisory_ids {
+            policy = policy.reject_advisory(id);
+        }
+        if self.collateral_grace_period_secs > 0 {
+            policy = policy
+                .collateral_grace_period(Duration::from_secs(self.collateral_grace_period_secs));
+        }
+        if self.platform_grace_period_secs > 0 {
+            policy =
+                policy.platform_grace_period(Duration::from_secs(self.platform_grace_period_secs));
+        }
+        if self.qe_grace_period_secs > 0 {
+            policy = policy.qe_grace_period(Duration::from_secs(self.qe_grace_period_secs));
+        }
+        if self.min_tcb_eval_data_number > 0 {
+            policy = policy.min_tcb_eval_data_number(self.min_tcb_eval_data_number);
+        }
+        policy = policy.allow_dynamic_platform(self.allow_dynamic_platform);
+        policy = policy.allow_cached_keys(self.allow_cached_keys);
+        policy = policy.allow_smt(self.allow_smt);
+        if let Some(types) = self.accepted_sgx_types {
+            policy = policy.accepted_sgx_types(&types);
+        }
+        policy
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::policy::{PckIdentity, PlatformInfo, QeInfo, TcbVerdict};
+    use crate::tcb_info::TcbStatus::*;
+
+    fn make_test_claims(tcb_status: TcbStatus) -> QuoteClaims {
+        use crate::qe_identity::{QeTcb, QeTcbLevel};
+        use crate::tcb_info::{Tcb, TcbComponents, TcbLevel};
+
+        QuoteClaims {
+            claims_version: 1,
+            header: crate::quote::Header {
+                version: 3,
+                attestation_key_type: 2,
+                tee_type: 0,
+                qe_svn: 0,
+                pce_svn: 0,
+                qe_vendor_id: [0; 16],
+                user_data: [0; 20],
+            },
+            tee_type: 0,
+            tcb: TcbVerdict {
+                status: tcb_status,
+                advisory_ids: vec![],
+                eval_data_number: 17,
+            },
+            platform: PlatformInfo {
+                tcb_level: TcbLevel {
+                    tcb: Tcb {
+                        sgx_components: vec![TcbComponents { svn: 0 }; 16],
+                        tdx_components: vec![],
+                        pce_svn: 13,
+                    },
+                    tcb_date: "2023-07-22T00:00:00Z".to_string(),
+                    tcb_status,
+                    advisory_ids: vec![],
+                },
+                tcb_date_tag: 1_690_000_000, // ~2023-07-22
+                pck: PckIdentity {
+                    ppid: vec![0u8; 16],
+                    cpu_svn: [0u8; 16],
+                    pce_svn: 13,
+                    pce_id: vec![0u8; 2],
+                    fmspc: [0u8; 6],
+                    sgx_type: 0,
+                    platform_instance_id: None,
+                    dynamic_platform: PckCertFlag::Undefined,
+                    cached_keys: PckCertFlag::Undefined,
+                    smt_enabled: PckCertFlag::Undefined,
+                    platform_provider_id: None,
+                },
+                root_key_id: vec![0u8; 48],
+                pck_crl_num: 1,
+                root_ca_crl_num: 1,
+            },
+            qe: QeInfo {
+                tcb_level: QeTcbLevel {
+                    tcb: QeTcb { isvsvn: 8 },
+                    tcb_date: "2024-03-13T00:00:00Z".to_string(),
+                    tcb_status: UpToDate,
+                    advisory_ids: vec![],
+                },
+                report: crate::quote::EnclaveReport {
+                    cpu_svn: [0u8; 16],
+                    misc_select: 0,
+                    reserved1: [0u8; 28],
+                    attributes: [0u8; 16],
+                    mr_enclave: [0u8; 32],
+                    reserved2: [0u8; 32],
+                    mr_signer: [0u8; 32],
+                    reserved3: [0u8; 96],
+                    isv_prod_id: 1,
+                    isv_svn: 8,
+                    reserved4: [0u8; 60],
+                    report_data: [0u8; 64],
+                },
+                tcb_eval_data_number: 17,
+            },
+            report: crate::quote::Report::SgxEnclave(crate::quote::EnclaveReport {
+                cpu_svn: [0u8; 16],
+                misc_select: 0,
+                reserved1: [0u8; 28],
+                attributes: [0u8; 16],
+                mr_enclave: [0u8; 32],
+                reserved2: [0u8; 32],
+                mr_signer: [0u8; 32],
+                reserved3: [0u8; 96],
+                isv_prod_id: 0,
+                isv_svn: 0,
+                reserved4: [0u8; 60],
+                report_data: [0u8; 64],
+            }),
+            earliest_issue_date: 1_690_000_000,
+            latest_issue_date: 1_690_100_000,
+            earliest_expiration_date: 1_703_000_000, // ~2023-12-19
+            qe_iden_earliest_issue_date: 1_690_000_000,
+            qe_iden_latest_issue_date: 1_690_100_000,
+            qe_iden_earliest_expiration_date: 1_703_000_000,
+        }
+    }
+
+    // -- TCB status checks --
+
+    #[test]
+    fn policy_strict_accepts_up_to_date() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_702_000_000); // within collateral window
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_strict_rejects_sw_hardening() {
+        let data = make_test_claims(SWHardeningNeeded);
+        let policy = QuotePolicy::strict(1_702_000_000);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("TCB status"), "{err}");
+    }
+
+    #[test]
+    fn policy_out_of_date_with_fresh_tcb_date_accepts() {
+        let mut data = make_test_claims(OutOfDate);
+        data.platform.tcb_date_tag = 1_702_000_000;
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(OutOfDate);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_allow_status_builder() {
+        let data = make_test_claims(SWHardeningNeeded);
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(SWHardeningNeeded);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- Advisory ID blacklist --
+
+    #[test]
+    fn policy_allows_advisory_when_not_blacklisted() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_rejects_blacklisted_advisory() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000).reject_advisory("INTEL-SA-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_advisory_blacklist_case_insensitive() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000).reject_advisory("intel-sa-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_reject_advisories_batch() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00820".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00820".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .reject_advisories(&["INTEL-SA-00615", "INTEL-SA-00820"]);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00820"), "{err}");
+    }
+
+    #[test]
+    fn policy_empty_advisories_passes() {
+        let data = make_test_claims(UpToDate);
+        assert!(data.tcb.advisory_ids.is_empty());
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- Collateral grace period --
+
+    #[test]
+    fn policy_collateral_expired_no_grace_rejects() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_704_000_000);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Collateral expired"), "{err}");
+    }
+
+    #[test]
+    fn policy_collateral_expired_with_grace_accepts() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_704_000_000)
+            .collateral_grace_period(Duration::from_secs(2_000_000));
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_collateral_expired_grace_too_short_rejects() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_704_000_000)
+            .collateral_grace_period(Duration::from_secs(500_000));
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Collateral expired"), "{err}");
+    }
+
+    #[test]
+    fn policy_collateral_not_expired_zero_grace_passes() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- Platform grace period --
+
+    #[test]
+    fn policy_platform_grace_skipped_for_up_to_date() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_platform_grace_skipped_for_sw_hardening() {
+        let data = make_test_claims(SWHardeningNeeded);
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(SWHardeningNeeded);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_platform_grace_skipped_for_config_needed() {
+        let data = make_test_claims(ConfigurationNeeded);
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(ConfigurationNeeded);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_platform_grace_checked_for_out_of_date_rejects() {
+        let data = make_test_claims(OutOfDate);
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(OutOfDate);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Platform TCB too old"), "{err}");
+    }
+
+    #[test]
+    fn policy_platform_grace_checked_for_out_of_date_accepts_with_grace() {
+        let data = make_test_claims(OutOfDate);
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDate)
+            .platform_grace_period(Duration::from_secs(13_000_000));
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_platform_grace_too_short_rejects() {
+        let data = make_test_claims(OutOfDate);
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDate)
+            .platform_grace_period(Duration::from_secs(11_000_000));
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Platform TCB too old"), "{err}");
+    }
+
+    #[test]
+    fn policy_platform_grace_checked_for_out_of_date_config_needed() {
+        let data = make_test_claims(OutOfDateConfigurationNeeded);
+        let policy = QuotePolicy::strict(1_702_000_000).allow_status(OutOfDateConfigurationNeeded);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Platform TCB too old"), "{err}");
+    }
+
+    // -- min_tcb_eval_data_number --
+
+    #[test]
+    fn policy_min_eval_num_rejects_below() {
+        let data = make_test_claims(UpToDate);
+        assert_eq!(data.tcb.eval_data_number, 17);
+        let policy = QuotePolicy::strict(1_702_000_000).min_tcb_eval_data_number(20);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("below minimum"), "{err}");
+    }
+
+    #[test]
+    fn policy_min_eval_num_accepts_equal() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_702_000_000).min_tcb_eval_data_number(17);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- Platform flags --
+
+    #[test]
+    fn policy_rejects_dynamic_platform_true() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.dynamic_platform = PckCertFlag::True;
+        let policy = QuotePolicy::strict(1_702_000_000);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Dynamic platform"), "{err}");
+    }
+
+    #[test]
+    fn policy_allows_dynamic_platform_when_configured() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.dynamic_platform = PckCertFlag::True;
+        let policy = QuotePolicy::strict(1_702_000_000).allow_dynamic_platform(true);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_undefined_platform_flags_pass() {
+        let data = make_test_claims(UpToDate);
+        assert_eq!(data.platform.pck.dynamic_platform, PckCertFlag::Undefined);
+        assert_eq!(data.platform.pck.cached_keys, PckCertFlag::Undefined);
+        assert_eq!(data.platform.pck.smt_enabled, PckCertFlag::Undefined);
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_rejects_smt_true() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.smt_enabled = PckCertFlag::True;
+        let policy = QuotePolicy::strict(1_702_000_000);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("SMT"), "{err}");
+    }
+
+    #[test]
+    fn policy_rejects_cached_keys_true() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.cached_keys = PckCertFlag::True;
+        let policy = QuotePolicy::strict(1_702_000_000);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("Cached keys"), "{err}");
+    }
+
+    // -- SGX type whitelist --
+
+    #[test]
+    fn policy_sgx_type_not_configured_passes() {
+        let data = make_test_claims(UpToDate);
+        let policy = QuotePolicy::strict(1_702_000_000);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    #[test]
+    fn policy_sgx_type_whitelist_rejects() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.sgx_type = 1;
+        let policy = QuotePolicy::strict(1_702_000_000).accepted_sgx_types(&[0]);
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("SGX type"), "{err}");
+    }
+
+    #[test]
+    fn policy_sgx_type_whitelist_accepts() {
+        let mut data = make_test_claims(UpToDate);
+        data.platform.pck.sgx_type = 1;
+        let policy = QuotePolicy::strict(1_702_000_000).accepted_sgx_types(&[0, 1, 2]);
+        assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- Advisory blacklist during grace --
+
+    #[test]
+    fn policy_blacklist_checked_during_collateral_grace() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_704_000_000)
+            .collateral_grace_period(Duration::from_secs(2_000_000))
+            .reject_advisory("INTEL-SA-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_blacklist_checked_during_platform_grace() {
+        let mut data = make_test_claims(OutOfDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDate)
+            .platform_grace_period(Duration::from_secs(13_000_000))
+            .reject_advisory("INTEL-SA-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_blacklist_checked_for_out_of_date_config_needed() {
+        let mut data = make_test_claims(OutOfDateConfigurationNeeded);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDateConfigurationNeeded)
+            .platform_grace_period(Duration::from_secs(13_000_000))
+            .reject_advisory("INTEL-SA-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_blacklist_checked_without_grace() {
+        let mut data = make_test_claims(UpToDate);
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        let policy = QuotePolicy::strict(1_702_000_000).reject_advisory("INTEL-SA-00615");
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("INTEL-SA-00615"), "{err}");
+    }
+
+    #[test]
+    fn policy_platform_grace_does_not_cover_qe_out_of_date() {
+        let mut data = make_test_claims(OutOfDate);
+        data.platform.tcb_level.tcb_status = UpToDate;
+        data.platform.tcb_level.advisory_ids = vec![];
+        data.platform.tcb_date_tag = 1_702_000_000;
+        data.qe.tcb_level.tcb_status = OutOfDate;
+        data.qe.tcb_level.tcb_date = "2023-07-22T00:00:00Z".to_string();
+        data.qe.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDate)
+            .platform_grace_period(Duration::from_secs(13_000_000));
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("QE TCB too old"), "{err}");
+    }
+
+    #[test]
+    fn policy_qe_grace_accepts_qe_out_of_date() {
+        let mut data = make_test_claims(OutOfDate);
+        data.platform.tcb_level.tcb_status = UpToDate;
+        data.platform.tcb_level.advisory_ids = vec![];
+        data.qe.tcb_level.tcb_status = OutOfDate;
+        data.qe.tcb_level.tcb_date = "2023-07-22T00:00:00Z".to_string();
+        data.qe.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
+
+        let policy = QuotePolicy::strict(1_702_000_000)
+            .allow_status(OutOfDate)
+            .qe_grace_period(Duration::from_secs(13_000_000));
+        assert!(policy.validate(&data).is_ok());
+    }
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,12 +3,15 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3_async_runtimes::tokio::future_into_py;
 use serde_json;
+use std::time::Duration;
 
 use crate::{
     collateral::CollateralClient,
     intel,
+    policy::{QuoteClaims, QuotePolicy},
     quote::{EnclaveReport, Header, Quote, Report, TDReport10, TDReport15},
-    verify::{verify, VerifiedReport},
+    tcb_info::TcbStatus,
+    verify::{QuoteVerifier, VerifiedReport},
     QuoteCollateralV3,
 };
 
@@ -538,6 +541,154 @@ impl PyQuote {
     }
 }
 
+#[pyclass(from_py_object)]
+#[derive(Clone)]
+pub struct PyQuotePolicy {
+    inner: QuotePolicy,
+}
+
+fn parse_tcb_status(value: &str) -> PyResult<TcbStatus> {
+    match value {
+        "UpToDate" => Ok(TcbStatus::UpToDate),
+        "SWHardeningNeeded" => Ok(TcbStatus::SWHardeningNeeded),
+        "ConfigurationNeeded" => Ok(TcbStatus::ConfigurationNeeded),
+        "ConfigurationAndSWHardeningNeeded" => Ok(TcbStatus::ConfigurationAndSWHardeningNeeded),
+        "OutOfDate" => Ok(TcbStatus::OutOfDate),
+        "OutOfDateConfigurationNeeded" => Ok(TcbStatus::OutOfDateConfigurationNeeded),
+        "Revoked" => Ok(TcbStatus::Revoked),
+        _ => Err(PyValueError::new_err(format!(
+            "Unknown TCB status: {value}"
+        ))),
+    }
+}
+
+#[pymethods]
+impl PyQuotePolicy {
+    #[staticmethod]
+    fn strict(now_secs: u64) -> Self {
+        Self {
+            inner: QuotePolicy::strict(now_secs),
+        }
+    }
+
+    #[staticmethod]
+    fn claims_only(now_secs: u64) -> Self {
+        Self {
+            inner: QuotePolicy::claims_only(now_secs),
+        }
+    }
+    fn allow_status(&self, status: &str) -> PyResult<Self> {
+        Ok(Self {
+            inner: self.inner.clone().allow_status(parse_tcb_status(status)?),
+        })
+    }
+    fn reject_advisory(&self, id: &str) -> Self {
+        Self {
+            inner: self.inner.clone().reject_advisory(id),
+        }
+    }
+    fn reject_advisories(&self, ids: Vec<String>) -> Self {
+        Self {
+            inner: self.inner.clone().reject_advisories(&ids),
+        }
+    }
+    fn collateral_grace_period(&self, secs: u64) -> Self {
+        Self {
+            inner: self
+                .inner
+                .clone()
+                .collateral_grace_period(Duration::from_secs(secs)),
+        }
+    }
+    fn platform_grace_period(&self, secs: u64) -> Self {
+        Self {
+            inner: self
+                .inner
+                .clone()
+                .platform_grace_period(Duration::from_secs(secs)),
+        }
+    }
+    fn qe_grace_period(&self, secs: u64) -> Self {
+        Self {
+            inner: self
+                .inner
+                .clone()
+                .qe_grace_period(Duration::from_secs(secs)),
+        }
+    }
+    fn min_tcb_eval_data_number(&self, value: u32) -> Self {
+        Self {
+            inner: self.inner.clone().min_tcb_eval_data_number(value),
+        }
+    }
+    fn allow_dynamic_platform(&self, value: bool) -> Self {
+        Self {
+            inner: self.inner.clone().allow_dynamic_platform(value),
+        }
+    }
+    fn allow_cached_keys(&self, value: bool) -> Self {
+        Self {
+            inner: self.inner.clone().allow_cached_keys(value),
+        }
+    }
+    fn allow_smt(&self, value: bool) -> Self {
+        Self {
+            inner: self.inner.clone().allow_smt(value),
+        }
+    }
+    fn accepted_sgx_types(&self, values: Vec<u8>) -> Self {
+        Self {
+            inner: self.inner.clone().accepted_sgx_types(&values),
+        }
+    }
+}
+
+#[pyclass]
+pub struct PyQuoteClaims {
+    inner: QuoteClaims,
+}
+
+#[pymethods]
+impl PyQuoteClaims {
+    fn to_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner)
+            .map_err(|e| PyValueError::new_err(format!("Failed to serialize claims: {e}")))
+    }
+}
+
+#[pyclass]
+pub struct PyQuoteVerifier {
+    inner: QuoteVerifier,
+}
+
+#[pymethods]
+impl PyQuoteVerifier {
+    #[new]
+    #[pyo3(signature = (root_ca_der=None))]
+    fn new(root_ca_der: Option<Vec<u8>>) -> Self {
+        let inner = root_ca_der.map_or_else(QuoteVerifier::new_prod, QuoteVerifier::new);
+        Self { inner }
+    }
+
+    fn verify_with_policy(
+        &self,
+        raw_quote: &Bound<'_, PyBytes>,
+        collateral: &PyQuoteCollateralV3,
+        now_secs: u64,
+        policy: &PyQuotePolicy,
+    ) -> PyResult<PyQuoteClaims> {
+        self.inner
+            .verify_with_policy(
+                raw_quote.as_bytes(),
+                collateral.inner.clone(),
+                now_secs,
+                &policy.inner,
+            )
+            .map(|inner| PyQuoteClaims { inner })
+            .map_err(|e| PyValueError::new_err(format!("Verification failed: {e}")))
+    }
+}
+
 #[pyfunction]
 fn py_verify(
     raw_quote: &Bound<'_, PyBytes>,
@@ -546,12 +697,10 @@ fn py_verify(
 ) -> PyResult<PyVerifiedReport> {
     let quote_bytes = raw_quote.as_bytes();
 
-    match verify(quote_bytes, &collateral.inner, now_secs) {
-        Ok(verified_report) => Ok(PyVerifiedReport {
-            inner: verified_report,
-        }),
-        Err(e) => Err(PyValueError::new_err(format!("Verification failed: {e:?}"))),
-    }
+    QuoteVerifier::new_prod()
+        .verify(quote_bytes, &collateral.inner, now_secs)
+        .map(|inner| PyVerifiedReport { inner })
+        .map_err(|e| PyValueError::new_err(format!("Verification failed: {e:?}")))
 }
 
 #[pyfunction]
@@ -565,12 +714,10 @@ fn py_verify_with_root_ca(
     let root_ca = root_ca_der.as_bytes();
 
     let verifier = crate::verify::QuoteVerifier::new(root_ca.to_vec());
-    match verifier.verify(quote_bytes, &collateral.inner, now_secs) {
-        Ok(verified_report) => Ok(PyVerifiedReport {
-            inner: verified_report,
-        }),
-        Err(e) => Err(PyValueError::new_err(format!("Verification failed: {e:?}"))),
-    }
+    verifier
+        .verify(quote_bytes, &collateral.inner, now_secs)
+        .map(|inner| PyVerifiedReport { inner })
+        .map_err(|e| PyValueError::new_err(format!("Verification failed: {e:?}")))
 }
 
 #[pyfunction]
@@ -621,6 +768,9 @@ pub fn register_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySgxEnclaveReport>()?;
     m.add_class::<PyPckExtension>()?;
     m.add_class::<PyQuote>()?;
+    m.add_class::<PyQuotePolicy>()?;
+    m.add_class::<PyQuoteClaims>()?;
+    m.add_class::<PyQuoteVerifier>()?;
     m.add_function(wrap_pyfunction!(py_verify, m)?)?;
     m.add_function(wrap_pyfunction!(py_verify_with_root_ca, m)?)?;
     m.add_function(wrap_pyfunction!(parse_quote, m)?)?;

--- a/src/tcb_info.rs
+++ b/src/tcb_info.rs
@@ -145,9 +145,7 @@ pub struct TdxModuleTcb {
     pub isvsvn: u8,
 }
 
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize, Display,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Display)]
 #[display("{_variant}")]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
@@ -174,20 +172,26 @@ impl TcbStatus {
         }
     }
 
-    /// Returns true if the TCB status is acceptable to let the caller decide
-    /// whether to accept the quote or not.
-    ///
-    /// Currently, `Revoked` status is considered invalid and will cause the verification to fail.
-    pub(crate) fn is_valid(&self) -> bool {
-        match self {
-            Self::UpToDate => true,
-            Self::SWHardeningNeeded => true,
-            Self::ConfigurationNeeded => true,
-            Self::ConfigurationAndSWHardeningNeeded => true,
-            Self::OutOfDate => true,
-            Self::OutOfDateConfigurationNeeded => true,
-            Self::Revoked => false,
+    fn converge_with_qe(self, qe: TcbStatus) -> TcbStatus {
+        use TcbStatus::*;
+        match (qe, self) {
+            (OutOfDate, ConfigurationNeeded | ConfigurationAndSWHardeningNeeded) => {
+                OutOfDateConfigurationNeeded
+            }
+            _ => qe.max(self),
         }
+    }
+}
+
+impl Ord for TcbStatus {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.severity().cmp(&other.severity())
+    }
+}
+
+impl PartialOrd for TcbStatus {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -212,13 +216,9 @@ impl TcbStatusWithAdvisory {
         }
     }
 
-    /// Merge two TCB statuses, taking the worse status and combining advisory IDs
+    /// Merge a platform status with a QE status using Intel QVL convergence rules.
     pub fn merge(self, other: &TcbStatusWithAdvisory) -> Self {
-        let final_status = if other.status.severity() > self.status.severity() {
-            other.status
-        } else {
-            self.status
-        };
+        let final_status = self.status.converge_with_qe(other.status);
 
         let mut advisory_ids = self.advisory_ids;
         for id in &other.advisory_ids {
@@ -255,6 +255,16 @@ mod tests {
         let result = a.merge(&b);
         assert_eq!(result.status, OutOfDate);
         assert_eq!(result.advisory_ids, vec!["INTEL-SA-00001"]);
+    }
+
+    #[test]
+    fn qe_out_of_date_converges_configuration_status() {
+        let platform = TcbStatusWithAdvisory::new(TcbStatus::ConfigurationNeeded, vec![]);
+        let qe = TcbStatusWithAdvisory::new(TcbStatus::OutOfDate, vec![]);
+        assert_eq!(
+            platform.merge(&qe).status,
+            TcbStatus::OutOfDateConfigurationNeeded
+        );
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,6 +95,40 @@ pub(crate) fn extract_raw_certs(cert_chain: &[u8]) -> Result<Vec<Vec<u8>>> {
         .collect())
 }
 
+pub(crate) fn parse_rfc3339_unix_secs(value: &str) -> Result<u64> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .map_err(|e| anyhow!("Failed to parse RFC3339 datetime: {e}"))?
+        .timestamp()
+        .try_into()
+        .context("RFC3339 datetime is before Unix epoch")
+}
+
+pub(crate) mod serde_vec_bytes {
+    use alloc::vec::Vec;
+    use serde::ser::SerializeSeq;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use serde_bytes::{ByteBuf, Bytes};
+
+    pub fn serialize<S>(value: &[Vec<u8>], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(value.len()))?;
+        for item in value {
+            seq.serialize_element(Bytes::new(item))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Vec::<ByteBuf>::deserialize(deserializer)?;
+        Ok(value.into_iter().map(ByteBuf::into_vec).collect())
+    }
+}
+
 pub fn extract_certs<'a>(cert_chain: &'a [u8]) -> Result<Vec<CertificateDer<'a>>> {
     let mut certs = Vec::<CertificateDer<'a>>::new();
 
@@ -113,6 +147,35 @@ pub fn encode_as_der_with<C: Config>(data: &[u8]) -> Result<Vec<u8>> {
     use crate::config::EcdsaSigEncoder;
     let (first, second) = data.split_at_checked(32).context("Invalid key length")?;
     C::SigEncoder::encode_ecdsa_sig(first, second)
+}
+
+/// Extract the CRL Number (OID 2.5.29.20) from a DER-encoded CRL.
+///
+/// Returns `Ok(0)` if the CRL Number extension is not present.
+#[cfg(feature = "default-x509")]
+pub fn extract_crl_number(crl_der: &[u8]) -> Result<u32> {
+    use der::Decode as _;
+    let crl: x509_cert::crl::CertificateList<x509_cert::certificate::Rfc5280> =
+        x509_cert::crl::CertificateList::from_der(crl_der).context("Failed to parse CRL")?;
+    let Some(extensions) = &crl.tbs_cert_list.crl_extensions else {
+        return Ok(0);
+    };
+    for ext in extensions.iter() {
+        // OID 2.5.29.20 = id-ce-cRLNumber
+        if ext.extn_id.to_string() == "2.5.29.20" {
+            // CRL Number is encoded as an ASN.1 INTEGER
+            let crl_num =
+                der::asn1::UintRef::from_der(ext.extn_value.as_bytes()).context("CRL number")?;
+            let bytes = crl_num.as_bytes();
+            // Convert big-endian bytes to u32 (CRL numbers are typically small)
+            let mut val: u32 = 0;
+            for &b in bytes {
+                val = val.checked_shl(8).context("CRL number too large for u32")? | u32::from(b);
+            }
+            return Ok(val);
+        }
+    }
+    Ok(0)
 }
 
 /// Parse CRL DER bytes into CertRevocationList objects.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,29 +4,62 @@ use anyhow::{bail, ensure, Context, Result};
 use rustls_pki_types::UnixTime;
 use scale::Decode;
 
+#[cfg(feature = "default-x509")]
+use crate::policy::{PckIdentity, PlatformInfo, Policy, QeInfo, QuoteClaims, TcbVerdict};
 use {
     crate::constants::*,
-    crate::intel,
-    crate::qe_identity::QeIdentity,
-    crate::tcb_info::{TcbInfo, TcbStatusWithAdvisory, TdxModuleTcbLevel},
+    crate::policy::PckCertFlag,
+    crate::qe_identity::{QeIdentity, QeTcbLevel},
+    crate::tcb_info::{TcbInfo, TcbLevel, TcbStatus, TcbStatusWithAdvisory, TdxModuleTcbLevel},
     alloc::string::String,
     alloc::vec::Vec,
 };
 
-#[cfg(feature = "default-x509")]
-use crate::configs::DefaultConfig;
 pub use crate::quote::{AuthData, EnclaveReport, Quote};
+
 use crate::{
     config::{Config, CryptoProvider},
     quote::{Report, TDAttributes},
-    utils::{encode_as_der_with, extract_certs, parse_crls, verify_certificate_chain},
+    utils::{
+        encode_as_der_with, extract_certs, parse_crls, parse_rfc3339_unix_secs,
+        verify_certificate_chain,
+    },
 };
 use crate::{
     quote::{TDReport10, TDReport15},
     QuoteCollateralV3,
 };
+
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
+
+/// Crypto backend configuration for quote verification.
+///
+/// Holds the signature verification algorithm and SHA-256 implementation
+/// needed by the verification logic. Use [`ring::backend()`] or
+/// [`rustcrypto::backend()`] to obtain a pre-configured instance.
+pub struct CryptoBackend {
+    /// ECDSA P-256 SHA-256 algorithm for certificate and raw signature verification
+    pub sig_algo: &'static dyn rustls_pki_types::SignatureVerificationAlgorithm,
+    /// SHA-256 hash function
+    pub sha256: fn(&[u8]) -> [u8; 32],
+    /// SHA-384 hash function (used for root_key_id computation)
+    pub sha384: fn(&[u8]) -> [u8; 48],
+    /// Raw ECDSA `r || s` to DER encoder.
+    pub encode_ecdsa: fn(&[u8]) -> Result<Vec<u8>>,
+    /// Parse Intel PCK extensions with the configured X.509 backend.
+    pub parse_pck_extension: fn(&[u8]) -> Result<crate::intel::PckExtension>,
+}
+
+fn backend_for<C: Config>() -> CryptoBackend {
+    CryptoBackend {
+        sig_algo: C::Crypto::sig_algo(),
+        sha256: C::Crypto::sha256,
+        sha384: C::Crypto::sha384,
+        encode_ecdsa: encode_as_der_with::<C>,
+        parse_pck_extension: crate::intel::parse_pck_extension_with::<C>,
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TeeType {
@@ -67,8 +100,147 @@ fn format_error_chain(e: &anyhow::Error) -> String {
 use borsh::BorshSchema;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
+use core::marker::PhantomData;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Result of cryptographic quote verification, before policy validation.
+///
+/// The enclave report is private — it can only be obtained by passing a [`Policy`]
+/// via [`validate()`](Self::validate).
+///
+/// [`QuoteClaims`] is built lazily via [`claims()`](Self::claims) —
+/// the `verify()` call itself does the minimum work (crypto only).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
+struct QuoteVerificationResult {
+    header: crate::quote::Header,
+    report: Report,
+    collateral: QuoteCollateralV3,
+    #[serde(with = "crate::utils::serde_vec_bytes")]
+    pck_cert_chain_der: Vec<Vec<u8>>,
+    // -- core verification results (always computed) --
+    tee_type: u32,
+    tcb_status: TcbStatus,
+    advisory_ids: Vec<String>,
+    platform_tcb_level: TcbLevel,
+    qe_tcb_level: QeTcbLevel,
+    pck_ext: PckCertChainResult,
+    qe_report: EnclaveReport,
+    tcb_eval_data_number: u32,
+    qe_tcb_eval_data_number: u32,
+    #[serde(with = "serde_bytes")]
+    root_key_id: [u8; 48],
+}
+
+impl QuoteVerificationResult {
+    /// Build the full [`QuoteClaims`] from verification intermediates.
+    ///
+    /// Computes the collateral time window from all 8 sources (TCBInfo, QEIdentity,
+    /// 2 CRLs, 4 certificate chains), root_key_id SHA-384, CRL numbers, and tcb_date_tag.
+    #[cfg(feature = "default-x509")]
+    pub fn claims(&self) -> Result<QuoteClaims> {
+        // Parse collateral JSON for time window computation
+        let tcb_info: TcbInfo = serde_json::from_str(&self.collateral.tcb_info)
+            .context("Failed to parse TcbInfo for claims")?;
+        let qe_identity: QeIdentity = serde_json::from_str(&self.collateral.qe_identity)
+            .context("Failed to parse QeIdentity for claims")?;
+        let pck_certs: Vec<CertificateDer<'_>> = self
+            .pck_cert_chain_der
+            .iter()
+            .map(|cert| CertificateDer::from(cert.as_slice()))
+            .collect();
+
+        let collateral_dates =
+            compute_collateral_time_window(&self.collateral, &pck_certs, &tcb_info, &qe_identity)?;
+
+        // root_key_id: SHA-384 of root CA's raw public key bytes
+        let root_key_id = self.root_key_id;
+
+        // CRL numbers
+        let root_ca_crl_num =
+            crate::utils::extract_crl_number(&self.collateral.root_ca_crl).unwrap_or(0);
+        let pck_crl_num = crate::utils::extract_crl_number(&self.collateral.pck_crl).unwrap_or(0);
+
+        // tcb_date_tag
+        let tcb_date_tag = parse_rfc3339_unix_secs(&self.platform_tcb_level.tcb_date)
+            .context("Failed to parse platform TCB date")?;
+
+        Ok(QuoteClaims {
+            claims_version: 1,
+            header: self.header,
+            tee_type: self.tee_type,
+            tcb: TcbVerdict {
+                status: self.tcb_status,
+                advisory_ids: self.advisory_ids.clone(),
+                eval_data_number: self.tcb_eval_data_number,
+            },
+            platform: PlatformInfo {
+                tcb_level: self.platform_tcb_level.clone(),
+                tcb_date_tag,
+                pck: PckIdentity {
+                    ppid: self.pck_ext.ppid.clone(),
+                    cpu_svn: self.pck_ext.cpu_svn,
+                    pce_svn: self.pck_ext.pce_svn,
+                    pce_id: self.pck_ext.pce_id.clone(),
+                    fmspc: self.pck_ext.fmspc,
+                    sgx_type: self.pck_ext.sgx_type,
+                    platform_instance_id: self.pck_ext.platform_instance_id,
+                    dynamic_platform: self.pck_ext.dynamic_platform,
+                    cached_keys: self.pck_ext.cached_keys,
+                    smt_enabled: self.pck_ext.smt_enabled,
+                    // Intel's upstream DCAP Rego policy checks
+                    // `platform_provider_id`, but the upstream QvE producer
+                    // currently leaves it as a TODO when building the platform
+                    // measurement JSON:
+                    // https://github.com/intel/confidential-computing.tee.dcap/blob/main/ae/QvE/qve/qve.cpp
+                    platform_provider_id: None,
+                },
+                root_key_id: root_key_id.to_vec(),
+                pck_crl_num,
+                root_ca_crl_num,
+            },
+            qe: QeInfo {
+                tcb_level: self.qe_tcb_level.clone(),
+                report: self.qe_report,
+                tcb_eval_data_number: self.qe_tcb_eval_data_number,
+            },
+            report: self.report.clone(),
+            earliest_issue_date: collateral_dates.earliest_issue,
+            latest_issue_date: collateral_dates.latest_issue,
+            earliest_expiration_date: collateral_dates.earliest_expiration,
+            qe_iden_earliest_issue_date: collateral_dates.qe_iden_earliest_issue,
+            qe_iden_latest_issue_date: collateral_dates.qe_iden_latest_issue,
+            qe_iden_earliest_expiration_date: collateral_dates.qe_iden_earliest_expiration,
+        })
+    }
+
+    /// Convert directly into [`VerifiedReport`] **without applying any policy**.
+    ///
+    /// # Warning
+    /// This skips all policy checks (TCB status, advisory IDs, collateral
+    /// freshness, platform flags). Use only when you handle validation
+    /// externally or intentionally accept any verification result.
+    pub fn into_report_unchecked(self) -> VerifiedReport {
+        let platform_status = TcbStatusWithAdvisory::new(
+            self.platform_tcb_level.tcb_status,
+            self.platform_tcb_level.advisory_ids.clone(),
+        );
+        let qe_status = TcbStatusWithAdvisory::new(
+            self.qe_tcb_level.tcb_status,
+            self.qe_tcb_level.advisory_ids.clone(),
+        );
+        VerifiedReport {
+            status: self.tcb_status.to_string(),
+            advisory_ids: self.advisory_ids,
+            report: self.report,
+            ppid: self.pck_ext.ppid,
+            platform_status,
+            qe_status,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
 pub struct VerifiedReport {
@@ -81,26 +253,25 @@ pub struct VerifiedReport {
     pub platform_status: TcbStatusWithAdvisory,
 }
 
-/// Quote verifier with a configurable root certificate.
+/// Quote verifier with configurable root certificate and crypto backend.
 ///
-/// All other configurable choices (X.509 parser, signature encoder, crypto
-/// primitives) are selected at the call site by passing a [`Config`] type
-/// parameter to [`Self::verify_with`] / [`Self::dangerous_verify_with_tcb_override_with`].
-/// The non-generic [`Self::verify`] / [`Self::dangerous_verify_with_tcb_override`]
-/// methods use [`DefaultConfig`].
-pub struct QuoteVerifier {
+/// Provides both the backwards-compatible report API and the detailed claims API.
+pub struct QuoteVerifier<C: Config = crate::configs::DefaultConfig> {
     root_ca_der: Vec<u8>,
     allow_service_td: bool,
     allow_debug: bool,
+    config: PhantomData<C>,
 }
 
-impl QuoteVerifier {
+#[cfg(feature = "default-x509")]
+impl QuoteVerifier<crate::configs::DefaultConfig> {
     /// Create a new verifier with a custom root certificate.
     pub fn new(root_ca_der: Vec<u8>) -> Self {
         Self {
             root_ca_der,
             allow_service_td: false,
             allow_debug: false,
+            config: PhantomData,
         }
     }
 
@@ -108,55 +279,133 @@ impl QuoteVerifier {
     pub fn new_prod() -> Self {
         Self::new(TRUSTED_ROOT_CA_DER.to_vec())
     }
+}
 
-    /// Allow non-zero `mr_service_td` in TDX 1.5 quotes (opt-in).
-    /// Default is `false` — existing callers are unaffected.
+impl<C: Config> QuoteVerifier<C> {
+    /// Create a verifier for `C` with a custom root certificate.
+    pub fn new_with_config(root_ca_der: Vec<u8>) -> Self {
+        Self {
+            root_ca_der,
+            allow_service_td: false,
+            allow_debug: false,
+            config: PhantomData,
+        }
+    }
+
+    /// Select a different compile-time verification backend.
+    pub fn with_config<D: Config>(self) -> QuoteVerifier<D> {
+        QuoteVerifier {
+            root_ca_der: self.root_ca_der,
+            allow_service_td: self.allow_service_td,
+            allow_debug: self.allow_debug,
+            config: PhantomData,
+        }
+    }
+
     pub fn allow_service_td(mut self, allow: bool) -> Self {
         self.allow_service_td = allow;
         self
     }
 
-    /// Allow debug-mode enclaves (SGX debug bit, TDX `TUD.DEBUG`). Default `false`.
     pub fn allow_debug(mut self, allow: bool) -> Self {
         self.allow_debug = allow;
         self
     }
 
-    /// Verify a quote with the configured root certificate, using
-    /// [`DefaultConfig`].
+    /// Verify a quote, apply a policy, and return detailed serializable claims.
     #[cfg(feature = "default-x509")]
+    pub fn verify_with_policy<P: Policy + ?Sized>(
+        &self,
+        raw_quote: &[u8],
+        collateral: impl Into<QuoteCollateralV3>,
+        now_secs: u64,
+        policy: &P,
+    ) -> Result<QuoteClaims> {
+        let claims = self
+            .verify_result(raw_quote, collateral, now_secs)?
+            .claims()?;
+        policy.validate(&claims)?;
+        Ok(claims)
+    }
+
+    fn verify_result(
+        &self,
+        raw_quote: &[u8],
+        collateral: impl Into<QuoteCollateralV3>,
+        now_secs: u64,
+    ) -> Result<QuoteVerificationResult> {
+        let backend = backend_for::<C>();
+        verify_impl(
+            raw_quote,
+            collateral.into(),
+            now_secs,
+            &self.root_ca_der,
+            &backend,
+            self.allow_service_td,
+            self.allow_debug,
+            #[cfg(feature = "danger-allow-tcb-override")]
+            None::<fn(TcbInfo) -> TcbInfo>,
+        )
+    }
+
+    /// Verify with the one-shot API using this verifier's [`Config`].
     pub fn verify(
         &self,
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        self.verify_with::<DefaultConfig>(raw_quote, collateral, now_secs)
+        self.verify_result(raw_quote, collateral, now_secs)
+            .map(QuoteVerificationResult::into_report_unchecked)
     }
 
-    /// Verify a quote, selecting an explicit [`Config`] for X.509 / DER /
-    /// crypto operations. Use this to plug in a custom backend.
-    pub fn verify_with<C: Config>(
+    /// Verify a quote with the configured root certificate, passing a TCB info override.
+    ///
+    /// The override function receives `TcbInfo` after signature verification and can
+    /// modify it before TCB level matching. Use with extreme caution.
+    #[cfg(all(feature = "danger-allow-tcb-override", feature = "default-x509"))]
+    pub fn dangerous_verify_claims_with_tcb_override(
         &self,
         raw_quote: &[u8],
-        collateral: &QuoteCollateralV3,
+        collateral: impl Into<QuoteCollateralV3>,
         now_secs: u64,
-    ) -> Result<VerifiedReport> {
-        verify_impl::<C>(
+        override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
+    ) -> Result<QuoteClaims> {
+        verify_impl(
             raw_quote,
-            collateral,
+            collateral.into(),
             now_secs,
             &self.root_ca_der,
+            &backend_for::<C>(),
             self.allow_service_td,
             self.allow_debug,
-            #[cfg(feature = "danger-allow-tcb-override")]
-            None::<fn(_) -> _>,
+            Some(override_tcb_info),
+        )?
+        .claims()
+    }
+
+    #[cfg(feature = "danger-allow-tcb-override")]
+    fn dangerous_verify_result_with_tcb_override<F: FnOnce(TcbInfo) -> TcbInfo>(
+        &self,
+        raw_quote: &[u8],
+        collateral: impl Into<QuoteCollateralV3>,
+        now_secs: u64,
+        override_tcb_info: F,
+    ) -> Result<QuoteVerificationResult> {
+        let backend = backend_for::<C>();
+        verify_impl(
+            raw_quote,
+            collateral.into(),
+            now_secs,
+            &self.root_ca_der,
+            &backend,
+            self.allow_service_td,
+            self.allow_debug,
+            Some(override_tcb_info),
         )
     }
 
-    /// Like [`Self::verify`], but takes a closure to mutate TCB info after the
-    /// signature check passes. Uses [`DefaultConfig`].
-    #[cfg(all(feature = "default-x509", feature = "danger-allow-tcb-override"))]
+    #[cfg(all(feature = "danger-allow-tcb-override", feature = "default-x509"))]
     pub fn dangerous_verify_with_tcb_override(
         &self,
         raw_quote: &[u8],
@@ -164,121 +413,251 @@ impl QuoteVerifier {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        self.dangerous_verify_with_tcb_override_with::<DefaultConfig, _>(
+        self.dangerous_verify_result_with_tcb_override(
             raw_quote,
             collateral,
             now_secs,
             override_tcb_info,
         )
+        .map(QuoteVerificationResult::into_report_unchecked)
+    }
+}
+
+/// Backwards-compatible one-shot verification using [`DefaultConfig`].
+#[cfg(feature = "default-x509")]
+pub fn verify(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::<crate::configs::DefaultConfig>::new_prod()
+        .verify(raw_quote, collateral, now_secs)
+}
+
+#[cfg(all(feature = "default-x509", feature = "danger-allow-tcb-override"))]
+pub fn dangerous_verify_with_tcb_override(
+    raw_quote: &[u8],
+    collateral: &QuoteCollateralV3,
+    now_secs: u64,
+    override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
+) -> Result<VerifiedReport> {
+    QuoteVerifier::<crate::configs::DefaultConfig>::new_prod().dangerous_verify_with_tcb_override(
+        raw_quote,
+        collateral,
+        now_secs,
+        override_tcb_info,
+    )
+}
+
+/// Verification policy builder for JS/WASM.
+///
+/// ```js
+/// const policy = new QuotePolicy(now)
+///     .allow_status("OutOfDate")
+///     .collateral_grace_period(7n * 86400n)
+///     .allow_smt(true);
+/// ```
+#[cfg(feature = "js")]
+#[wasm_bindgen(js_name = "QuotePolicy")]
+pub struct JsQuotePolicy {
+    inner: crate::policy::QuotePolicy,
+}
+
+#[cfg(feature = "js")]
+fn js_parse_tcb_status(s: &str) -> Result<TcbStatus, JsValue> {
+    match s {
+        "UpToDate" => Ok(TcbStatus::UpToDate),
+        "SWHardeningNeeded" => Ok(TcbStatus::SWHardeningNeeded),
+        "ConfigurationNeeded" => Ok(TcbStatus::ConfigurationNeeded),
+        "ConfigurationAndSWHardeningNeeded" => Ok(TcbStatus::ConfigurationAndSWHardeningNeeded),
+        "OutOfDate" => Ok(TcbStatus::OutOfDate),
+        "OutOfDateConfigurationNeeded" => Ok(TcbStatus::OutOfDateConfigurationNeeded),
+        "Revoked" => Ok(TcbStatus::Revoked),
+        _ => Err(JsValue::from_str(&alloc::format!(
+            "Unknown TCB status: {s}"
+        ))),
+    }
+}
+
+#[cfg(feature = "js")]
+#[wasm_bindgen(js_class = "QuotePolicy")]
+impl JsQuotePolicy {
+    /// Create a strict policy: only `UpToDate`, no grace period, no advisory blacklist.
+    #[wasm_bindgen(constructor)]
+    pub fn strict(now_secs: u64) -> Self {
+        Self {
+            inner: crate::policy::QuotePolicy::strict(now_secs),
+        }
     }
 
-    /// Variant of [`Self::dangerous_verify_with_tcb_override`] with an explicit
-    /// [`Config`].
-    #[cfg(feature = "danger-allow-tcb-override")]
-    pub fn dangerous_verify_with_tcb_override_with<C: Config, F: FnOnce(TcbInfo) -> TcbInfo>(
+    /// Create a pass-through policy for downstream appraisal.
+    #[wasm_bindgen(js_name = "claimsOnly")]
+    pub fn claims_only(now_secs: u64) -> Self {
+        Self {
+            inner: crate::policy::QuotePolicy::claims_only(now_secs),
+        }
+    }
+
+    /// Allow an additional TCB status (e.g. "OutOfDate", "SWHardeningNeeded").
+    pub fn allow_status(self, status: &str) -> Result<JsQuotePolicy, JsValue> {
+        let s = js_parse_tcb_status(status)?;
+        Ok(Self {
+            inner: self.inner.allow_status(s),
+        })
+    }
+
+    /// Reject a specific advisory ID (e.g. "INTEL-SA-00334").
+    pub fn reject_advisory(self, id: &str) -> Self {
+        Self {
+            inner: self.inner.reject_advisory(id),
+        }
+    }
+
+    /// Reject multiple advisory IDs at once.
+    pub fn reject_advisories(self, ids: Vec<String>) -> Self {
+        Self {
+            inner: self.inner.reject_advisories(&ids),
+        }
+    }
+
+    /// Set collateral grace period in seconds.
+    pub fn collateral_grace_period(self, secs: u64) -> Self {
+        Self {
+            inner: self
+                .inner
+                .collateral_grace_period(Duration::from_secs(secs)),
+        }
+    }
+
+    /// Set platform grace period in seconds.
+    pub fn platform_grace_period(self, secs: u64) -> Self {
+        Self {
+            inner: self.inner.platform_grace_period(Duration::from_secs(secs)),
+        }
+    }
+
+    /// Set QE grace period in seconds.
+    pub fn qe_grace_period(self, secs: u64) -> Self {
+        Self {
+            inner: self.inner.qe_grace_period(Duration::from_secs(secs)),
+        }
+    }
+
+    /// Set minimum TCB evaluation data number.
+    pub fn min_tcb_eval_data_number(self, min: u32) -> Self {
+        Self {
+            inner: self.inner.min_tcb_eval_data_number(min),
+        }
+    }
+
+    /// Set whether dynamic platforms are allowed.
+    pub fn allow_dynamic_platform(self, allow: bool) -> Self {
+        Self {
+            inner: self.inner.allow_dynamic_platform(allow),
+        }
+    }
+
+    /// Set whether cached keys are allowed.
+    pub fn allow_cached_keys(self, allow: bool) -> Self {
+        Self {
+            inner: self.inner.allow_cached_keys(allow),
+        }
+    }
+
+    /// Set whether SMT (hyperthreading) is allowed.
+    pub fn allow_smt(self, allow: bool) -> Self {
+        Self {
+            inner: self.inner.allow_smt(allow),
+        }
+    }
+
+    /// Set accepted SGX types (e.g. [0, 1, 2]).
+    pub fn accepted_sgx_types(self, types: Vec<u8>) -> Self {
+        Self {
+            inner: self.inner.accepted_sgx_types(&types),
+        }
+    }
+}
+
+/// Quote verifier for JS/WASM.
+///
+/// ```js
+/// const verifier = new QuoteVerifier();          // Intel production root CA
+/// const verifier = new QuoteVerifier(rootCaDer);  // custom root CA
+/// const result = verifier.verify(quote, collateral, now);
+/// ```
+#[cfg(feature = "js")]
+#[wasm_bindgen(js_name = "QuoteVerifier")]
+pub struct JsQuoteVerifier {
+    inner: QuoteVerifier,
+}
+
+#[cfg(feature = "js")]
+#[wasm_bindgen(js_class = "QuoteVerifier")]
+impl JsQuoteVerifier {
+    /// Create a verifier. No argument = Intel production root CA; pass `rootCaDer` for custom.
+    #[wasm_bindgen(constructor)]
+    pub fn new(root_ca_der: Option<Vec<u8>>) -> Self {
+        let inner = match root_ca_der {
+            Some(der) => QuoteVerifier::new(der),
+            None => QuoteVerifier::new_prod(),
+        };
+        Self { inner }
+    }
+
+    /// Backwards-compatible one-shot verification returning `VerifiedReport`.
+    pub fn verify(
         &self,
-        raw_quote: &[u8],
-        collateral: &QuoteCollateralV3,
-        now_secs: u64,
-        override_tcb_info: F,
-    ) -> Result<VerifiedReport> {
-        verify_impl::<C>(
-            raw_quote,
-            collateral,
-            now_secs,
-            &self.root_ca_der,
-            self.allow_service_td,
-            self.allow_debug,
-            Some(override_tcb_info),
-        )
-    }
-}
-
-#[cfg(all(feature = "js", feature = "_anycrypto", feature = "default-x509"))]
-#[wasm_bindgen]
-pub fn js_verify(
-    raw_quote: JsValue,
-    quote_collateral: JsValue,
-    now: u64,
-) -> Result<JsValue, JsValue> {
-    let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
-        .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
-    let quote_collateral = serde_wasm_bindgen::from_value::<QuoteCollateralV3>(quote_collateral)?;
-
-    let verified_report = verify(&raw_quote, &quote_collateral, now).map_err(|e| {
-        let error_msg = format_error_chain(&e);
-        serde_wasm_bindgen::to_value(&error_msg)
-            .unwrap_or_else(|_| JsValue::from_str("Failed to encode Error"))
-    })?;
-
-    serde_wasm_bindgen::to_value(&verified_report)
-        .map_err(|_| JsValue::from_str("Failed to encode verified_report"))
-}
-
-#[cfg(all(feature = "js", feature = "_anycrypto", feature = "default-x509"))]
-#[wasm_bindgen]
-pub fn js_verify_with_root_ca(
-    raw_quote: JsValue,
-    quote_collateral: JsValue,
-    root_ca_der: JsValue,
-    now: u64,
-) -> Result<JsValue, JsValue> {
-    let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
-        .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
-    let quote_collateral = serde_wasm_bindgen::from_value::<QuoteCollateralV3>(quote_collateral)?;
-    let root_ca_der: Vec<u8> = serde_wasm_bindgen::from_value(root_ca_der)
-        .map_err(|_| JsValue::from_str("Failed to decode root_ca_der"))?;
-
-    let verifier = QuoteVerifier::new(root_ca_der);
-    let verified_report = verifier
-        .verify(&raw_quote, &quote_collateral, now)
-        .map_err(|e| {
-            let error_msg = format_error_chain(&e);
-            serde_wasm_bindgen::to_value(&error_msg)
-                .unwrap_or_else(|_| JsValue::from_str("Failed to encode Error"))
-        })?;
-
-    serde_wasm_bindgen::to_value(&verified_report)
-        .map_err(|_| JsValue::from_str("Failed to encode verified_report"))
-}
-
-#[cfg(all(feature = "js", feature = "report"))]
-#[wasm_bindgen]
-pub async fn js_get_collateral(pccs_url: JsValue, raw_quote: JsValue) -> Result<JsValue, JsValue> {
-    let pccs_url: String = serde_wasm_bindgen::from_value(pccs_url)
-        .map_err(|_| JsValue::from_str("Failed to decode pccs_url"))?;
-    let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
-        .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
-
-    let collateral: QuoteCollateralV3 =
-        crate::collateral::CollateralClient::with_default_http(pccs_url)
-            .map_err(|e| JsValue::from_str(&format_error_chain(&e)))?
-            .fetch(&raw_quote)
-            .await
+        raw_quote: JsValue,
+        quote_collateral: JsValue,
+        now: u64,
+    ) -> Result<JsValue, JsValue> {
+        let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
+            .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
+        let quote_collateral =
+            serde_wasm_bindgen::from_value::<QuoteCollateralV3>(quote_collateral)?;
+        let report = self
+            .inner
+            .verify(&raw_quote, &quote_collateral, now)
             .map_err(|e| JsValue::from_str(&format_error_chain(&e)))?;
-    serde_wasm_bindgen::to_value(&collateral)
-        .map_err(|_| JsValue::from_str("Failed to encode collateral"))
-}
+        serde_wasm_bindgen::to_value(&report)
+            .map_err(|_| JsValue::from_str("Failed to encode verified report"))
+    }
 
-// Parse JSON with `serde-json-core`, matching `serde_json::from_str`'s strictness:
-// `serde-json-core` returns the value plus bytes consumed and silently ignores the
-// tail, while `serde_json` rejects anything after the value except JSON whitespace
-// (` `, `\n`, `\r`, `\t`). Enforce the same here so parsing behavior stays identical
-// across the `json-core` feature flag.
-#[cfg(feature = "json-core")]
-fn from_json_core_str<T: serde::de::DeserializeOwned>(s: &str) -> Result<T> {
-    let (value, consumed) =
-        serde_json_core::from_str::<T>(s).map_err(|e| anyhow::anyhow!("{e:?}"))?;
-    let trailing = s
-        .get(consumed..)
-        .context("serde_json_core returned an invalid consumed offset")?;
-    ensure!(
-        trailing
-            .trim_end_matches([' ', '\n', '\r', '\t'])
-            .is_empty(),
-        "trailing non-whitespace content"
-    );
-    Ok(value)
+    /// Verify the quote, apply the built-in policy, and return claims.
+    pub fn verify_with_policy(
+        &self,
+        raw_quote: JsValue,
+        quote_collateral: JsValue,
+        now: u64,
+        policy: &JsQuotePolicy,
+    ) -> Result<JsValue, JsValue> {
+        let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
+            .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
+        let quote_collateral =
+            serde_wasm_bindgen::from_value::<QuoteCollateralV3>(quote_collateral)?;
+        let claims = self
+            .inner
+            .verify_with_policy(&raw_quote, quote_collateral, now, &policy.inner)
+            .map_err(|e| JsValue::from_str(&format_error_chain(&e)))?;
+        serde_wasm_bindgen::to_value(&claims)
+            .map_err(|_| JsValue::from_str("Failed to encode quote claims"))
+    }
+
+    /// Fetch collateral from a PCCS server.
+    pub async fn get_collateral(pccs_url: &str, raw_quote: JsValue) -> Result<JsValue, JsValue> {
+        let raw_quote: Vec<u8> = serde_wasm_bindgen::from_value(raw_quote)
+            .map_err(|_| JsValue::from_str("Failed to decode raw_quote"))?;
+
+        let collateral: QuoteCollateralV3 =
+            crate::collateral::CollateralClient::with_default_http(pccs_url)
+                .map_err(|e| JsValue::from_str(&format_error_chain(&e)))?
+                .fetch(&raw_quote)
+                .await
+                .map_err(|e| JsValue::from_str(&format_error_chain(&e)))?;
+        serde_wasm_bindgen::to_value(&collateral)
+            .map_err(|_| JsValue::from_str("Failed to encode collateral"))
+    }
 }
 
 // =============================================================================
@@ -286,34 +665,26 @@ fn from_json_core_str<T: serde::de::DeserializeOwned>(s: &str) -> Result<T> {
 // =============================================================================
 
 /// Verify TCB Info collateral: certificate chain, signature, parsing, and expiration check
-fn verify_tcb_info_signature<C: Config>(
+fn verify_tcb_info_signature(
     collateral: &QuoteCollateralV3,
     now: UnixTime,
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
+    backend: &CryptoBackend,
 ) -> Result<TcbInfo> {
-    // Parse TCB Info. Under the `json-core` feature, route through
-    // `serde-json-core` instead of `serde_json` for a smaller footprint
-    // on size-constrained targets (e.g. `wasm32-unknown-unknown`,
-    // `no_std` / embedded, TEE enclaves).
-    #[cfg(not(feature = "json-core"))]
+    // Parse TCB Info
     let tcb_info = serde_json::from_str::<TcbInfo>(&collateral.tcb_info)
         .context("Failed to decode TcbInfo")?;
-    #[cfg(feature = "json-core")]
-    let tcb_info =
-        from_json_core_str::<TcbInfo>(&collateral.tcb_info).context("Failed to decode TcbInfo")?;
 
     // Check validity window
-    let issue_date = chrono::DateTime::parse_from_rfc3339(&tcb_info.issue_date)
-        .ok()
+    let issue_date = parse_rfc3339_unix_secs(&tcb_info.issue_date)
         .context("Failed to parse TCB Info issue date")?;
-    let next_update = chrono::DateTime::parse_from_rfc3339(&tcb_info.next_update)
-        .ok()
+    let next_update = parse_rfc3339_unix_secs(&tcb_info.next_update)
         .context("Failed to parse TCB Info next update")?;
-    if now.as_secs() < issue_date.timestamp() as u64 {
+    if now.as_secs() < issue_date {
         bail!("TCBInfo issue date is in the future");
     }
-    if now.as_secs() > next_update.timestamp() as u64 {
+    if now.as_secs() > next_update {
         bail!("TCBInfo expired");
     }
 
@@ -327,10 +698,10 @@ fn verify_tcb_info_signature<C: Config>(
     verify_certificate_chain(&tcb_leaf_cert, tcb_chain, now, crls, trust_anchor)?;
 
     // Verify signature
-    let asn1_signature = encode_as_der_with::<C>(&collateral.tcb_info_signature)?;
+    let asn1_signature = (backend.encode_ecdsa)(&collateral.tcb_info_signature)?;
     if tcb_leaf_cert
         .verify_signature(
-            C::Crypto::sig_algo(),
+            backend.sig_algo,
             collateral.tcb_info.as_bytes(),
             &asn1_signature,
         )
@@ -347,31 +718,26 @@ fn verify_tcb_info_signature<C: Config>(
 // =============================================================================
 
 /// Verify QE Identity collateral: certificate chain, signature, parsing, and expiration check
-fn verify_qe_identity_signature<C: Config>(
+fn verify_qe_identity_signature(
     collateral: &QuoteCollateralV3,
     now: UnixTime,
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
+    backend: &CryptoBackend,
 ) -> Result<QeIdentity> {
-    // Parse QE Identity. See TCB-Info site above for `json-core` feature.
-    #[cfg(not(feature = "json-core"))]
+    // Parse QE Identity
     let qe_identity = serde_json::from_str::<QeIdentity>(&collateral.qe_identity)
-        .context("Failed to decode QeIdentity")?;
-    #[cfg(feature = "json-core")]
-    let qe_identity = from_json_core_str::<QeIdentity>(&collateral.qe_identity)
         .context("Failed to decode QeIdentity")?;
 
     // Check validity window
-    let issue_date = chrono::DateTime::parse_from_rfc3339(&qe_identity.issue_date)
-        .ok()
+    let issue_date = parse_rfc3339_unix_secs(&qe_identity.issue_date)
         .context("Failed to parse QE Identity issue date")?;
-    let next_update = chrono::DateTime::parse_from_rfc3339(&qe_identity.next_update)
-        .ok()
+    let next_update = parse_rfc3339_unix_secs(&qe_identity.next_update)
         .context("Failed to parse QE Identity next update")?;
-    if now.as_secs() < issue_date.timestamp() as u64 {
+    if now.as_secs() < issue_date {
         bail!("QE Identity issue date is in the future");
     }
-    if now.as_secs() > next_update.timestamp() as u64 {
+    if now.as_secs() > next_update {
         bail!("QE Identity expired");
     }
 
@@ -385,10 +751,10 @@ fn verify_qe_identity_signature<C: Config>(
     verify_certificate_chain(&qe_id_leaf_cert, qe_id_chain, now, crls, trust_anchor)?;
 
     // Verify signature
-    let qe_id_asn1_signature = encode_as_der_with::<C>(&collateral.qe_identity_signature)?;
+    let qe_id_asn1_signature = (backend.encode_ecdsa)(&collateral.qe_identity_signature)?;
     if qe_id_leaf_cert
         .verify_signature(
-            C::Crypto::sig_algo(),
+            backend.sig_algo,
             collateral.qe_identity.as_bytes(),
             &qe_id_asn1_signature,
         )
@@ -408,12 +774,13 @@ fn verify_qe_identity_signature<C: Config>(
 ///
 /// Verifies the PCK certificate chain against the trusted root and CRLs.
 /// Extracts cpu_svn, pce_svn, fmspc, and ppid from the certificate.
-fn verify_pck_cert_chain<C: Config>(
+fn verify_pck_cert_chain(
     collateral: &QuoteCollateralV3,
     certification_data: &crate::quote::CertificationData,
     now: UnixTime,
     crls: &[webpki::CertRevocationList<'_>],
     trust_anchor: rustls_pki_types::TrustAnchor,
+    backend: &CryptoBackend,
 ) -> Result<PckCertChainResult> {
     // Extract PCK certificate chain - prefer collateral, fall back to quote
     let certification_certs = if let Some(pem_chain) = &collateral.pck_certificate_chain {
@@ -421,7 +788,7 @@ fn verify_pck_cert_chain<C: Config>(
             .context("Failed to extract PCK certificates from collateral")?
     } else {
         if certification_data.cert_type != PCK_CERT_CHAIN {
-            bail!("Unsupported DCAP PCK cert format: {}. Use CollateralClient::fetch() to obtain the PCK certificate.", certification_data.cert_type);
+            bail!("Unsupported DCAP PCK cert format: {}. Use get_collateral() to fetch PCK certificate.", certification_data.cert_type);
         }
         extract_certs(&certification_data.body.data)
             .context("Failed to extract PCK certificates from quote")?
@@ -437,24 +804,59 @@ fn verify_pck_cert_chain<C: Config>(
     verify_certificate_chain(&pck_leaf_cert, pck_chain, now, crls, trust_anchor)?;
 
     // Extract Intel extension data from PCK cert (parsed once)
-    let pck_ext = intel::parse_pck_extension_with::<C>(pck_leaf)?;
+    let pck_ext = (backend.parse_pck_extension)(pck_leaf)?;
+
+    // Preserve pce_id as the raw value from the PCK cert SGX extension.
+    let pce_id = pck_ext.pce_id.clone();
+
+    // Convert platform_instance_id to fixed-size array
+    let platform_instance_id = pck_ext.platform_instance_id.as_ref().and_then(|v| {
+        let arr: [u8; 16] = v.as_slice().try_into().ok()?;
+        Some(arr)
+    });
 
     Ok(PckCertChainResult {
+        pck_cert_chain_der: certification_certs
+            .iter()
+            .map(|cert| cert.as_ref().to_vec())
+            .collect(),
         pck_leaf_der: pck_leaf.as_ref().to_vec(),
         ppid: pck_ext.ppid,
         cpu_svn: pck_ext.cpu_svn,
         pce_svn: pck_ext.pce_svn,
         fmspc: pck_ext.fmspc,
+        pce_id,
+        sgx_type: pck_ext.sgx_type as u8,
+        platform_instance_id,
+        dynamic_platform: pck_ext.dynamic_platform.into(),
+        cached_keys: pck_ext.cached_keys.into(),
+        smt_enabled: pck_ext.smt_enabled.into(),
     })
 }
 
 /// Result from PCK certificate chain verification
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
 struct PckCertChainResult {
+    #[serde(with = "crate::utils::serde_vec_bytes")]
+    pck_cert_chain_der: Vec<Vec<u8>>,
+    #[serde(with = "serde_bytes")]
     pck_leaf_der: Vec<u8>,
+    #[serde(with = "serde_bytes")]
     ppid: Vec<u8>,
+    #[serde(with = "serde_bytes")]
     cpu_svn: [u8; 16],
     pce_svn: u16,
+    #[serde(with = "serde_bytes")]
     fmspc: [u8; 6],
+    #[serde(with = "serde_bytes")]
+    pce_id: Vec<u8>,
+    sgx_type: u8,
+    platform_instance_id: Option<[u8; 16]>,
+    dynamic_platform: PckCertFlag,
+    cached_keys: PckCertFlag,
+    smt_enabled: PckCertFlag,
 }
 
 // =============================================================================
@@ -462,21 +864,18 @@ struct PckCertChainResult {
 // =============================================================================
 
 /// Verify QE report signature using PCK certificate
-fn verify_qe_report_signature<C: Config>(
+fn verify_qe_report_signature(
     pck_leaf: &CertificateDer,
     auth_data: &crate::quote::AuthDataV3,
+    backend: &CryptoBackend,
 ) -> Result<EnclaveReport> {
     let pck_leaf_cert =
         webpki::EndEntityCert::try_from(pck_leaf).context("Failed to parse PCK certificate")?;
 
     // Verify QE report signature (signed by PCK)
-    let qe_report_signature = encode_as_der_with::<C>(&auth_data.qe_report_signature)?;
+    let qe_report_signature = (backend.encode_ecdsa)(&auth_data.qe_report_signature)?;
     if pck_leaf_cert
-        .verify_signature(
-            C::Crypto::sig_algo(),
-            &auth_data.qe_report,
-            &qe_report_signature,
-        )
+        .verify_signature(backend.sig_algo, &auth_data.qe_report, &qe_report_signature)
         .is_err()
     {
         bail!("Signature is invalid for qe_report in quote");
@@ -495,9 +894,10 @@ fn verify_qe_report_signature<C: Config>(
 // =============================================================================
 
 /// Verify QE report hash matches attestation key and auth data (panic-free)
-fn verify_qe_report_data<C: Config>(
+fn verify_qe_report_data(
     qe_report: &EnclaveReport,
     auth_data: &crate::quote::AuthDataV3,
+    backend: &CryptoBackend,
 ) -> Result<()> {
     use crate::constants::{ATTESTATION_KEY_LEN, AUTHENTICATION_DATA_LEN};
 
@@ -509,7 +909,7 @@ fn verify_qe_report_data<C: Config>(
     let mut qe_hash_data = [0u8; ATTESTATION_KEY_LEN + AUTHENTICATION_DATA_LEN];
     qe_hash_data[..ATTESTATION_KEY_LEN].copy_from_slice(&auth_data.ecdsa_attestation_key);
     qe_hash_data[ATTESTATION_KEY_LEN..].copy_from_slice(&auth_data.qe_auth_data.data);
-    let qe_hash = C::Crypto::sha256(&qe_hash_data);
+    let qe_hash = (backend.sha256)(&qe_hash_data);
     if qe_hash[..] != qe_report.report_data[..32] {
         bail!("QE report hash mismatch");
     }
@@ -527,23 +927,25 @@ fn verify_qe_report_data<C: Config>(
 // =============================================================================
 
 /// Verify ISV enclave report signature using attestation key
-fn verify_isv_report_signature<C: Config>(
+fn verify_isv_report_signature(
     raw_quote: &[u8],
     quote: &Quote,
     auth_data: &crate::quote::AuthDataV3,
+    backend: &CryptoBackend,
 ) -> Result<()> {
     // Prepend 0x04 to raw public key for SEC1 uncompressed format
     let mut pub_key = [0x04u8; 65];
     pub_key[1..].copy_from_slice(&auth_data.ecdsa_attestation_key);
 
     // DER-encode the raw r||s signature for SignatureVerificationAlgorithm
-    let der_sig = encode_as_der_with::<C>(&auth_data.ecdsa_signature)?;
+    let der_sig = (backend.encode_ecdsa)(&auth_data.ecdsa_signature)?;
 
     let signed_data = raw_quote
         .get(..quote.signed_length())
         .context("Failed to get signed quote scope")?;
 
-    C::Crypto::sig_algo()
+    backend
+        .sig_algo
         .verify_signature(&pub_key, signed_data, &der_sig)
         .map_err(|_| anyhow::anyhow!("ISV enclave report signature is invalid"))
 }
@@ -552,10 +954,7 @@ fn verify_isv_report_signature<C: Config>(
 // Step 8: Match Platform TCB (PCK Cert's CPU_SVN/PCE_SVN/FMSPC vs TCB Info)
 // =============================================================================
 
-/// Match platform TCB level and return status with advisory IDs.
-///
-/// For TDX, this also folds in TDX Module Identity status and advisory IDs,
-/// following Intel DCAP QVL behavior.
+/// Match platform TCB level and return the matched TcbLevel
 fn match_platform_tcb(
     tcb_info: &TcbInfo,
     quote: &Quote,
@@ -563,7 +962,7 @@ fn match_platform_tcb(
     cpu_svn: &[u8],
     pce_svn: u16,
     fmspc: &[u8],
-) -> Result<TcbStatusWithAdvisory> {
+) -> Result<TcbLevel> {
     // Verify FMSPC matches
     let tcb_fmspc = hex::decode(&tcb_info.fmspc)
         .ok()
@@ -593,9 +992,6 @@ fn match_platform_tcb(
         }
 
         let sgx_components: Vec<u8> = tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
-        // Reject mismatched component count so `.zip()` below cannot
-        // silently truncate a comparison and accept a platform whose
-        // unchecked SVN bytes are below the required level.
         if sgx_components.len() != cpu_svn.len() {
             bail!(
                 "SGX component count mismatch: expected {}, got {}",
@@ -635,35 +1031,25 @@ fn match_platform_tcb(
             }
         }
 
-        // Found matching level
-        let mut status =
-            TcbStatusWithAdvisory::new(tcb_level.tcb_status, tcb_level.advisory_ids.clone());
-
-        // For TDX, also fold in TDX module identity status and advisories
+        let mut matched = tcb_level.clone();
         if tee_type.is_tdx() {
             if let Some(module_status) =
                 match_tdx_module_identity(tcb_info, quote).context("TDX module identity check")?
             {
-                status = status.merge(&module_status);
+                matched.tcb_status = matched.tcb_status.max(module_status.status);
+                for advisory in module_status.advisory_ids {
+                    if !matched.advisory_ids.contains(&advisory) {
+                        matched.advisory_ids.push(advisory);
+                    }
+                }
             }
         }
-
-        return Ok(status);
+        return Ok(matched);
     }
 
     bail!("No matching TCB level found");
 }
 
-/// Match TDX Module Identity against TCB Info and TD report.
-///
-/// Follows Intel DCAP QVL behavior:
-/// - For TDX TCB Info (version >= 3, id == "TDX"), read `tdxModule`
-/// - For module versions > 0, select the `tdxModuleIdentities` entry whose `id`
-///   matches `TDX_{tee_tcb_svn[1]}` (case-insensitive)
-/// - Verify MRSEAM signer matches the expected `mrsigner`
-/// - Apply `attributes_mask` when comparing SEAMATTRIBUTES
-/// - If a module identity entry is used, derive module TCB status and
-///   advisory IDs from its TCB levels based on module ISVSVN.
 fn match_tdx_module_identity(
     tcb_info: &TcbInfo,
     quote: &Quote,
@@ -803,7 +1189,8 @@ fn match_tdx_module_identity(
 // Main verification flow following the trust chain
 // =============================================================================
 
-/// Internal implementation that uses QuoteVerifier
+/// Cryptographic verification of a quote. Returns [`QuoteClaims`] without
+/// applying any policy — the caller decides acceptance via [`QuoteClaims::validate()`].
 ///
 /// Trust chain verification order:
 /// 1. Verify TCB Info signature (Intel Root -> TCB Signing Cert -> TCB Info JSON)
@@ -816,17 +1203,19 @@ fn match_tdx_module_identity(
 /// 8. Match Platform TCB (PCK Cert's CPU_SVN/PCE_SVN/FMSPC vs TCB Info)
 /// 9. Match QE TCB (QE Report's ISVSVN vs QE Identity tcb_levels)
 /// 10. Merge TCB statuses
-fn verify_impl<C: Config>(
+#[allow(clippy::too_many_arguments)]
+fn verify_impl(
     raw_quote: &[u8],
-    collateral: &QuoteCollateralV3,
+    collateral: QuoteCollateralV3,
     now_secs: u64,
     root_ca_der: &[u8],
+    backend: &CryptoBackend,
     allow_service_td: bool,
     allow_debug: bool,
     #[cfg(feature = "danger-allow-tcb-override")] override_tcb_info: Option<
         impl FnOnce(TcbInfo) -> TcbInfo,
     >,
-) -> Result<VerifiedReport> {
+) -> Result<QuoteVerificationResult> {
     // Setup trust anchor and time
     let root_ca = CertificateDer::from_slice(root_ca_der);
     let trust_anchor =
@@ -845,9 +1234,6 @@ fn verify_impl<C: Config>(
     let quote = Quote::decode(&mut quote_slice).context("Failed to decode quote")?;
     if !ALLOWED_QUOTE_VERSIONS.contains(&quote.header.version) {
         bail!("Unsupported DCAP quote version");
-    }
-    if quote.header.qe_vendor_id != INTEL_QE_VENDOR_ID {
-        bail!("Unknown QE vendor ID");
     }
     let tee_type = TeeType::from_u32(quote.header.tee_type)?;
     match tee_type {
@@ -869,22 +1255,17 @@ fn verify_impl<C: Config>(
 
     // Step 1: Verify TCB Info signature
     let mut tcb_info =
-        verify_tcb_info_signature::<C>(collateral, now, &crls, trust_anchor.clone())?;
+        verify_tcb_info_signature(&collateral, now, &crls, trust_anchor.clone(), backend)?;
 
     #[cfg(feature = "danger-allow-tcb-override")]
-    {
-        tcb_info = match override_tcb_info {
-            Some(override_tcb_info) => override_tcb_info(tcb_info),
-            None => tcb_info,
-        };
+    if let Some(override_tcb_info) = override_tcb_info {
+        tcb_info = override_tcb_info(tcb_info);
     }
-
-    // Canonicalize TCB levels ordering to match Intel QVL expectations.
     tcb_info.canonicalize_tcb_levels();
 
     // Step 2: Verify QE Identity signature
     let qe_identity =
-        verify_qe_identity_signature::<C>(collateral, now, &crls, trust_anchor.clone())?;
+        verify_qe_identity_signature(&collateral, now, &crls, trust_anchor.clone(), backend)?;
     let (expected_qe_id, allowed_qe_versions): (&str, &[u8]) = match tee_type {
         TeeType::Sgx => ("QE", &[2]),
         TeeType::Tdx => ("TD_QE", &[2, 3]),
@@ -900,29 +1281,30 @@ fn verify_impl<C: Config>(
     }
 
     // Step 3: Verify PCK certificate chain
-    let pck_result = verify_pck_cert_chain::<C>(
-        collateral,
+    let pck_result = verify_pck_cert_chain(
+        &collateral,
         &auth_data.certification_data,
         now,
         &crls,
         trust_anchor,
+        backend,
     )?;
     let pck_leaf = CertificateDer::from(pck_result.pck_leaf_der.as_slice());
 
     // Step 4: Verify QE Report signature
-    let qe_report = verify_qe_report_signature::<C>(&pck_leaf, &auth_data)?;
+    let qe_report = verify_qe_report_signature(&pck_leaf, &auth_data, backend)?;
 
     // Step 5: Verify QE Report content (hash check)
-    verify_qe_report_data::<C>(&qe_report, &auth_data)?;
+    verify_qe_report_data(&qe_report, &auth_data, backend)?;
 
-    // Step 6: Verify QE Report policy
-    let qe_status = verify_qe_identity_policy(&qe_report, &qe_identity)?;
+    // Step 6: Verify QE Report policy (returns matched QeTcbLevel)
+    let qe_tcb_level = verify_qe_identity_policy(&qe_report, &qe_identity)?;
 
     // Step 7: Verify ISV Report signature
-    verify_isv_report_signature::<C>(raw_quote, &quote, &auth_data)?;
+    verify_isv_report_signature(raw_quote, &quote, &auth_data, backend)?;
 
-    // Step 8: Match Platform TCB
-    let platform_status = match_platform_tcb(
+    // Step 8: Match Platform TCB (returns matched TcbLevel)
+    let platform_tcb_level = match_platform_tcb(
         &tcb_info,
         &quote,
         tee_type,
@@ -931,22 +1313,215 @@ fn verify_impl<C: Config>(
         &pck_result.fmspc,
     )?;
 
-    // Step 9 & 10: QE TCB matching is done in verify_qe_identity_policy, merge statuses
-    let final_status = platform_status.clone().merge(&qe_status);
-    if !final_status.status.is_valid() {
-        bail!("TCB status is invalid: {:?}", final_status.status);
+    // Step 9 & 10: Merge statuses (take worst)
+    let platform_status = TcbStatusWithAdvisory::new(
+        platform_tcb_level.tcb_status,
+        platform_tcb_level.advisory_ids.clone(),
+    );
+    let qe_status =
+        TcbStatusWithAdvisory::new(qe_tcb_level.tcb_status, qe_tcb_level.advisory_ids.clone());
+    let final_status = platform_status.merge(&qe_status);
+
+    // Revoked means the platform's keys are compromised — reject unconditionally,
+    // regardless of policy. This is a security invariant, not a policy decision.
+    if final_status.status == TcbStatus::Revoked {
+        bail!("TCB status is invalid: Revoked");
     }
+
+    #[cfg(feature = "default-x509")]
+    let root_key_id = {
+        let root_cert: x509_cert::Certificate =
+            der::Decode::from_der(root_ca_der).context("Failed to parse root CA certificate")?;
+        let raw_key = root_cert
+            .tbs_certificate()
+            .subject_public_key_info()
+            .subject_public_key
+            .raw_bytes();
+        (backend.sha384)(raw_key)
+    };
+    #[cfg(not(feature = "default-x509"))]
+    let root_key_id = [0u8; 48];
 
     // Validate report attributes (debug mode check, etc.)
     validate_attrs(&quote.report, allow_service_td, allow_debug)?;
 
-    Ok(VerifiedReport {
-        status: final_status.status.to_string(),
-        advisory_ids: final_status.advisory_ids,
+    Ok(QuoteVerificationResult {
+        header: quote.header,
         report: quote.report,
-        ppid: pck_result.ppid,
-        qe_status,
-        platform_status,
+        collateral,
+        pck_cert_chain_der: pck_result.pck_cert_chain_der.clone(),
+        tee_type: quote.header.tee_type,
+        tcb_status: final_status.status,
+        advisory_ids: final_status.advisory_ids,
+        platform_tcb_level,
+        qe_tcb_level,
+        pck_ext: pck_result,
+        qe_report,
+        tcb_eval_data_number: tcb_info
+            .tcb_evaluation_data_number
+            .min(qe_identity.tcb_evaluation_data_number),
+        qe_tcb_eval_data_number: qe_identity.tcb_evaluation_data_number,
+        root_key_id,
+    })
+}
+
+/// Collateral time window dates (8 sources + QE Identity subset).
+#[cfg(feature = "default-x509")]
+struct CollateralDates {
+    earliest_issue: u64,
+    latest_issue: u64,
+    earliest_expiration: u64,
+    /// QE Identity-specific dates (sources \[5\] + \[7\] only).
+    qe_iden_earliest_issue: u64,
+    qe_iden_latest_issue: u64,
+    qe_iden_earliest_expiration: u64,
+}
+
+/// Compute the collateral time window: earliest issue, latest issue, earliest expiration.
+///
+/// Matches Intel QVL's `qve_get_collateral_dates()` which considers **8 date sources**:
+///
+/// 1. Root CA CRL thisUpdate/nextUpdate
+/// 2. PCK CRL thisUpdate/nextUpdate
+/// 3. PCK CRL issuer certificate chain notBefore/notAfter
+/// 4. PCK certificate chain notBefore/notAfter
+/// 5. TCBInfo issuer certificate chain notBefore/notAfter
+/// 6. QEIdentity issuer certificate chain notBefore/notAfter
+/// 7. TCBInfo JSON issueDate/nextUpdate
+/// 8. QEIdentity JSON issueDate/nextUpdate
+#[cfg(feature = "default-x509")]
+fn compute_collateral_time_window(
+    collateral: &QuoteCollateralV3,
+    pck_cert_chain: &[CertificateDer<'_>],
+    tcb_info: &TcbInfo,
+    qe_identity: &QeIdentity,
+) -> Result<CollateralDates> {
+    fn parse_crl_dates(crl_der: &[u8]) -> Result<(u64, Option<u64>)> {
+        use der::Decode as _;
+        let crl: x509_cert::crl::CertificateList<x509_cert::certificate::Rfc5280> =
+            x509_cert::crl::CertificateList::from_der(crl_der)
+                .context("Failed to parse CRL for time window")?;
+        let this_update = crl.tbs_cert_list.this_update.to_unix_duration().as_secs();
+        let next_update = crl
+            .tbs_cert_list
+            .next_update
+            .map(|t| t.to_unix_duration().as_secs());
+        Ok((this_update, next_update))
+    }
+
+    /// Extract notBefore/notAfter from a PEM certificate chain and fold into min/max accumulators.
+    fn fold_cert_chain_dates(
+        pem_chain: &[u8],
+        earliest_issue: &mut u64,
+        latest_issue: &mut u64,
+        earliest_expiration: &mut u64,
+    ) -> Result<()> {
+        let certs = extract_certs(pem_chain)?;
+        fold_der_cert_dates(&certs, earliest_issue, latest_issue, earliest_expiration)
+    }
+
+    fn fold_der_cert_dates(
+        certs: &[CertificateDer<'_>],
+        earliest_issue: &mut u64,
+        latest_issue: &mut u64,
+        earliest_expiration: &mut u64,
+    ) -> Result<()> {
+        use der::Decode as _;
+        for cert_der in certs {
+            let cert = x509_cert::Certificate::from_der(cert_der)
+                .context("Failed to parse certificate for time window")?;
+            let not_before = cert
+                .tbs_certificate()
+                .validity()
+                .not_before
+                .to_unix_duration()
+                .as_secs();
+            let not_after = cert
+                .tbs_certificate()
+                .validity()
+                .not_after
+                .to_unix_duration()
+                .as_secs();
+            *earliest_issue = (*earliest_issue).min(not_before);
+            *latest_issue = (*latest_issue).max(not_before);
+            *earliest_expiration = (*earliest_expiration).min(not_after);
+        }
+        Ok(())
+    }
+
+    // TCBInfo dates (already parsed upstream)
+    let tcb_issue = parse_rfc3339_unix_secs(&tcb_info.issue_date).context("TCBInfo issueDate")?;
+    let tcb_next = parse_rfc3339_unix_secs(&tcb_info.next_update).context("TCBInfo nextUpdate")?;
+
+    // QEIdentity dates (already parsed upstream)
+    let qe_issue =
+        parse_rfc3339_unix_secs(&qe_identity.issue_date).context("QEIdentity issueDate")?;
+    let qe_next =
+        parse_rfc3339_unix_secs(&qe_identity.next_update).context("QEIdentity nextUpdate")?;
+
+    let mut earliest_issue = tcb_issue.min(qe_issue);
+    let mut latest_issue = tcb_issue.max(qe_issue);
+    let mut earliest_expiration = tcb_next.min(qe_next);
+
+    // Include CRL dates (sources 1 & 2)
+    for crl_der in [&collateral.root_ca_crl[..], &collateral.pck_crl[..]] {
+        let (this_update, next_update) = parse_crl_dates(crl_der)?;
+        earliest_issue = earliest_issue.min(this_update);
+        latest_issue = latest_issue.max(this_update);
+        if let Some(next) = next_update {
+            earliest_expiration = earliest_expiration.min(next);
+        }
+    }
+
+    // Include certificate chain dates (sources 3-6)
+    // PCK CRL issuer chain (same PEM as pck_crl_issuer_chain)
+    fold_cert_chain_dates(
+        collateral.pck_crl_issuer_chain.as_bytes(),
+        &mut earliest_issue,
+        &mut latest_issue,
+        &mut earliest_expiration,
+    )?;
+    // PCK certificate chain
+    fold_der_cert_dates(
+        pck_cert_chain,
+        &mut earliest_issue,
+        &mut latest_issue,
+        &mut earliest_expiration,
+    )?;
+    // TCBInfo issuer chain
+    fold_cert_chain_dates(
+        collateral.tcb_info_issuer_chain.as_bytes(),
+        &mut earliest_issue,
+        &mut latest_issue,
+        &mut earliest_expiration,
+    )?;
+    // QEIdentity issuer chain (source [5]) — also track QE-specific dates
+    let mut qe_chain_earliest_issue = u64::MAX;
+    let mut qe_chain_latest_issue = 0u64;
+    let mut qe_chain_earliest_expiration = u64::MAX;
+    fold_cert_chain_dates(
+        collateral.qe_identity_issuer_chain.as_bytes(),
+        &mut qe_chain_earliest_issue,
+        &mut qe_chain_latest_issue,
+        &mut qe_chain_earliest_expiration,
+    )?;
+    // Fold into global window
+    earliest_issue = earliest_issue.min(qe_chain_earliest_issue);
+    latest_issue = latest_issue.max(qe_chain_latest_issue);
+    earliest_expiration = earliest_expiration.min(qe_chain_earliest_expiration);
+
+    // QE Identity-specific window: min/max of source [5] (issuer chain) + source [7] (JSON)
+    let qe_iden_earliest_issue = qe_chain_earliest_issue.min(qe_issue);
+    let qe_iden_latest_issue = qe_chain_latest_issue.max(qe_issue);
+    let qe_iden_earliest_expiration = qe_chain_earliest_expiration.min(qe_next);
+
+    Ok(CollateralDates {
+        earliest_issue,
+        latest_issue,
+        earliest_expiration,
+        qe_iden_earliest_issue,
+        qe_iden_latest_issue,
+        qe_iden_earliest_expiration,
     })
 }
 
@@ -962,7 +1537,6 @@ fn validate_attrs(report: &Report, allow_service_td: bool, allow_debug: bool) ->
     fn validate_td10(report: &TDReport10, allow_debug: bool) -> Result<()> {
         let td_attrs =
             TDAttributes::parse(report.td_attributes).context("Failed to parse TD attributes")?;
-        // TUD bit 0 is DEBUG; bits 7:1 are reserved and must always be zero.
         if td_attrs.tud & !0x01 != 0 {
             bail!("Reserved bits in TD attributes are set");
         }
@@ -993,26 +1567,48 @@ fn validate_attrs(report: &Report, allow_service_td: bool, allow_debug: bool) ->
     }
 }
 
-/// Convenience entry points pinning the [`crate::configs::RingConfig`]
-/// (audited cert parser + sig encoder + ring crypto). Equivalent to calling
-/// `verify_with::<RingConfig>(...)` on a default `QuoteVerifier`.
+/// Ring crypto backend module.
+///
+/// Provides a pre-configured [`CryptoBackend`] using ring for ECDSA P-256 and SHA-256.
 #[cfg(all(feature = "ring", feature = "default-x509"))]
 pub mod ring {
     use super::*;
-    pub use crate::configs::RingConfig;
 
-    /// Verify a quote using Intel's trusted root CA and the ring crypto provider.
+    fn ring_sha256(data: &[u8]) -> [u8; 32] {
+        let digest = ::ring::digest::digest(&::ring::digest::SHA256, data);
+        let mut out = [0u8; 32];
+        out.copy_from_slice(digest.as_ref());
+        out
+    }
+
+    fn ring_sha384(data: &[u8]) -> [u8; 48] {
+        let digest = ::ring::digest::digest(&::ring::digest::SHA384, data);
+        let mut out = [0u8; 48];
+        out.copy_from_slice(digest.as_ref());
+        out
+    }
+
+    /// Returns a [`CryptoBackend`] backed by ring.
+    pub fn backend() -> CryptoBackend {
+        CryptoBackend {
+            sig_algo: webpki::ring::ECDSA_P256_SHA256,
+            sha256: ring_sha256,
+            sha384: ring_sha384,
+            encode_ecdsa: encode_as_der_with::<crate::configs::RingConfig>,
+            parse_pck_extension: crate::intel::parse_pck_extension_with::<crate::configs::RingConfig>,
+        }
+    }
+
     pub fn verify(
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new_prod().verify_with::<RingConfig>(raw_quote, collateral, now_secs)
+        QuoteVerifier::new_prod()
+            .with_config::<crate::configs::RingConfig>()
+            .verify(raw_quote, collateral, now_secs)
     }
 
-    /// Verify a quote using Intel's trusted root CA and the ring crypto
-    /// provider, passing a function to override TCB info after the signature
-    /// check.
     #[cfg(feature = "danger-allow-tcb-override")]
     pub fn dangerous_verify_with_tcb_override(
         raw_quote: &[u8],
@@ -1020,37 +1616,52 @@ pub mod ring {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<RingConfig, _>(
-            raw_quote,
-            collateral,
-            now_secs,
-            override_tcb_info,
-        )
+        QuoteVerifier::new_prod()
+            .with_config::<crate::configs::RingConfig>()
+            .dangerous_verify_with_tcb_override(raw_quote, collateral, now_secs, override_tcb_info)
     }
 }
 
-/// Convenience entry points pinning the
-/// [`crate::configs::RustCryptoConfig`] (audited cert parser + sig
-/// encoder + RustCrypto crypto). Equivalent to calling
-/// `verify_with::<RustCryptoConfig>(...)` on a default `QuoteVerifier`.
+/// RustCrypto backend module.
+///
+/// Provides a pre-configured [`CryptoBackend`] using RustCrypto (sha2 + p256) for ECDSA P-256 and SHA-256.
 #[cfg(all(feature = "rustcrypto", feature = "default-x509"))]
 pub mod rustcrypto {
     use super::*;
-    pub use crate::configs::RustCryptoConfig;
 
-    /// Verify a quote using Intel's trusted root CA and the RustCrypto
-    /// crypto provider.
+    fn rustcrypto_sha256(data: &[u8]) -> [u8; 32] {
+        use sha2::Digest;
+        sha2::Sha256::digest(data).into()
+    }
+
+    fn rustcrypto_sha384(data: &[u8]) -> [u8; 48] {
+        use sha2::Digest;
+        sha2::Sha384::digest(data).into()
+    }
+
+    /// Returns a [`CryptoBackend`] backed by RustCrypto.
+    pub fn backend() -> CryptoBackend {
+        CryptoBackend {
+            sig_algo: webpki::rustcrypto::ECDSA_P256_SHA256,
+            sha256: rustcrypto_sha256,
+            sha384: rustcrypto_sha384,
+            encode_ecdsa: encode_as_der_with::<crate::configs::RustCryptoConfig>,
+            parse_pck_extension: crate::intel::parse_pck_extension_with::<
+                crate::configs::RustCryptoConfig,
+            >,
+        }
+    }
+
     pub fn verify(
         raw_quote: &[u8],
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new_prod().verify_with::<RustCryptoConfig>(raw_quote, collateral, now_secs)
+        QuoteVerifier::new_prod()
+            .with_config::<crate::configs::RustCryptoConfig>()
+            .verify(raw_quote, collateral, now_secs)
     }
 
-    /// Verify a quote using Intel's trusted root CA and the RustCrypto crypto
-    /// provider, passing a function to override TCB info after the signature
-    /// check.
     #[cfg(feature = "danger-allow-tcb-override")]
     pub fn dangerous_verify_with_tcb_override(
         raw_quote: &[u8],
@@ -1058,76 +1669,10 @@ pub mod rustcrypto {
         now_secs: u64,
         override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
     ) -> Result<VerifiedReport> {
-        QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<RustCryptoConfig, _>(
-            raw_quote,
-            collateral,
-            now_secs,
-            override_tcb_info,
-        )
+        QuoteVerifier::new_prod()
+            .with_config::<crate::configs::RustCryptoConfig>()
+            .dangerous_verify_with_tcb_override(raw_quote, collateral, now_secs, override_tcb_info)
     }
-}
-
-/// Verify a quote using Intel's trusted root CA, with [`DefaultConfig`].
-///
-/// `DefaultConfig` selects the audited cert parser + sig encoder, plus the
-/// `ring` crypto provider when the `ring` feature is enabled, otherwise
-/// `rustcrypto`. To pin a specific config, use [`verify_with`] or one of the
-/// [`ring::verify`] / [`rustcrypto::verify`] convenience entry points.
-#[cfg(all(feature = "_anycrypto", feature = "default-x509"))]
-pub fn verify(
-    raw_quote: &[u8],
-    collateral: &QuoteCollateralV3,
-    now_secs: u64,
-) -> Result<VerifiedReport> {
-    QuoteVerifier::new_prod().verify(raw_quote, collateral, now_secs)
-}
-
-/// Variant of [`verify`] with an explicit [`Config`]. Use this to plug in a
-/// custom backend.
-#[cfg(feature = "_anycrypto")]
-pub fn verify_with<C: Config>(
-    raw_quote: &[u8],
-    collateral: &QuoteCollateralV3,
-    now_secs: u64,
-) -> Result<VerifiedReport> {
-    QuoteVerifier::new_prod().verify_with::<C>(raw_quote, collateral, now_secs)
-}
-
-/// Like [`verify`], but takes a closure to mutate TCB info after the
-/// signature check. Uses [`DefaultConfig`].
-#[cfg(all(
-    feature = "_anycrypto",
-    feature = "default-x509",
-    feature = "danger-allow-tcb-override"
-))]
-pub fn dangerous_verify_with_tcb_override(
-    raw_quote: &[u8],
-    collateral: &QuoteCollateralV3,
-    now_secs: u64,
-    override_tcb_info: impl FnOnce(TcbInfo) -> TcbInfo,
-) -> Result<VerifiedReport> {
-    QuoteVerifier::new_prod().dangerous_verify_with_tcb_override(
-        raw_quote,
-        collateral,
-        now_secs,
-        override_tcb_info,
-    )
-}
-
-/// Variant of [`dangerous_verify_with_tcb_override`] with an explicit [`Config`].
-#[cfg(all(feature = "_anycrypto", feature = "danger-allow-tcb-override"))]
-pub fn dangerous_verify_with_tcb_override_with<C: Config, F: FnOnce(TcbInfo) -> TcbInfo>(
-    raw_quote: &[u8],
-    collateral: &QuoteCollateralV3,
-    now_secs: u64,
-    override_tcb_info: F,
-) -> Result<VerifiedReport> {
-    QuoteVerifier::new_prod().dangerous_verify_with_tcb_override_with::<C, _>(
-        raw_quote,
-        collateral,
-        now_secs,
-        override_tcb_info,
-    )
 }
 
 // =============================================================================
@@ -1143,11 +1688,11 @@ pub fn dangerous_verify_with_tcb_override_with<C: Config, F: FnOnce(TcbInfo) -> 
 /// - ATTRIBUTES match after applying the mask
 /// - ISVSVN meets minimum requirement from QE Identity TCB levels (Step 9)
 ///
-/// Returns the QE TCB status and advisory IDs based on the QE's ISVSVN.
+/// Returns the matched QeTcbLevel based on the QE's ISVSVN.
 fn verify_qe_identity_policy(
     qe_report: &EnclaveReport,
     qe_identity: &QeIdentity,
-) -> Result<TcbStatusWithAdvisory> {
+) -> Result<QeTcbLevel> {
     // Verify MRSIGNER
     if qe_report.mr_signer != qe_identity.mrsigner {
         bail!(
@@ -1157,7 +1702,6 @@ fn verify_qe_identity_policy(
         );
     }
 
-    // QE must always be production-mode; `allow_debug` only governs the workload.
     validate_sgx_attrs(qe_report, false).context("QE report validation failed")?;
 
     // Verify ISVPRODID
@@ -1211,17 +1755,14 @@ fn verify_qe_identity_policy(
 /// Match QE ISVSVN against QE Identity TCB levels
 ///
 /// TCB levels are expected to be sorted from highest to lowest ISVSVN.
-/// Returns the status and advisory IDs for the matching level.
+/// Returns the matched QeTcbLevel.
 fn match_qe_tcb_level(
     isv_svn: u16,
     tcb_levels: &[crate::qe_identity::QeTcbLevel],
-) -> Result<TcbStatusWithAdvisory> {
+) -> Result<QeTcbLevel> {
     for tcb_level in tcb_levels {
         if isv_svn >= tcb_level.tcb.isvsvn {
-            return Ok(TcbStatusWithAdvisory::new(
-                tcb_level.tcb_status,
-                tcb_level.advisory_ids.clone(),
-            ));
+            return Ok(tcb_level.clone());
         }
     }
 
@@ -1424,9 +1965,9 @@ mod tests {
 
         let result = verify_qe_identity_policy(&qe_report, &qe_identity);
         assert!(result.is_ok());
-        let status = result.unwrap();
-        assert_eq!(status.status, UpToDate);
-        assert!(status.advisory_ids.is_empty());
+        let tcb_level = result.unwrap();
+        assert_eq!(tcb_level.tcb_status, UpToDate);
+        assert!(tcb_level.advisory_ids.is_empty());
     }
 
     #[test]
@@ -1437,9 +1978,9 @@ mod tests {
 
         let result = verify_qe_identity_policy(&qe_report, &qe_identity);
         assert!(result.is_ok());
-        let status = result.unwrap();
-        assert_eq!(status.status, OutOfDate);
-        assert_eq!(status.advisory_ids, vec!["INTEL-SA-00615"]);
+        let tcb_level = result.unwrap();
+        assert_eq!(tcb_level.tcb_status, OutOfDate);
+        assert_eq!(tcb_level.advisory_ids, vec!["INTEL-SA-00615"]);
     }
 
     #[test]
@@ -1450,8 +1991,8 @@ mod tests {
 
         let result = verify_qe_identity_policy(&qe_report, &qe_identity);
         assert!(result.is_ok());
-        let status = result.unwrap();
-        assert_eq!(status.status, UpToDate); // Matches first level (isvsvn >= 8)
+        let tcb_level = result.unwrap();
+        assert_eq!(tcb_level.tcb_status, UpToDate); // Matches first level (isvsvn >= 8)
     }
 
     #[test]
@@ -1478,87 +2019,9 @@ mod tests {
 
         let result = verify_qe_identity_policy(&qe_report, &qe_identity);
         assert!(result.is_ok());
-        let status = result.unwrap();
+        let tcb_level = result.unwrap();
         // Should match level with isvsvn=6 (7 >= 6)
-        assert_eq!(status.status, OutOfDate);
-        assert_eq!(status.advisory_ids, vec!["INTEL-SA-00615"]);
-    }
-
-    fn make_sgx_report(attributes_byte0: u8) -> EnclaveReport {
-        let mut report = make_test_qe_report();
-        report.attributes[0] = attributes_byte0;
-        report
-    }
-
-    fn make_td10_report(td_attributes: [u8; 8]) -> TDReport10 {
-        TDReport10 {
-            tee_tcb_svn: [0u8; 16],
-            mr_seam: [0u8; 48],
-            mr_signer_seam: [0u8; 48],
-            seam_attributes: [0u8; 8],
-            td_attributes,
-            xfam: [0u8; 8],
-            mr_td: [0u8; 48],
-            mr_config_id: [0u8; 48],
-            mr_owner: [0u8; 48],
-            mr_owner_config: [0u8; 48],
-            rt_mr0: [0u8; 48],
-            rt_mr1: [0u8; 48],
-            rt_mr2: [0u8; 48],
-            rt_mr3: [0u8; 48],
-            report_data: [0u8; 64],
-        }
-    }
-
-    #[test]
-    fn test_sgx_debug_rejected_by_default() {
-        // SGX attributes byte 0 bit 1 (0x02) is the DEBUG flag.
-        let report = make_sgx_report(0x02);
-        let err = validate_sgx_attrs(&report, false).unwrap_err();
-        assert!(err.to_string().contains("Debug mode is enabled"));
-    }
-
-    #[test]
-    fn test_sgx_debug_allowed_when_opted_in() {
-        let report = make_sgx_report(0x02);
-        validate_sgx_attrs(&report, true).unwrap();
-    }
-
-    #[test]
-    fn test_sgx_non_debug_passes_regardless() {
-        let report = make_sgx_report(0x00);
-        validate_sgx_attrs(&report, false).unwrap();
-        validate_sgx_attrs(&report, true).unwrap();
-    }
-
-    #[test]
-    fn test_td10_debug_rejected_by_default() {
-        // TUD bit 0 = DEBUG, byte 3 bit 4 (0x10) = SEPT_VE_DISABLE (required).
-        let report = Report::TD10(make_td10_report([0x01, 0, 0, 0x10, 0, 0, 0, 0]));
-        let err = validate_attrs(&report, false, false).unwrap_err();
-        assert!(err.to_string().contains("Debug mode is enabled"));
-    }
-
-    #[test]
-    fn test_td10_debug_allowed_when_opted_in() {
-        let report = Report::TD10(make_td10_report([0x01, 0, 0, 0x10, 0, 0, 0, 0]));
-        validate_attrs(&report, false, true).unwrap();
-    }
-
-    #[test]
-    fn test_td10_reserved_tud_bits_always_rejected() {
-        // Bit 1 of TUD is reserved and must remain zero even with allow_debug.
-        let report = Report::TD10(make_td10_report([0x02, 0, 0, 0x10, 0, 0, 0, 0]));
-        let err_default = validate_attrs(&report, false, false).unwrap_err();
-        assert!(err_default.to_string().contains("Reserved bits"));
-        let err_allowed = validate_attrs(&report, false, true).unwrap_err();
-        assert!(err_allowed.to_string().contains("Reserved bits"));
-    }
-
-    #[test]
-    fn test_td10_clean_attrs_pass() {
-        let report = Report::TD10(make_td10_report([0x00, 0, 0, 0x10, 0, 0, 0, 0]));
-        validate_attrs(&report, false, false).unwrap();
-        validate_attrs(&report, false, true).unwrap();
+        assert_eq!(tcb_level.tcb_status, OutOfDate);
+        assert_eq!(tcb_level.advisory_ids, vec!["INTEL-SA-00615"]);
     }
 }

--- a/tests/config_conformance.rs
+++ b/tests/config_conformance.rs
@@ -121,7 +121,7 @@ fn encode_ecdsa_sig_handles_edge_cases() {
 }
 
 /// A `Config` defined entirely in this test crate, to prove the plumbing in
-/// `verify_with::<C>` actually accepts a downstream-defined config and that
+/// `QuoteVerifier<C>` actually accepts a downstream-defined config and that
 /// custom configs can mix-and-match per-component.
 struct ForwardingConfig;
 impl Config for ForwardingConfig {
@@ -132,7 +132,7 @@ impl Config for ForwardingConfig {
 
 #[test]
 fn verify_with_custom_config_matches_default() {
-    use dcap_qvl::verify::{verify, verify_with};
+    use dcap_qvl::verify::{verify, QuoteVerifier};
 
     let raw_quote = include_bytes!("../sample/tdx_quote");
     let collateral: QuoteCollateralV3 =
@@ -156,11 +156,13 @@ fn verify_with_custom_config_matches_default() {
         .expect("nonzero nextUpdate timestamp");
 
     let default_result = verify(raw_quote, &collateral, now);
-    let custom_result = verify_with::<ForwardingConfig>(raw_quote, &collateral, now);
+    let custom_result = QuoteVerifier::new_prod()
+        .with_config::<ForwardingConfig>()
+        .verify(raw_quote, &collateral, now);
     assert_eq!(
         default_result.map_err(|e| e.to_string()),
         custom_result.map_err(|e| e.to_string()),
-        "verify_with::<ForwardingConfig> must match verify"
+        "custom configured verifier must match verify"
     );
 }
 

--- a/tests/esbuild/src/main.ts
+++ b/tests/esbuild/src/main.ts
@@ -1,4 +1,4 @@
-import init, { js_verify, js_get_collateral } from "@phala/dcap-qvl-web";
+import init, { QuoteVerifier, QuotePolicy } from "@phala/dcap-qvl-web";
 import wasm from "@phala/dcap-qvl-web/dcap-qvl-web_bg.wasm";
 
 const PCCS_URL = "https://pccs.phala.network/tdx/certification/v4";
@@ -14,12 +14,13 @@ async function fetchQuoteAsUint8Array(url: string): Promise<Uint8Array> {
 
 init(wasm).then(() => {
   console.log("Phala DCAP QVL initialized!");
-  // You can now use js_verify, js_get_collateral, etc.
   fetchQuoteAsUint8Array("/sample/tdx_quote").then(async (rawQuote) => {
-    const quoteCollateral = await js_get_collateral(PCCS_URL, rawQuote);
+    const quoteCollateral = await QuoteVerifier.get_collateral(PCCS_URL, rawQuote);
     const now = BigInt(Math.floor(Date.now() / 1000));
-    const result = js_verify(rawQuote, quoteCollateral, now);
-    console.log("Verification Result:", result);
+    const verifier = new QuoteVerifier();
+    const policy = new QuotePolicy(now);
+    const report = verifier.verify_with_policy(rawQuote, quoteCollateral, now, policy);
+    console.log("Verification Result:", report);
   });
 }).catch((error: unknown) => {
   console.error("Error:", error);

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -29,6 +29,7 @@ See [TEST_WEB.md](TEST_WEB.md) for detailed web testing documentation.
 ```bash
 cd tests/js
 node verify_quote_node.js
+node verify_quote_rego_node.js
 ```
 
 ### Verify Quote in Web Browser

--- a/tests/js/get_collateral_node.js
+++ b/tests/js/get_collateral_node.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { js_get_collateral } = require("../../pkg/node/dcap-qvl-node");
+const { QuoteVerifier } = require("../../pkg/node/dcap-qvl-node");
 
 // Function to read a file as a Uint8Array
 function readFileAsUint8Array(filePath) {
@@ -16,7 +16,7 @@ const rawQuote = readFileAsUint8Array(rawQuotePath);
     try {
         // Call the js_get_collateral function for TDX quote
         let pccs_url = "https://pccs.phala.network/tdx/certification/v4";
-        const result = await js_get_collateral(pccs_url, rawQuote);
+        const result = await QuoteVerifier.get_collateral(pccs_url, rawQuote);
         console.log("Collateral Result:", result);
     } catch (error) {
         console.error("Get collateral failed:", error);

--- a/tests/js/get_collateral_web.js
+++ b/tests/js/get_collateral_web.js
@@ -1,4 +1,4 @@
-import init, { js_get_collateral } from "/pkg/web/dcap-qvl-web.js";
+import init, { QuoteVerifier } from "/pkg/web/dcap-qvl-web.js";
 
 // Function to fetch a file as a Uint8Array
 async function fetchFileAsUint8Array(url) {
@@ -18,9 +18,8 @@ async function getCollateral() {
 
         const rawQuote = await fetchFileAsUint8Array(rawQuoteUrl);
 
-        // Call the js_get_collateral function for TDX quote
         let pccs_url = "https://pccs.phala.network/tdx/certification/v4";
-        const result = await js_get_collateral(pccs_url, rawQuote);
+        const result = await QuoteVerifier.get_collateral(pccs_url, rawQuote);
         console.log("Collateral Result:", result);
     } catch (error) {
         console.error("Get collateral failed:", error);

--- a/tests/js/verify_quote_node.js
+++ b/tests/js/verify_quote_node.js
@@ -1,9 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const {
-  js_verify,
-  js_get_collateral,
-} = require("../../pkg/node/dcap-qvl-node");
+const { QuoteVerifier, QuotePolicy } = require("../../pkg/node/dcap-qvl-node");
 
 // Function to read a file as a Uint8Array
 function readFileAsUint8Array(filePath) {
@@ -22,11 +19,12 @@ const now = BigInt(Math.floor(Date.now() / 1000));
 
 (async () => {
   try {
-    // Call the js_verify function
     let pccs_url = "https://pccs.phala.network/tdx/certification/v4";
-    const quoteCollateral = await js_get_collateral(pccs_url, rawQuote);
-    const result = js_verify(rawQuote, quoteCollateral, now);
-    console.log("Verification Result:", result);
+    const quoteCollateral = await QuoteVerifier.get_collateral(pccs_url, rawQuote);
+    const verifier = new QuoteVerifier();
+    const policy = new QuotePolicy(now);
+    const report = verifier.verify_with_policy(rawQuote, quoteCollateral, now, policy);
+    console.log("Verification Result:", report);
   } catch (error) {
     console.error("Verification failed:", error);
   }

--- a/tests/js/verify_quote_web.js
+++ b/tests/js/verify_quote_web.js
@@ -1,4 +1,4 @@
-import init, { js_verify, js_get_collateral } from "/pkg/web/dcap-qvl-web.js";
+import init, { QuoteVerifier, QuotePolicy } from "/pkg/web/dcap-qvl-web.js";
 
 // Function to fetch a file as a Uint8Array
 async function fetchFileAsUint8Array(url) {
@@ -26,14 +26,16 @@ async function loadFilesAndVerify() {
 
     // Get the quote collateral
     let pccs_url = "https://pccs.phala.network/tdx/certification/v4";
-    const quoteCollateral = await js_get_collateral(pccs_url, rawQuote);
+    const quoteCollateral = await QuoteVerifier.get_collateral(pccs_url, rawQuote);
 
     // Current timestamp
     const now = BigInt(Math.floor(Date.now() / 1000));
 
-    // Call the js_verify function
-    const result = js_verify(rawQuote, quoteCollateral, now);
-    console.log("Verification Result:", result);
+    // Verify
+    const verifier = new QuoteVerifier();
+    const policy = new QuotePolicy(now);
+    const report = verifier.verify_with_policy(rawQuote, quoteCollateral, now, policy);
+    console.log("Verification Result:", report);
   } catch (error) {
     console.error("Verification failed:", error);
   }

--- a/tests/js/verify_quote_web_test.js
+++ b/tests/js/verify_quote_web_test.js
@@ -1,4 +1,4 @@
-import init, { js_verify, js_verify_with_root_ca, js_get_collateral } from "/pkg/web/dcap-qvl-web.js";
+import init, { QuoteVerifier, QuotePolicy } from "/pkg/web/dcap-qvl-web.js";
 
 const testOutputs = [];
 let passed = 0;
@@ -90,10 +90,11 @@ async function runTests() {
         const rootCA = await fetchFile('/test_data/certs/root_ca.der');
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
-        if (!result || !result.status) {
-            throw new Error('Verification should succeed but got no result');
+        const claims = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+        if (!claims || !claims.tcb || !claims.platform || !claims.report) {
+            throw new Error('Claims export should include detailed verified claims');
         }
+
     });
 
     // Test valid SGX quote v4
@@ -103,10 +104,8 @@ async function runTests() {
         const rootCA = await fetchFile('/test_data/certs/root_ca.der');
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
-        if (!result || !result.status) {
-            throw new Error('Verification should succeed but got no result');
-        }
+        const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+
     });
 
     // Test valid SGX quote v5
@@ -116,10 +115,8 @@ async function runTests() {
         const rootCA = await fetchFile('/test_data/certs/root_ca.der');
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
-        if (!result || !result.status) {
-            throw new Error('Verification should succeed but got no result');
-        }
+        const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+
     });
 
     // Test valid TDX quote
@@ -129,10 +126,8 @@ async function runTests() {
         const rootCA = await fetchFile('/test_data/certs/root_ca.der');
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
-        if (!result || !result.status) {
-            throw new Error('Verification should succeed but got no result');
-        }
+        const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+
     });
 
     log('');
@@ -146,7 +141,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             // WASM errors might be strings or objects
@@ -165,7 +160,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             // WASM errors might be strings or objects
@@ -184,7 +179,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -205,7 +200,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             // WASM errors might be strings or objects
@@ -224,7 +219,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -245,7 +240,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -263,7 +258,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -284,7 +279,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -305,7 +300,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -323,7 +318,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -344,7 +339,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -365,7 +360,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -386,7 +381,7 @@ async function runTests() {
         const now = BigInt(Math.floor(Date.now() / 1000));
 
         try {
-            const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
+            const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
             throw new Error('Should have failed but succeeded');
         } catch (error) {
             const errorStr = typeof error === 'string' ? error : (error.message || String(error));
@@ -407,8 +402,9 @@ async function runTests() {
         const rootCA = await fetchFile("/test_data/certs/root_ca.der");
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = js_verify_with_root_ca(quote, collateral, rootCA, now);
-        if (!result || !result.status) {
+        const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+        const report = result.into_report_unchecked();
+        if (!report || !report.status) {
             throw new Error(
                 "Verification should succeed for PKS enabled quote"
             );
@@ -422,14 +418,9 @@ async function runTests() {
     await runTest('Fetch collateral from PCCS', async () => {
         const quote = await fetchFile('/sample/tdx_quote');
 
-        // Check if get_collateral function is available in Web WASM
-        if (typeof js_get_collateral !== 'function') {
-            throw new Error('js_get_collateral function not available in Web WASM');
-        }
-
         // Test with HTTP URL (our mock server runs on HTTP)
         const mockPccsUrl = 'http://localhost:8765/tdx/certification/v4';
-        const result = js_get_collateral(mockPccsUrl, quote);
+        const result = QuoteVerifier.get_collateral(mockPccsUrl, quote);
 
         // The function should return a promise in Web WASM just like in Node.js
         if (!result || typeof result.then !== 'function') {

--- a/tests/near/contracts/gas-test/Cargo.lock
+++ b/tests/near/contracts/gas-test/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-qvl"
-version = "0.3.10"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/tests/near/contracts/gas-test/src/lib.rs
+++ b/tests/near/contracts/gas-test/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use dcap_qvl::{verify::verify, QuoteCollateralV3};
+use dcap_qvl::{verify::{QuoteVerifier, ring}, QuoteCollateralV3};
 use hex::decode;
 use near_sdk::{env, log, near};
 
@@ -57,9 +57,10 @@ impl Contract {
         // Get current timestamp in seconds
         let timestamp_s = get_block_timestamp_secs();
 
-        // Call dcap-qvl::verify::verify() directly
-        match verify(&quote_bytes, &collateral_data, timestamp_s) {
-            Ok(_verified_report) => {
+        // Call dcap-qvl verify
+        let verifier = QuoteVerifier::new_prod();
+        match verifier.verify_with_policy(&quote_bytes, collateral_data, timestamp_s, &dcap_qvl::QuotePolicy::claims_only(timestamp_s)) {
+            Ok(_claims) => {
                 log!("Verification result: Success");
                 true
             }

--- a/tests/test_case.js
+++ b/tests/test_case.js
@@ -87,13 +87,10 @@ async function cmdVerify(args) {
     }
 
     try {
-        let result;
-        if (rootCaDer) {
-            result = wasmModule.js_verify_with_root_ca(quoteBytes, collateral, rootCaDer, now);
-        } else {
-            result = wasmModule.js_verify(quoteBytes, collateral, now);
-        }
-
+        const verifier = rootCaDer
+            ? new wasmModule.QuoteVerifier(rootCaDer)
+            : new wasmModule.QuoteVerifier();
+        const result = verifier.verify(quoteBytes, collateral, now);
         console.log("Verification successful");
         console.log(`Status: ${result.status}`);
         process.exit(0);
@@ -136,7 +133,7 @@ async function cmdGetCollateral(args) {
     }
 
     try {
-        const result = await wasmModule.js_get_collateral(pccsUrl, quoteBytes);
+        const result = await wasmModule.QuoteVerifier.get_collateral(pccsUrl, quoteBytes);
 
         if (!result || !result.tcb_info_issuer_chain) {
             console.error("Error: Collateral missing required fields");

--- a/tests/verify_quote.rs
+++ b/tests/verify_quote.rs
@@ -1,38 +1,47 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-#![cfg(feature = "default-x509")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
 
 use dcap_qvl::{quote::Quote, verify::VerifiedReport, QuoteCollateralV3};
 use der::Decode as DerDecode;
 use scale::Decode as ScaleDecode;
 use serde_json::Value;
-use x509_cert::{certificate::Rfc5280, crl::CertificateList};
+use x509_cert::crl::CertificateList;
 
 pub fn verify(
     raw_quote: &[u8],
     collateral: &QuoteCollateralV3,
     now_secs: u64,
 ) -> anyhow::Result<VerifiedReport> {
-    use dcap_qvl::verify::{ring, rustcrypto};
-    let ring_result = ring::verify(raw_quote, collateral, now_secs);
-    let rustcrypto_result = rustcrypto::verify(raw_quote, collateral, now_secs);
+    use dcap_qvl::verify::QuoteVerifier;
+
+    let ring_verifier = QuoteVerifier::new_prod();
+    let rustcrypto_verifier = QuoteVerifier::new_prod();
+
+    let ring_result = ring_verifier
+        .with_config::<dcap_qvl::configs::RingConfig>()
+        .verify(raw_quote, collateral, now_secs);
+    let rustcrypto_result = rustcrypto_verifier
+        .with_config::<dcap_qvl::configs::RustCryptoConfig>()
+        .verify(raw_quote, collateral, now_secs);
+
     assert_eq!(
         ring_result.map_err(|e| e.to_string()),
         rustcrypto_result.map_err(|e| e.to_string())
     );
-    ring::verify(raw_quote, collateral, now_secs)
+    QuoteVerifier::new_prod()
+        .with_config::<dcap_qvl::configs::RingConfig>()
+        .verify(raw_quote, collateral, now_secs)
 }
 
 fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
     fn parse_issue_next(json_str: &str) -> (u64, u64) {
         let value: Value = serde_json::from_str(json_str).expect("valid JSON");
-        let issue = value
-            .get("issueDate")
-            .and_then(Value::as_str)
-            .expect("issueDate string");
-        let next = value
-            .get("nextUpdate")
-            .and_then(Value::as_str)
-            .expect("nextUpdate string");
+        let issue = value["issueDate"].as_str().expect("issueDate string");
+        let next = value["nextUpdate"].as_str().expect("nextUpdate string");
         let issue_ts = chrono::DateTime::parse_from_rfc3339(issue)
             .expect("issueDate parse")
             .timestamp() as u64;
@@ -43,7 +52,8 @@ fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
     }
 
     fn parse_crl_bounds(crl_der: &[u8]) -> (u64, Option<u64>) {
-        let crl = CertificateList::<Rfc5280>::from_der(crl_der).expect("CRL parse");
+        let crl: CertificateList<x509_cert::certificate::Rfc5280> =
+            CertificateList::from_der(crl_der).expect("CRL parse");
         let this_update = crl.tbs_cert_list.this_update.to_unix_duration().as_secs();
         let next_update = crl
             .tbs_cert_list
@@ -70,7 +80,7 @@ fn now_from_collateral(collateral: &QuoteCollateralV3) -> u64 {
         "collateral validity window invalid"
     );
     if not_after > not_before {
-        not_after.checked_sub(1).expect("nonzero not_after")
+        not_after - 1
     } else {
         not_after
     }
@@ -95,6 +105,221 @@ fn could_parse_sgx_quote() {
     );
 }
 
+/// Cross-validate all QuoteClaims fields against independently computed values.
+#[test]
+fn sgx_claims_cross_validation() {
+    use dcap_qvl::verify::QuoteVerifier;
+    use dcap_qvl::PckCertFlag;
+
+    let raw_quote = include_bytes!("../sample/sgx_quote").to_vec();
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/sgx_quote_collateral.json")).unwrap();
+    let now = now_from_collateral(&collateral);
+
+    let verifier = QuoteVerifier::new_prod();
+    let result = verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral.clone(),
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let s = &result;
+    let claims_json = serde_json::to_value(s).expect("claims must be serializable");
+    for key in [
+        "claims_version",
+        "header",
+        "tee_type",
+        "tcb",
+        "platform",
+        "qe",
+        "report",
+    ] {
+        assert!(claims_json.get(key).is_some(), "missing claim group: {key}");
+    }
+
+    // Parse quote for later use
+    let parsed_quote = Quote::decode(&mut &raw_quote[..]).unwrap();
+
+    // ── TCB status ──────────────────────────────────────────────────────
+    assert_eq!(
+        s.tcb.status.to_string(),
+        "ConfigurationAndSWHardeningNeeded"
+    );
+    assert_eq!(s.tcb.advisory_ids, ["INTEL-SA-00289", "INTEL-SA-00615"]);
+
+    // earliest_expiration is computed lazily in claims()
+    assert!(s.earliest_expiration_date > 0);
+
+    // ── tcb_date_tag ────────────────────────────────────────────────────
+    let expected_tcb_date = chrono::DateTime::parse_from_rfc3339(&s.platform.tcb_level.tcb_date)
+        .unwrap()
+        .timestamp() as u64;
+    assert_eq!(s.platform.tcb_date_tag, expected_tcb_date);
+
+    // ── CRL numbers ─────────────────────────────────────────────────────
+    fn extract_crl_num(crl_der: &[u8]) -> u32 {
+        let crl: CertificateList<x509_cert::certificate::Rfc5280> =
+            CertificateList::from_der(crl_der).unwrap();
+        if let Some(exts) = &crl.tbs_cert_list.crl_extensions {
+            for ext in exts.iter() {
+                if ext.extn_id.to_string() == "2.5.29.20" {
+                    let num =
+                        <der::asn1::UintRef as DerDecode>::from_der(ext.extn_value.as_bytes())
+                            .unwrap();
+                    let bytes = num.as_bytes();
+                    let mut val: u32 = 0;
+                    for &b in bytes {
+                        val = (val << 8) | u32::from(b);
+                    }
+                    return val;
+                }
+            }
+        }
+        0
+    }
+    assert_eq!(
+        s.platform.root_ca_crl_num,
+        extract_crl_num(&collateral.root_ca_crl)
+    );
+    assert_eq!(s.platform.pck_crl_num, extract_crl_num(&collateral.pck_crl));
+
+    // ── tcb_eval_data_number ────────────────────────────────────────────
+    let tcb_info_parsed: dcap_qvl::TcbInfo = serde_json::from_str(&collateral.tcb_info).unwrap();
+    let qe_id_parsed: dcap_qvl::QeIdentity = serde_json::from_str(&collateral.qe_identity).unwrap();
+    let expected_eval_num = tcb_info_parsed
+        .tcb_evaluation_data_number
+        .min(qe_id_parsed.tcb_evaluation_data_number);
+    assert_eq!(s.tcb.eval_data_number, expected_eval_num);
+
+    // ── root_key_id ─────────────────────────────────────────────────────
+    let root_ca_der = include_bytes!("../src/TrustedRootCA.der");
+    let root_cert: x509_cert::Certificate = DerDecode::from_der(root_ca_der).unwrap();
+    let raw_pub_key = root_cert
+        .tbs_certificate()
+        .subject_public_key_info()
+        .subject_public_key
+        .raw_bytes();
+    let expected_root_key_id: [u8; 48] = {
+        use sha2::Digest;
+        sha2::Sha384::digest(raw_pub_key).into()
+    };
+    assert_eq!(s.platform.root_key_id, expected_root_key_id);
+
+    // ── PCK certificate fields ──────────────────────────────────────────
+    let pck_chain_der = dcap_qvl::intel::extract_cert_chain(&parsed_quote).unwrap();
+    let pck_ext = dcap_qvl::intel::parse_pck_extension(&pck_chain_der[0]).unwrap();
+
+    assert_eq!(s.platform.pck.cpu_svn, pck_ext.cpu_svn);
+    assert_eq!(s.platform.pck.pce_svn, pck_ext.pce_svn);
+    assert_eq!(s.platform.pck.fmspc, pck_ext.fmspc);
+    assert_eq!(s.platform.pck.ppid, pck_ext.ppid);
+    assert_eq!(s.platform.pck.sgx_type, pck_ext.sgx_type as u8);
+
+    let expected_pce_id = pck_ext.pce_id.clone();
+    assert_eq!(s.platform.pck.pce_id, expected_pce_id);
+
+    // ── TEE type ────────────────────────────────────────────────────────
+    assert_eq!(s.tee_type, 0x00000000); // SGX
+
+    // ── Platform instance (Processor CA → should be Undefined) ──────────
+    assert_eq!(s.platform.pck.dynamic_platform, PckCertFlag::Undefined);
+    assert_eq!(s.platform.pck.cached_keys, PckCertFlag::Undefined);
+    assert_eq!(s.platform.pck.smt_enabled, PckCertFlag::Undefined);
+
+    // ── TCB levels ──────────────────────────────────────────────────────
+    assert!(!s.platform.tcb_level.tcb_date.is_empty());
+    assert!(!s.qe.tcb_level.tcb_date.is_empty());
+
+    // Verify ring and rustcrypto produce identical claims
+    let rustcrypto_verifier = QuoteVerifier::new_prod();
+    let rc_result = rustcrypto_verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral.clone(),
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let rc = &rc_result;
+    assert_eq!(s.tcb.status, rc.tcb.status);
+    assert_eq!(s.tcb.advisory_ids, rc.tcb.advisory_ids);
+    assert_eq!(s.earliest_expiration_date, rc.earliest_expiration_date);
+    assert_eq!(s.platform.tcb_date_tag, rc.platform.tcb_date_tag);
+    assert_eq!(s.platform.pck_crl_num, rc.platform.pck_crl_num);
+    assert_eq!(s.platform.root_ca_crl_num, rc.platform.root_ca_crl_num);
+    assert_eq!(s.tcb.eval_data_number, rc.tcb.eval_data_number);
+    assert_eq!(s.platform.root_key_id, rc.platform.root_key_id);
+    assert_eq!(s.platform.pck.ppid, rc.platform.pck.ppid);
+    assert_eq!(s.platform.pck.cpu_svn, rc.platform.pck.cpu_svn);
+    assert_eq!(s.platform.pck.pce_svn, rc.platform.pck.pce_svn);
+    assert_eq!(s.platform.pck.pce_id, rc.platform.pck.pce_id);
+    assert_eq!(s.platform.pck.fmspc, rc.platform.pck.fmspc);
+    assert_eq!(s.tee_type, rc.tee_type);
+    assert_eq!(s.platform.pck.sgx_type, rc.platform.pck.sgx_type);
+    assert_eq!(
+        s.platform.pck.platform_instance_id,
+        rc.platform.pck.platform_instance_id
+    );
+    assert_eq!(
+        s.platform.pck.dynamic_platform,
+        rc.platform.pck.dynamic_platform
+    );
+    assert_eq!(s.platform.pck.cached_keys, rc.platform.pck.cached_keys);
+    assert_eq!(s.platform.pck.smt_enabled, rc.platform.pck.smt_enabled);
+}
+
+#[test]
+fn claims_use_quote_embedded_pck_chain_when_collateral_omits_it() {
+    use dcap_qvl::verify::QuoteVerifier;
+
+    let raw_quote = include_bytes!("../sample/sgx_quote").to_vec();
+    let collateral_without_chain: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/sgx_quote_collateral.json")).unwrap();
+    assert!(collateral_without_chain.pck_certificate_chain.is_none());
+    let now = now_from_collateral(&collateral_without_chain);
+
+    let parsed_quote = Quote::decode(&mut &raw_quote[..]).unwrap();
+    let embedded_pem = String::from_utf8_lossy(parsed_quote.raw_cert_chain().unwrap())
+        .trim_end_matches('\0')
+        .to_string();
+
+    let mut collateral_with_chain = collateral_without_chain.clone();
+    collateral_with_chain.pck_certificate_chain = Some(embedded_pem);
+
+    let verifier = QuoteVerifier::new_prod();
+    let without_chain = verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral_without_chain,
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let with_chain = verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral_with_chain,
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+
+    assert_eq!(
+        without_chain.earliest_issue_date,
+        with_chain.earliest_issue_date
+    );
+    assert_eq!(
+        without_chain.latest_issue_date,
+        with_chain.latest_issue_date
+    );
+    assert_eq!(
+        without_chain.earliest_expiration_date,
+        with_chain.earliest_expiration_date
+    );
+}
+
 #[test]
 fn could_parse_tdx_quote() {
     let raw_quote = include_bytes!("../sample/tdx_quote");
@@ -107,4 +332,236 @@ fn could_parse_tdx_quote() {
     let tcb_status = verify(raw_quote, &quote_collateral, now).unwrap();
     assert_eq!(tcb_status.status, "UpToDate");
     assert!(tcb_status.advisory_ids.is_empty());
+}
+
+/// Print key QuoteClaims fields for both SGX and TDX quotes.
+#[test]
+fn print_claims_comparison() {
+    use dcap_qvl::verify::QuoteVerifier;
+
+    fn ts_to_utc(ts: u64) -> String {
+        chrono::DateTime::from_timestamp(ts as i64, 0)
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+            .unwrap_or_else(|| format!("{ts}"))
+    }
+
+    let verifier = QuoteVerifier::new_prod();
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SGX Quote
+    // ═══════════════════════════════════════════════════════════════════
+    println!("\n{:=<80}", "");
+    println!("SGX Quote — QuoteClaims");
+    println!("{:=<80}", "");
+
+    let raw_quote = include_bytes!("../sample/sgx_quote").to_vec();
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/sgx_quote_collateral.json")).unwrap();
+    let now = now_from_collateral(&collateral);
+
+    let result = verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral.clone(),
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let s = &result;
+
+    println!("{:<40} {:?}", "tcb.status", s.tcb.status);
+    println!("{:<40} {:?}", "tcb.advisory_ids", s.tcb.advisory_ids);
+    println!(
+        "{:<40} {} ({})",
+        "tcb.earliest_expiration",
+        s.earliest_expiration_date,
+        ts_to_utc(s.earliest_expiration_date)
+    );
+    println!("{:<40} {}", "tcb.eval_data_number", s.tcb.eval_data_number);
+    println!(
+        "{:<40} {} ({})",
+        "platform.tcb_date_tag",
+        s.platform.tcb_date_tag,
+        ts_to_utc(s.platform.tcb_date_tag)
+    );
+    println!("{:<40} {}", "platform.pck_crl_num", s.platform.pck_crl_num);
+    println!(
+        "{:<40} {}",
+        "platform.root_ca_crl_num", s.platform.root_ca_crl_num
+    );
+    println!(
+        "{:<40} {}...",
+        "platform.root_key_id",
+        hex::encode(&s.platform.root_key_id[..24])
+    );
+    println!(
+        "{:<40} {}",
+        "platform.pck.fmspc",
+        hex::encode(s.platform.pck.fmspc)
+    );
+    println!(
+        "{:<40} {}",
+        "platform.pck.sgx_type", s.platform.pck.sgx_type
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.dynamic_platform", s.platform.pck.dynamic_platform
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.cached_keys", s.platform.pck.cached_keys
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.smt_enabled", s.platform.pck.smt_enabled
+    );
+    println!("{:<40} 0x{:08X}", "tee_type", s.tee_type);
+    println!(
+        "{:<40} {:?}",
+        "platform.tcb_level.tcb_status", s.platform.tcb_level.tcb_status
+    );
+    println!(
+        "{:<40} {:?}",
+        "qe.tcb_level.tcb_status", s.qe.tcb_level.tcb_status
+    );
+
+    // ═══════════════════════════════════════════════════════════════════
+    // TDX Quote
+    // ═══════════════════════════════════════════════════════════════════
+    println!("\n{:=<80}", "");
+    println!("TDX Quote — QuoteClaims");
+    println!("{:=<80}", "");
+
+    let raw_quote_tdx = include_bytes!("../sample/tdx_quote");
+    let collateral_tdx: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/tdx_quote_collateral.json")).unwrap();
+    let now_tdx = now_from_collateral(&collateral_tdx);
+
+    let result_tdx = verifier
+        .verify_with_policy(
+            raw_quote_tdx,
+            collateral_tdx.clone(),
+            now_tdx,
+            &dcap_qvl::QuotePolicy::claims_only(now_tdx),
+        )
+        .unwrap();
+    let t = &result_tdx;
+
+    println!("{:<40} {:?}", "tcb.status", t.tcb.status);
+    println!("{:<40} {:?}", "tcb.advisory_ids", t.tcb.advisory_ids);
+    println!(
+        "{:<40} {} ({})",
+        "tcb.earliest_expiration",
+        t.earliest_expiration_date,
+        ts_to_utc(t.earliest_expiration_date)
+    );
+    println!("{:<40} {}", "tcb.eval_data_number", t.tcb.eval_data_number);
+    println!(
+        "{:<40} {} ({})",
+        "platform.tcb_date_tag",
+        t.platform.tcb_date_tag,
+        ts_to_utc(t.platform.tcb_date_tag)
+    );
+    println!("{:<40} {}", "platform.pck_crl_num", t.platform.pck_crl_num);
+    println!(
+        "{:<40} {}",
+        "platform.root_ca_crl_num", t.platform.root_ca_crl_num
+    );
+    println!(
+        "{:<40} {}...",
+        "platform.root_key_id",
+        hex::encode(&t.platform.root_key_id[..24])
+    );
+    println!(
+        "{:<40} {}",
+        "platform.pck.fmspc",
+        hex::encode(t.platform.pck.fmspc)
+    );
+    println!(
+        "{:<40} {}",
+        "platform.pck.sgx_type", t.platform.pck.sgx_type
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.dynamic_platform", t.platform.pck.dynamic_platform
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.cached_keys", t.platform.pck.cached_keys
+    );
+    println!(
+        "{:<40} {:?}",
+        "platform.pck.smt_enabled", t.platform.pck.smt_enabled
+    );
+    println!("{:<40} 0x{:08X}", "tee_type", t.tee_type);
+    println!(
+        "{:<40} {:?}",
+        "platform.tcb_level.tcb_status", t.platform.tcb_level.tcb_status
+    );
+    println!(
+        "{:<40} {:?}",
+        "qe.tcb_level.tcb_status", t.qe.tcb_level.tcb_status
+    );
+}
+
+/// Cross-validate TDX claims fields.
+#[test]
+fn tdx_claims_cross_validation() {
+    use dcap_qvl::verify::QuoteVerifier;
+
+    let raw_quote = include_bytes!("../sample/tdx_quote");
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/tdx_quote_collateral.json")).unwrap();
+    let now = now_from_collateral(&collateral);
+
+    let verifier = QuoteVerifier::new_prod();
+    let result = verifier
+        .verify_with_policy(
+            raw_quote,
+            collateral.clone(),
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let s = &result;
+
+    // TDX quote should have tee_type = 0x81
+    assert_eq!(s.tee_type, 0x00000081);
+    assert_eq!(s.tcb.status.to_string(), "UpToDate");
+    assert!(s.tcb.advisory_ids.is_empty());
+
+    // Fields should be populated (computed lazily in claims())
+    assert!(s.earliest_expiration_date > 0);
+    assert!(s.platform.tcb_date_tag > 0);
+
+    // root_key_id should match SHA-384 of Intel root CA raw public key bytes
+    let root_ca_der = include_bytes!("../src/TrustedRootCA.der");
+    let root_cert: x509_cert::Certificate = DerDecode::from_der(root_ca_der).unwrap();
+    let raw_pub_key = root_cert
+        .tbs_certificate()
+        .subject_public_key_info()
+        .subject_public_key
+        .raw_bytes();
+    let expected_root_key_id: [u8; 48] = {
+        use sha2::Digest;
+        sha2::Sha384::digest(raw_pub_key).into()
+    };
+    assert_eq!(s.platform.root_key_id, expected_root_key_id);
+
+    // Verify ring == rustcrypto for all fields
+    let rc_verifier = QuoteVerifier::new_prod();
+    let rc_result = rc_verifier
+        .verify_with_policy(
+            raw_quote,
+            collateral.clone(),
+            now,
+            &dcap_qvl::QuotePolicy::claims_only(now),
+        )
+        .unwrap();
+    let rc = &rc_result;
+    assert_eq!(s.tee_type, rc.tee_type);
+    assert_eq!(s.tcb.status, rc.tcb.status);
+    assert_eq!(s.platform.root_key_id, rc.platform.root_key_id);
+    assert_eq!(s.earliest_expiration_date, rc.earliest_expiration_date);
+    assert_eq!(s.tcb.eval_data_number, rc.tcb.eval_data_number);
 }

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
 
 #[cfg(feature = "danger-allow-tcb-override")]
 mod tests {
@@ -17,14 +22,17 @@ mod tests {
         collateral: &QuoteCollateralV3,
         now_secs: u64,
     ) -> anyhow::Result<VerifiedReport> {
-        use dcap_qvl::verify::{ring, rustcrypto};
-        let ring_result = ring::verify(raw_quote, collateral, now_secs);
-        let rustcrypto_result = rustcrypto::verify(raw_quote, collateral, now_secs);
+        use dcap_qvl::verify::QuoteVerifier;
+        let ring_verifier = QuoteVerifier::new_prod();
+        let rustcrypto_verifier = QuoteVerifier::new_prod();
+
+        let ring_result = ring_verifier.verify(raw_quote, collateral, now_secs);
+        let rustcrypto_result = rustcrypto_verifier.verify(raw_quote, collateral, now_secs);
         assert_eq!(
             ring_result.map_err(|e| e.to_string()),
             rustcrypto_result.map_err(|e| e.to_string())
         );
-        ring::verify(raw_quote, collateral, now_secs)
+        ring_verifier.verify(raw_quote, collateral, now_secs)
     }
 
     fn dangerous_verify_with_tcb_override<F>(
@@ -36,14 +44,17 @@ mod tests {
     where
         F: FnOnce(TcbInfo) -> TcbInfo + Copy,
     {
-        use dcap_qvl::verify::{ring, rustcrypto};
-        let ring_result = ring::dangerous_verify_with_tcb_override(
+        use dcap_qvl::verify::QuoteVerifier;
+        let ring_verifier = QuoteVerifier::new_prod();
+        let rustcrypto_verifier = QuoteVerifier::new_prod();
+
+        let ring_result = ring_verifier.dangerous_verify_with_tcb_override(
             raw_quote,
             collateral,
             now_secs,
             override_tcb_info,
         );
-        let rustcrypto_result = rustcrypto::dangerous_verify_with_tcb_override(
+        let rustcrypto_result = rustcrypto_verifier.dangerous_verify_with_tcb_override(
             raw_quote,
             collateral,
             now_secs,
@@ -53,7 +64,12 @@ mod tests {
             ring_result.map_err(|e| e.to_string()),
             rustcrypto_result.map_err(|e| e.to_string())
         );
-        ring::dangerous_verify_with_tcb_override(raw_quote, collateral, now_secs, override_tcb_info)
+        ring_verifier.dangerous_verify_with_tcb_override(
+            raw_quote,
+            collateral,
+            now_secs,
+            override_tcb_info,
+        )
     }
 
     fn force_out_of_date(mut tcb_info: TcbInfo) -> TcbInfo {
@@ -106,7 +122,8 @@ mod tests {
         }
 
         fn parse_crl_bounds(crl_der: &[u8]) -> (u64, Option<u64>) {
-            let crl = CertificateList::from_der(crl_der).expect("CRL parse");
+            let crl: CertificateList<x509_cert::certificate::Rfc5280> =
+                CertificateList::from_der(crl_der).expect("CRL parse");
             let this_update = crl.tbs_cert_list.this_update.to_unix_duration().as_secs();
             let next_update = crl
                 .tbs_cert_list
@@ -141,7 +158,7 @@ mod tests {
 
     #[test]
     fn override_can_change_tcb_result_and_runs_once() {
-        use dcap_qvl::verify::ring;
+        use dcap_qvl::verify::QuoteVerifier;
 
         let raw_quote = include_bytes!("../sample/tdx_quote");
         let raw_quote_collateral = include_bytes!("../sample/tdx_quote_collateral.json");
@@ -154,19 +171,21 @@ mod tests {
 
         static OVERRIDE_CALLS: AtomicUsize = AtomicUsize::new(0);
         OVERRIDE_CALLS.store(0, Ordering::SeqCst);
-        let ring_overridden = ring::dangerous_verify_with_tcb_override(
-            raw_quote,
-            &quote_collateral,
-            now,
-            |mut tcb_info| {
-                OVERRIDE_CALLS.fetch_add(1, Ordering::SeqCst);
-                for level in &mut tcb_info.tcb_levels {
-                    level.tcb_status = TcbStatus::OutOfDate;
-                }
-                tcb_info
-            },
-        )
-        .expect("verify with override");
+        let ring_verifier = QuoteVerifier::new_prod();
+        let ring_overridden = ring_verifier
+            .dangerous_verify_with_tcb_override(
+                raw_quote,
+                &quote_collateral,
+                now,
+                |mut tcb_info| {
+                    OVERRIDE_CALLS.fetch_add(1, Ordering::SeqCst);
+                    for level in &mut tcb_info.tcb_levels {
+                        level.tcb_status = TcbStatus::OutOfDate;
+                    }
+                    tcb_info
+                },
+            )
+            .expect("verify with override");
         assert_eq!(OVERRIDE_CALLS.load(Ordering::SeqCst), 1);
         assert_eq!(ring_overridden.status, "OutOfDate");
 
@@ -238,7 +257,7 @@ mod tests {
     #[test]
     fn overlong_sgx_components_are_rejected() {
         assert_sgx_count_mismatch_rejected(|c| {
-            c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4))
+            c.extend(std::iter::repeat_n(TcbComponents { svn: 0 }, 4))
         });
     }
 
@@ -250,7 +269,7 @@ mod tests {
     #[test]
     fn overlong_tdx_components_are_rejected() {
         assert_tdx_count_mismatch_rejected(|c| {
-            c.extend(std::iter::repeat(TcbComponents { svn: 0 }).take(4))
+            c.extend(std::iter::repeat_n(TcbComponents { svn: 0 }, 4))
         });
     }
 

--- a/tests/vite/src/main.ts
+++ b/tests/vite/src/main.ts
@@ -1,6 +1,6 @@
 import "./style.css";
 
-import init, { js_verify, js_get_collateral } from "@phala/dcap-qvl-web";
+import init, { QuoteVerifier, QuotePolicy } from "@phala/dcap-qvl-web";
 import wasm from "@phala/dcap-qvl-web/dcap-qvl-web_bg.wasm";
 
 const PCCS_URL = "https://pccs.phala.network/tdx/certification/v4";
@@ -16,16 +16,13 @@ async function fetchQuoteAsUint8Array(url: string): Promise<Uint8Array> {
 
 init(wasm).then(() => {
   console.log("Phala DCAP QVL initialized!");
-  // You can now use js_verify, js_get_collateral, etc.
   fetchQuoteAsUint8Array("/sample/tdx_quote").then(async (rawQuote) => {
-    const quoteCollateral = await js_get_collateral(PCCS_URL, rawQuote);
-    
-    // Current timestamp
+    const quoteCollateral = await QuoteVerifier.get_collateral(PCCS_URL, rawQuote);
     const now = BigInt(Math.floor(Date.now() / 1000));
-
-    // Call the js_verify function
-    const result = js_verify(rawQuote, quoteCollateral, now);
-    console.log("Verification Result:", result);
+    const verifier = new QuoteVerifier();
+    const policy = new QuotePolicy(now);
+    const report = verifier.verify_with_policy(rawQuote, quoteCollateral, now, policy);
+    console.log("Verification Result:", report);
   });
 }).catch((error: unknown) => {
   console.error("Error:", error);


### PR DESCRIPTION
## Summary

Reimplements the useful parts of #112 on current `master`, with claims—not an embedded policy engine—as the downstream policy boundary.

- keeps `QuoteVerifier::verify()` as the one-shot API returning `VerifiedReport`; its backend is selected by the verifier type
- adds `verify_with_policy()`, which returns detailed claims and takes an explicit trusted `now` timestamp
- makes `QuoteVerifier<C = DefaultConfig>` generic over the crypto/X.509 configuration; use `.with_config::<C>()` to select another backend
- removes the redundant method-level `verify_with::<C>()` API
- makes `QuoteClaims` fully Serde serializable and versions its schema with `claims_version`
- includes the authenticated quote header, report body, merged and unmerged TCB results, advisories, PCK identity and platform flags, QE report, root key ID, CRL numbers, and collateral time windows
- does **not** expose a mandatory two-phase intermediate result
- does **not** embed Rego or another policy engine; applications can pass serialized claims to a shared cross-TEE policy engine
- exposes direct claims output to Python and WASM
- preserves C/Go/mobile one-shot behavior and current generic `Config`, X.509, and crypto backend support
- retains TDX module identity, TCB canonicalization, debug/service-TD, and component-length checks from current `master`

The branch is squashed to one commit.

## API

Existing compatible API:

```rust
let report = QuoteVerifier::new_prod().verify(&quote, &collateral, now)?;
```

Detailed claims for a downstream policy engine:

```rust
let claims = QuoteVerifier::new_prod().verify_with_policy(
    &quote, collateral, now, &QuotePolicy::claims_only(now),
)?;
let policy_input = serde_json::to_value(&claims)?;
```

Optional built-in quote policy:

```rust
let claims = QuoteVerifier::new_prod().verify_with_policy(
    &quote,
    collateral,
    now,
    &QuotePolicy::strict(now),
)?;
```

## Validation

- `cargo test --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo build --target wasm32-unknown-unknown --features js`
- CLI build
- Python bindings: 25 passed, 4 skipped
- Mobile Rust bindings: 4 sample tests passed
- generic backend conformance tests pass

Supersedes #112.


