### PR TITLE
fix: address quote policy review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ runnable examples.
 Applications can request detailed serializable claims and optionally apply the built-in policy:
 
 ```rust
-use dcap_qvl::{QuoteVerifier, QuotePolicy, TcbStatus};
+use dcap_qvl::{QuotePolicy, TcbStatus};
+use dcap_qvl::verify::QuoteVerifier;
 
 let policy = QuotePolicy::strict(now)
     .allow_status(TcbStatus::SWHardeningNeeded)

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,9 +32,6 @@ the `PCCS_URL` environment variable:
 
 ```bash
 PCCS_URL=https://your-pccs/sgx/certification/v4/ dcap-qvl verify quote.bin
-
-# Require a strict UpToDate policy appraisal
-dcap-qvl verify --strict quote.bin
 ```
 
 The verified report is printed as JSON on stdout; progress goes to stderr.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -18,7 +18,7 @@ or other TEE verifiers and evaluate them with its own policy engine.
 
 ## QuotePolicy
 
-The built-in policy with 9 checks from Intel's Appraisal framework. Strict by default — only `UpToDate` status, no grace period, no advisory blacklist.
+The built-in policy with 10 checks inspired by Intel's Appraisal framework. Strict by default — only `UpToDate` status, no TCB grace period, no advisory blacklist.
 
 ### Basic Usage
 
@@ -43,12 +43,13 @@ let policy = QuotePolicy::strict(now)
     // Accept additional TCB statuses
     .allow_status(TcbStatus::SWHardeningNeeded)
     .allow_status(TcbStatus::ConfigurationNeeded)
+    // OutOfDate must be both allowed and within the platform grace window
+    .allow_status(TcbStatus::OutOfDate)
+    .platform_grace_period(Duration::from_secs(30 * 24 * 3600))
     // Reject specific advisory IDs (case-insensitive)
     .reject_advisory("INTEL-SA-00334")
     .reject_advisory("INTEL-SA-00615")
     .reject_advisories(&["INTEL-SA-00809", "INTEL-SA-00820"])
-    // Collateral freshness: accept expired collateral within grace window
-    .collateral_grace_period(Duration::from_secs(30 * 24 * 3600)) // 30 days
     // Minimum TCB evaluation data number
     .min_tcb_eval_data_number(17)
     // Platform flags (default: reject True)
@@ -59,13 +60,13 @@ let policy = QuotePolicy::strict(now)
     .accepted_sgx_types(&[0, 1]); // Standard + Scalable
 ```
 
-### The 9 Checks
+### The 10 Checks
 
 | # | Check | Default | Builder |
 |---|-------|---------|---------|
 | 1 | **TCB status whitelist** | Only `UpToDate` | `.allow_status(...)` |
 | 2 | **Advisory ID blacklist** | Empty set (allow all) | `.reject_advisory(...)` |
-| 3 | **Collateral expiration** | `earliest_expiration >= now` | `.collateral_grace_period(Duration)` |
+| 3 | **Collateral expiration** | `earliest_expiration >= now` | Not configurable |
 | 4 | **Platform TCB freshness** | Only for OutOfDate statuses | `.platform_grace_period(Duration)` |
 | 4b | **QE TCB freshness** | Only for QE `OutOfDate` | `.qe_grace_period(Duration)` |
 | 5 | **Min TCB eval data number** | Skip | `.min_tcb_eval_data_number(n)` |
@@ -76,13 +77,13 @@ let policy = QuotePolicy::strict(now)
 
 ### Grace Period Behavior
 
-**Collateral grace** (`collateral_grace_period`): Extends the collateral expiration window. If `earliest_expiration + grace >= now`, the quote is accepted.
+Expired collateral is always rejected by the cryptographic verification pipeline. There is no collateral expiration grace period.
 
-**Platform grace** (`platform_grace_period`): Applies only to the **platform** TCB level. For `OutOfDate` / `OutOfDateConfigurationNeeded`, checks `platform.tcb_date_tag + grace >= now`. For pure `OutOfDate`, only the **platform** advisories are skipped during the grace window. For `OutOfDateConfigurationNeeded`, platform advisories are still checked.
+**Platform grace** (`platform_grace_period`): Applies only to the **platform** TCB level. For `OutOfDate` / `OutOfDateConfigurationNeeded`, checks `platform.tcb_date_tag + grace >= now`. The corresponding status must also be explicitly enabled with `allow_status`; setting either option alone does not accept an out-of-date platform.
 
-**QE grace** (`qe_grace_period`): Applies only to the **QE** TCB level. For QE `OutOfDate`, checks `qe.tcb_level.tcb_date + grace >= now`. QE advisories are skipped only while this QE grace is active.
+**QE grace** (`qe_grace_period`): Applies only to the **QE** TCB level. For QE `OutOfDate`, checks `qe.tcb_level.tcb_date + grace >= now`. Because the merged verdict is also out of date, the corresponding merged status must be enabled with `allow_status`.
 
-`collateral_grace_period` is **mutually exclusive** with the TCB grace windows — setting it together with `platform_grace_period` or `qe_grace_period` causes a validation error.
+Advisory blacklists are enforced regardless of whether a platform or QE is inside a grace window.
 
 ### Platform Flags (Three-State)
 

--- a/python-bindings/python/dcap_qvl/__init__.py
+++ b/python-bindings/python/dcap_qvl/__init__.py
@@ -5,7 +5,7 @@ This package provides Python bindings for the DCAP (Data Center Attestation Prim
 quote verification library implemented in Rust.
 
 Claims API (matches Rust):
-1. verify(quote, collateral, now_secs) -> QuoteClaims
+1. verify(quote, collateral, now_secs) -> VerifiedReport
 2. QuoteVerifier.verify_with_policy(...) -> QuoteClaims
 
 Main classes:
@@ -15,7 +15,7 @@ Main classes:
 - QuoteClaims: Detailed serializable claims for downstream policy engines
 
 Main functions:
-- verify: Verify a quote with collateral data (returns QuoteClaims)
+- verify: Verify a quote with collateral data (returns VerifiedReport)
 - get_collateral: Get collateral from PCCS URL
 - get_collateral_from_pcs: Get collateral from Intel PCS
 - get_collateral_and_verify: Get collateral and verify quote
@@ -80,7 +80,7 @@ async def get_collateral_and_verify(
     raw_quote: bytes,
     pccs_url: Optional[str] = None,
 ) -> VerifiedReport:
-    """Get collateral and verify the quote, returning detailed claims.
+    """Get collateral and verify the quote, returning a verified report.
 
     Args:
         raw_quote: Raw quote bytes

--- a/python-bindings/python/dcap_qvl/_dcap_qvl.pyi
+++ b/python-bindings/python/dcap_qvl/_dcap_qvl.pyi
@@ -322,9 +322,9 @@ class PyQuotePolicy:
     Example::
 
         policy = QuotePolicy.strict(now_secs) \\
-            .allow_status("SWHardeningNeeded") \\
+            .allow_status("OutOfDate") \\
             .reject_advisory("INTEL-SA-00334") \\
-            .collateral_grace_period(90 * 24 * 3600) \\
+            .platform_grace_period(90 * 24 * 3600) \\
             .qe_grace_period(7 * 24 * 3600)
     """
 
@@ -346,10 +346,6 @@ class PyQuotePolicy:
 
     def reject_advisories(self, advisory_ids: List[str]) -> "PyQuotePolicy":
         """Reject multiple advisory IDs at once."""
-        ...
-
-    def collateral_grace_period(self, secs: int) -> "PyQuotePolicy":
-        """Set collateral grace period in seconds."""
         ...
 
     def platform_grace_period(self, secs: int) -> "PyQuotePolicy":

--- a/python-bindings/tests/test_python_bindings.py
+++ b/python-bindings/tests/test_python_bindings.py
@@ -115,7 +115,11 @@ class TestWithSampleData:
             json.loads(collateral_json["tcb_info"])["issueDate"],
             json.loads(collateral_json["qe_identity"])["issueDate"],
         ]
-        now = max(int(datetime.fromisoformat(value).timestamp()) for value in issue_dates)
+        # `fromisoformat` only accepts a trailing "Z" on Python >= 3.11.
+        now = max(
+            int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp())
+            for value in issue_dates
+        )
 
         report = dcap_qvl.verify(quote_data, collateral, now)
         assert isinstance(report, dcap_qvl.VerifiedReport)

--- a/python-bindings/tests/test_python_bindings.py
+++ b/python-bindings/tests/test_python_bindings.py
@@ -107,10 +107,24 @@ class TestWithSampleData:
 
         collateral = dcap_qvl.QuoteCollateralV3.from_json(json.dumps(collateral_json))
 
-        result = dcap_qvl.verify(quote_data, collateral, 1234567890)
+        # Pick a time inside the signed collateral JSON validity windows rather
+        # than a hard-coded pre-DCAP timestamp.
+        from datetime import datetime
 
-        assert isinstance(result, dcap_qvl.QuoteClaims)
-        claims = json.loads(result.to_json())
+        issue_dates = [
+            json.loads(collateral_json["tcb_info"])["issueDate"],
+            json.loads(collateral_json["qe_identity"])["issueDate"],
+        ]
+        now = max(int(datetime.fromisoformat(value).timestamp()) for value in issue_dates)
+
+        report = dcap_qvl.verify(quote_data, collateral, now)
+        assert isinstance(report, dcap_qvl.VerifiedReport)
+
+        claims = dcap_qvl.QuoteVerifier().verify_with_policy(
+            quote_data, collateral, now, dcap_qvl.QuotePolicy.claims_only(now)
+        )
+        assert isinstance(claims, dcap_qvl.QuoteClaims)
+        claims = json.loads(claims.to_json())
         assert "tcb" in claims
         assert "platform" in claims
         assert "qe" in claims

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -33,8 +33,8 @@ pub use simple::{QuotePolicy, QuotePolicyConfig};
 /// let now_unix_secs = 1_700_000_000u64;
 ///
 /// let policy = QuotePolicy::strict(now_unix_secs)
-///     .allow_status(TcbStatus::SWHardeningNeeded)
-///     .collateral_grace_period(Duration::from_secs(90 * 24 * 3600))
+///     .allow_status(TcbStatus::OutOfDate)
+///     .platform_grace_period(Duration::from_secs(90 * 24 * 3600))
 ///     .reject_advisory("INTEL-SA-00334");
 /// ```
 ///

--- a/src/policy/simple.rs
+++ b/src/policy/simple.rs
@@ -316,6 +316,9 @@ impl Policy for QuotePolicy {
 /// All fields default to the strict values (zero / empty / false).
 /// Pass as JSON from FFI (Go, Python) to configure verification policy.
 ///
+/// Unknown fields are rejected so that a stale or misspelled option in a
+/// security policy fails loudly instead of being silently ignored.
+///
 /// ```json
 /// {
 ///   "allowed_statuses": ["UpToDate", "SWHardeningNeeded"],
@@ -325,6 +328,7 @@ impl Policy for QuotePolicy {
 /// }
 /// ```
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QuotePolicyConfig {
     #[serde(default)]
     pub allowed_statuses: Vec<TcbStatus>,
@@ -804,5 +808,46 @@ mod tests {
             .allow_status(OutOfDate)
             .qe_grace_period(Duration::from_secs(13_000_000));
         assert!(policy.validate(&data).is_ok());
+    }
+
+    // -- QuotePolicyConfig --
+
+    #[test]
+    fn policy_config_default_is_strict() {
+        let config: QuotePolicyConfig = serde_json::from_str("{}").unwrap();
+        let policy = config.into_policy(1_702_000_000);
+        assert!(policy.validate(&make_test_claims(UpToDate)).is_ok());
+        let err = policy
+            .validate(&make_test_claims(SWHardeningNeeded))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not acceptable"), "{err}");
+    }
+
+    #[test]
+    fn policy_config_into_policy_applies_fields() {
+        let config: QuotePolicyConfig = serde_json::from_str(
+            r#"{
+                "allowed_statuses": ["UpToDate", "SWHardeningNeeded"],
+                "rejected_advisory_ids": ["INTEL-SA-00334"],
+                "allow_smt": true
+            }"#,
+        )
+        .unwrap();
+        let policy = config.into_policy(1_702_000_000);
+        assert!(policy.validate(&make_test_claims(SWHardeningNeeded)).is_ok());
+
+        let mut data = make_test_claims(UpToDate);
+        data.platform.tcb_level.advisory_ids = vec!["intel-sa-00334".to_string()];
+        let err = policy.validate(&data).unwrap_err().to_string();
+        assert!(err.contains("rejected by policy"), "{err}");
+    }
+
+    #[test]
+    fn policy_config_rejects_unknown_fields() {
+        // A stale or misspelled option in a security policy must fail loudly.
+        let result: Result<QuotePolicyConfig, _> =
+            serde_json::from_str(r#"{"collateral_grace_period_secs": 2592000}"#);
+        assert!(result.is_err());
     }
 }

--- a/src/policy/simple.rs
+++ b/src/policy/simple.rs
@@ -835,7 +835,9 @@ mod tests {
         )
         .unwrap();
         let policy = config.into_policy(1_702_000_000);
-        assert!(policy.validate(&make_test_claims(SWHardeningNeeded)).is_ok());
+        assert!(policy
+            .validate(&make_test_claims(SWHardeningNeeded))
+            .is_ok());
 
         let mut data = make_test_claims(UpToDate);
         data.platform.tcb_level.advisory_ids = vec!["intel-sa-00334".to_string()];

--- a/src/policy/simple.rs
+++ b/src/policy/simple.rs
@@ -27,11 +27,11 @@ use {
 /// // Strict: only UpToDate, collateral must not be expired
 /// let policy = QuotePolicy::strict(now);
 ///
-/// // With 90-day collateral grace period
+/// // Allow an out-of-date platform for 90 days after its TCB level date.
 /// use core::time::Duration;
 /// let policy = QuotePolicy::strict(now)
-///     .allow_status(TcbStatus::SWHardeningNeeded)
-///     .collateral_grace_period(Duration::from_secs(90 * 24 * 3600))
+///     .allow_status(TcbStatus::OutOfDate)
+///     .platform_grace_period(Duration::from_secs(90 * 24 * 3600))
 ///     .reject_advisory("INTEL-SA-00334");
 /// ```
 #[derive(Clone, Debug)]
@@ -39,9 +39,8 @@ pub struct QuotePolicy {
     claims_only: bool,
     acceptable_statuses: u8,
 
-    // Current time + grace periods (mutually exclusive, default 0 = no tolerance)
+    // Current time + TCB grace periods (default 0 = no tolerance)
     now: u64,
-    collateral_grace_period: u64,
     platform_grace_period: u64,
     qe_grace_period: u64,
 
@@ -87,7 +86,6 @@ impl QuotePolicy {
             claims_only: false,
             acceptable_statuses,
             now,
-            collateral_grace_period: 0,
             platform_grace_period: 0,
             qe_grace_period: 0,
             min_tcb_eval_data_number: None,
@@ -117,13 +115,6 @@ impl QuotePolicy {
     /// Allow an additional TCB status.
     pub fn allow_status(mut self, status: TcbStatus) -> Self {
         self.acceptable_statuses |= Self::status_to_flag(status);
-        self
-    }
-
-    /// Set collateral grace period (default: zero). Accepts quotes where
-    /// `earliest_expiration_date + grace_period >= now`.
-    pub fn collateral_grace_period(mut self, duration: Duration) -> Self {
-        self.collateral_grace_period = duration.as_secs();
         self
     }
 
@@ -222,16 +213,12 @@ impl Policy for QuotePolicy {
             );
         }
 
-        // 3. Collateral expiration: earliest_expiration + grace >= now
-        if data
-            .earliest_expiration_date
-            .saturating_add(self.collateral_grace_period)
-            < self.now
-        {
+        // 3. Collateral expiration. The verification pipeline already enforces
+        // this at the same trusted time; retain the check for delayed appraisal.
+        if data.earliest_expiration_date < self.now {
             bail!(
-                "Collateral expired: earliest_expiration {} + grace {} < now {}",
+                "Collateral expired: earliest_expiration {} < now {}",
                 data.earliest_expiration_date,
-                self.collateral_grace_period,
                 self.now
             );
         }
@@ -333,7 +320,7 @@ impl Policy for QuotePolicy {
 /// {
 ///   "allowed_statuses": ["UpToDate", "SWHardeningNeeded"],
 ///   "rejected_advisory_ids": ["INTEL-SA-00334"],
-///   "collateral_grace_period_secs": 2592000,
+///   "platform_grace_period_secs": 2592000,
 ///   "allow_smt": true
 /// }
 /// ```
@@ -343,8 +330,6 @@ pub struct QuotePolicyConfig {
     pub allowed_statuses: Vec<TcbStatus>,
     #[serde(default)]
     pub rejected_advisory_ids: Vec<String>,
-    #[serde(default)]
-    pub collateral_grace_period_secs: u64,
     #[serde(default)]
     pub platform_grace_period_secs: u64,
     #[serde(default)]
@@ -377,10 +362,6 @@ impl QuotePolicyConfig {
         };
         for id in self.rejected_advisory_ids {
             policy = policy.reject_advisory(id);
-        }
-        if self.collateral_grace_period_secs > 0 {
-            policy = policy
-                .collateral_grace_period(Duration::from_secs(self.collateral_grace_period_secs));
         }
         if self.platform_grace_period_secs > 0 {
             policy =
@@ -587,10 +568,10 @@ mod tests {
         assert!(policy.validate(&data).is_ok());
     }
 
-    // -- Collateral grace period --
+    // -- Collateral expiration --
 
     #[test]
-    fn policy_collateral_expired_no_grace_rejects() {
+    fn policy_collateral_expired_rejects() {
         let data = make_test_claims(UpToDate);
         let policy = QuotePolicy::strict(1_704_000_000);
         let err = policy.validate(&data).unwrap_err().to_string();
@@ -598,24 +579,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_collateral_expired_with_grace_accepts() {
-        let data = make_test_claims(UpToDate);
-        let policy = QuotePolicy::strict(1_704_000_000)
-            .collateral_grace_period(Duration::from_secs(2_000_000));
-        assert!(policy.validate(&data).is_ok());
-    }
-
-    #[test]
-    fn policy_collateral_expired_grace_too_short_rejects() {
-        let data = make_test_claims(UpToDate);
-        let policy = QuotePolicy::strict(1_704_000_000)
-            .collateral_grace_period(Duration::from_secs(500_000));
-        let err = policy.validate(&data).unwrap_err().to_string();
-        assert!(err.contains("Collateral expired"), "{err}");
-    }
-
-    #[test]
-    fn policy_collateral_not_expired_zero_grace_passes() {
+    fn policy_collateral_not_expired_passes() {
         let data = make_test_claims(UpToDate);
         let policy = QuotePolicy::strict(1_702_000_000);
         assert!(policy.validate(&data).is_ok());
@@ -771,18 +735,6 @@ mod tests {
     }
 
     // -- Advisory blacklist during grace --
-
-    #[test]
-    fn policy_blacklist_checked_during_collateral_grace() {
-        let mut data = make_test_claims(UpToDate);
-        data.tcb.advisory_ids = vec!["INTEL-SA-00615".to_string()];
-        data.platform.tcb_level.advisory_ids = vec!["INTEL-SA-00615".to_string()];
-        let policy = QuotePolicy::strict(1_704_000_000)
-            .collateral_grace_period(Duration::from_secs(2_000_000))
-            .reject_advisory("INTEL-SA-00615");
-        let err = policy.validate(&data).unwrap_err().to_string();
-        assert!(err.contains("INTEL-SA-00615"), "{err}");
-    }
 
     #[test]
     fn policy_blacklist_checked_during_platform_grace() {

--- a/src/python.rs
+++ b/src/python.rs
@@ -592,14 +592,6 @@ impl PyQuotePolicy {
             inner: self.inner.clone().reject_advisories(&ids),
         }
     }
-    fn collateral_grace_period(&self, secs: u64) -> Self {
-        Self {
-            inner: self
-                .inner
-                .clone()
-                .collateral_grace_period(Duration::from_secs(secs)),
-        }
-    }
     fn platform_grace_period(&self, secs: u64) -> Self {
         Self {
             inner: self

--- a/src/tcb_info.rs
+++ b/src/tcb_info.rs
@@ -172,13 +172,15 @@ impl TcbStatus {
         }
     }
 
-    fn converge_with_qe(self, qe: TcbStatus) -> TcbStatus {
+    /// Converge a platform status with a QE or TDX module status using Intel's
+    /// appraisal rule for an out-of-date component on a configured platform.
+    pub(crate) fn converge_with_component(self, component: TcbStatus) -> TcbStatus {
         use TcbStatus::*;
-        match (qe, self) {
+        match (component, self) {
             (OutOfDate, ConfigurationNeeded | ConfigurationAndSWHardeningNeeded) => {
                 OutOfDateConfigurationNeeded
             }
-            _ => qe.max(self),
+            _ => component.max(self),
         }
     }
 }
@@ -218,7 +220,7 @@ impl TcbStatusWithAdvisory {
 
     /// Merge a platform status with a QE status using Intel QVL convergence rules.
     pub fn merge(self, other: &TcbStatusWithAdvisory) -> Self {
-        let final_status = self.status.converge_with_qe(other.status);
+        let final_status = self.status.converge_with_component(other.status);
 
         let mut advisory_ids = self.advisory_ids;
         for id in &other.advisory_ids {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use asn1_der::{
     typed::{DerDecodable, Sequence},
     DerObject,
@@ -168,9 +168,10 @@ pub fn extract_crl_number(crl_der: &[u8]) -> Result<u32> {
                 der::asn1::UintRef::from_der(ext.extn_value.as_bytes()).context("CRL number")?;
             let bytes = crl_num.as_bytes();
             // Convert big-endian bytes to u32 (CRL numbers are typically small)
+            ensure!(bytes.len() <= 4, "CRL number too large for u32");
             let mut val: u32 = 0;
             for &b in bytes {
-                val = val.checked_shl(8).context("CRL number too large for u32")? | u32::from(b);
+                val = (val << 8) | u32::from(b);
             }
             return Ok(val);
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -157,9 +157,10 @@ impl QuoteVerificationResult {
         let root_key_id = self.root_key_id;
 
         // CRL numbers
-        let root_ca_crl_num =
-            crate::utils::extract_crl_number(&self.collateral.root_ca_crl).unwrap_or(0);
-        let pck_crl_num = crate::utils::extract_crl_number(&self.collateral.pck_crl).unwrap_or(0);
+        let root_ca_crl_num = crate::utils::extract_crl_number(&self.collateral.root_ca_crl)
+            .context("Failed to extract root CA CRL number")?;
+        let pck_crl_num = crate::utils::extract_crl_number(&self.collateral.pck_crl)
+            .context("Failed to extract PCK CRL number")?;
 
         // tcb_date_tag
         let tcb_date_tag = parse_rfc3339_unix_secs(&self.platform_tcb_level.tcb_date)
@@ -454,7 +455,7 @@ pub fn dangerous_verify_with_tcb_override(
 /// ```js
 /// const policy = new QuotePolicy(now)
 ///     .allow_status("OutOfDate")
-///     .collateral_grace_period(7n * 86400n)
+///     .platform_grace_period(7n * 86400n)
 ///     .allow_smt(true);
 /// ```
 #[cfg(feature = "js")]
@@ -517,15 +518,6 @@ impl JsQuotePolicy {
     pub fn reject_advisories(self, ids: Vec<String>) -> Self {
         Self {
             inner: self.inner.reject_advisories(&ids),
-        }
-    }
-
-    /// Set collateral grace period in seconds.
-    pub fn collateral_grace_period(self, secs: u64) -> Self {
-        Self {
-            inner: self
-                .inner
-                .collateral_grace_period(Duration::from_secs(secs)),
         }
     }
 
@@ -1036,7 +1028,9 @@ fn match_platform_tcb(
             if let Some(module_status) =
                 match_tdx_module_identity(tcb_info, quote).context("TDX module identity check")?
             {
-                matched.tcb_status = matched.tcb_status.max(module_status.status);
+                matched.tcb_status = matched
+                    .tcb_status
+                    .converge_with_component(module_status.status);
                 for advisory in module_status.advisory_ids {
                     if !matched.advisory_ids.contains(&advisory) {
                         matched.advisory_ids.push(advisory);
@@ -1234,6 +1228,9 @@ fn verify_impl(
     let quote = Quote::decode(&mut quote_slice).context("Failed to decode quote")?;
     if !ALLOWED_QUOTE_VERSIONS.contains(&quote.header.version) {
         bail!("Unsupported DCAP quote version");
+    }
+    if quote.header.qe_vendor_id != INTEL_QE_VENDOR_ID {
+        bail!("Unknown QE vendor ID");
     }
     let tee_type = TeeType::from_u32(quote.header.tee_type)?;
     match tee_type {

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -29,7 +29,6 @@ See [TEST_WEB.md](TEST_WEB.md) for detailed web testing documentation.
 ```bash
 cd tests/js
 node verify_quote_node.js
-node verify_quote_rego_node.js
 ```
 
 ### Verify Quote in Web Browser

--- a/tests/js/verify_quote_web_test.js
+++ b/tests/js/verify_quote_web_test.js
@@ -402,9 +402,8 @@ async function runTests() {
         const rootCA = await fetchFile("/test_data/certs/root_ca.der");
         const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const result = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
-        const report = result.into_report_unchecked();
-        if (!report || !report.status) {
+        const claims = new QuoteVerifier(rootCA).verify_with_policy(quote, collateral, now, QuotePolicy.claimsOnly(now));
+        if (!claims || !claims.tcb || !claims.platform || !claims.report) {
             throw new Error(
                 "Verification should succeed for PKS enabled quote"
             );

--- a/tests/near/contracts/gas-test/src/lib.rs
+++ b/tests/near/contracts/gas-test/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use dcap_qvl::{verify::{QuoteVerifier, ring}, QuoteCollateralV3};
+use dcap_qvl::{verify::QuoteVerifier, QuoteCollateralV3};
 use hex::decode;
 use near_sdk::{env, log, near};
 

--- a/tests/verify_quote.rs
+++ b/tests/verify_quote.rs
@@ -19,7 +19,8 @@ pub fn verify(
     use dcap_qvl::verify::QuoteVerifier;
 
     let ring_verifier = QuoteVerifier::new_prod();
-    let rustcrypto_verifier = QuoteVerifier::new_prod();
+    let rustcrypto_verifier =
+        QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RustCryptoConfig>();
 
     let ring_result = ring_verifier
         .with_config::<dcap_qvl::configs::RingConfig>()
@@ -549,7 +550,8 @@ fn tdx_claims_cross_validation() {
     assert_eq!(s.platform.root_key_id, expected_root_key_id);
 
     // Verify ring == rustcrypto for all fields
-    let rc_verifier = QuoteVerifier::new_prod();
+    let rc_verifier =
+        QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RustCryptoConfig>();
     let rc_result = rc_verifier
         .verify_with_policy(
             raw_quote,

--- a/tests/verify_quote.rs
+++ b/tests/verify_quote.rs
@@ -106,6 +106,53 @@ fn could_parse_sgx_quote() {
     );
 }
 
+/// End-to-end policy enforcement through the full verification pipeline:
+/// the strict policy must reject the SGX sample quote (status
+/// ConfigurationAndSWHardeningNeeded with known advisories), allowing the
+/// status must accept it, and blacklisting one of its advisories must
+/// reject it again.
+#[test]
+fn sgx_strict_policy_end_to_end() {
+    use dcap_qvl::verify::QuoteVerifier;
+    use dcap_qvl::{QuotePolicy, TcbStatus};
+
+    let raw_quote = include_bytes!("../sample/sgx_quote").to_vec();
+    let collateral: QuoteCollateralV3 =
+        serde_json::from_slice(include_bytes!("../sample/sgx_quote_collateral.json")).unwrap();
+    let now = now_from_collateral(&collateral);
+    let verifier = QuoteVerifier::new_prod();
+
+    // strict() only accepts UpToDate — the sample must be rejected.
+    let err = verifier
+        .verify_with_policy(
+            &raw_quote,
+            collateral.clone(),
+            now,
+            &QuotePolicy::strict(now),
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not acceptable"), "{err}");
+
+    // Allowing the sample's status makes the same pipeline accept it.
+    let policy =
+        QuotePolicy::strict(now).allow_status(TcbStatus::ConfigurationAndSWHardeningNeeded);
+    let claims = verifier
+        .verify_with_policy(&raw_quote, collateral.clone(), now, &policy)
+        .expect("allowed status must verify");
+    assert_eq!(claims.claims_version, 1);
+
+    // Blacklisting one of the sample's advisories rejects it again.
+    let policy = QuotePolicy::strict(now)
+        .allow_status(TcbStatus::ConfigurationAndSWHardeningNeeded)
+        .reject_advisory("INTEL-SA-00615");
+    let err = verifier
+        .verify_with_policy(&raw_quote, collateral, now, &policy)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("INTEL-SA-00615"), "{err}");
+}
+
 /// Cross-validate all QuoteClaims fields against independently computed values.
 #[test]
 fn sgx_claims_cross_validation() {

--- a/tests/verify_tcb_override.rs
+++ b/tests/verify_tcb_override.rs
@@ -23,8 +23,10 @@ mod tests {
         now_secs: u64,
     ) -> anyhow::Result<VerifiedReport> {
         use dcap_qvl::verify::QuoteVerifier;
-        let ring_verifier = QuoteVerifier::new_prod();
-        let rustcrypto_verifier = QuoteVerifier::new_prod();
+        let ring_verifier =
+            QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RingConfig>();
+        let rustcrypto_verifier =
+            QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RustCryptoConfig>();
 
         let ring_result = ring_verifier.verify(raw_quote, collateral, now_secs);
         let rustcrypto_result = rustcrypto_verifier.verify(raw_quote, collateral, now_secs);
@@ -45,8 +47,10 @@ mod tests {
         F: FnOnce(TcbInfo) -> TcbInfo + Copy,
     {
         use dcap_qvl::verify::QuoteVerifier;
-        let ring_verifier = QuoteVerifier::new_prod();
-        let rustcrypto_verifier = QuoteVerifier::new_prod();
+        let ring_verifier =
+            QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RingConfig>();
+        let rustcrypto_verifier =
+            QuoteVerifier::new_prod().with_config::<dcap_qvl::configs::RustCryptoConfig>();
 
         let ring_result = ring_verifier.dangerous_verify_with_tcb_override(
             raw_quote,


### PR DESCRIPTION
## Summary

Follow-up fixes for the quote claims and policy changes introduced in #208.

- restore the mandatory Intel QE vendor ID check
- remove the unreachable collateral grace-period API while retaining strict collateral expiry appraisal
- converge TDX module status using Intel's out-of-date/configuration rule
- reject CRL numbers that do not fit in the claims schema instead of silently truncating them
- fix Python API documentation and sample integration coverage
- repair the WASM web test and real Ring/RustCrypto cross-backend comparisons
- align README and policy documentation with the implemented TCB grace and advisory behavior

## Breaking API cleanup

The collateral grace period APIs are removed from Rust, Python, and WASM. The verification pipeline rejects expired TCB info, QE identity, certificates, and CRLs before policy appraisal, so this option could never make expired collateral pass when verification and policy used the same trusted time.

Platform and QE TCB grace periods remain available. Out-of-date statuses must be explicitly allowed and must also fall within their configured grace windows. Advisory blacklists continue to apply during grace windows.

## Validation

- cargo test --all-features
- cargo clippy --all-features --all-targets -- -D warnings
- Python source/test syntax compilation
- git diff --check