### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 description = "This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Command line interface for Intel SGX DCAP Quote Verification Library"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5.27", features = ["derive"] }
-dcap-qvl = { version = "0.6.0", path = "../" }
+dcap-qvl = { version = "0.6.1", path = "../" }
 hex = "0.4.3"
 ring = "0.17"
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }

--- a/dcap-qvl-js/package-lock.json
+++ b/dcap-qvl-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/dcap-qvl",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.3.13",

--- a/dcap-qvl-js/package.json
+++ b/dcap-qvl-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pure JavaScript implementation of DCAP Quote Verification Library",
   "type": "commonjs",
   "main": "src/index.js",

--- a/dcap-qvl-mobile/Cargo.toml
+++ b/dcap-qvl-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-mobile"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 description = "UniFFI-powered Kotlin and Swift bindings for dcap-qvl"


### PR DESCRIPTION
Bump Rust, CLI, mobile, and npm package versions to 0.6.1 for the follow-up release after #210.