### PR TITLE
fix(quote): mask PERFMON bit out of reserved_other in TDAttributes::parse

### DIFF
--- a/src/quote.rs
+++ b/src/quote.rs
@@ -204,10 +204,11 @@ impl TDAttributes {
         let kl = (input[3] & 0x80) != 0; // Bit 31
 
         // Extract OTHER flags (bytes 4-7)
-        let reserved_other = ((input[7] as u32) << 24)
+        // Mask bit 7 of input[7] (= PERFMON, bit 63) out of reserved_other.
+        let reserved_other = (((input[7] as u32) & 0x7F) << 24)
             | ((input[6] as u32) << 16)
             | ((input[5] as u32) << 8)
-            | ((input[4] as u32) & 0x7F);
+            | (input[4] as u32);
         let perfmon = (input[7] & 0x80) != 0; // Bit 63
 
         Ok(TDAttributes {


### PR DESCRIPTION
The `input[7]` (bit 63) is `PERFMON` bit according to the [Intel® TDX Module ABI Specification](https://www.intel.com/content/www/us/en/content-details/865801/intel-tdx-module-abi-specification-what-changed.html). This commit fix incorrectly applied & 0x7F mask to input[4] (bit 39, a reserved bit that should be checked).
<img width="1252" height="350" alt="image" src="https://github.com/user-attachments/assets/29c7ad56-d003-44ad-8446-1eaf95ac5089" />
