### PR TITLE
fix(quote): backport PERFMON reserved-bit fix to v0.5.x

### DIFF
--- a/src/quote.rs
+++ b/src/quote.rs
@@ -204,10 +204,11 @@ impl TDAttributes {
         let kl = (input[3] & 0x80) != 0; // Bit 31
 
         // Extract OTHER flags (bytes 4-7)
-        let reserved_other = ((input[7] as u32) << 24)
+        // Mask bit 7 of input[7] (= PERFMON, bit 63) out of reserved_other.
+        let reserved_other = (((input[7] as u32) & 0x7F) << 24)
             | ((input[6] as u32) << 16)
             | ((input[5] as u32) << 8)
-            | ((input[4] as u32) & 0x7F);
+            | (input[4] as u32);
         let perfmon = (input[7] & 0x80) != 0; // Bit 63
 
         Ok(TDAttributes {


### PR DESCRIPTION
## Summary

Backport #218 to the `release-v0.5.x` branch created from `v0.5.2`.

- exclude TDATTRIBUTES bit 63 (`PERFMON`) from `reserved_other`
- keep bit 39 in the reserved-bit validation

## Testing

- `cargo fmt --check`
- `cargo test --lib` (35 passed)
