### PR TITLE
chore(release): bump version to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 description = "This crate implements the quote verification logic for DCAP (Data Center Attestation Primitives) in pure Rust."

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-cli"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Command line interface for Intel SGX DCAP Quote Verification Library"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5.27", features = ["derive"] }
-dcap-qvl = { version = "0.6.2", path = "../" }
+dcap-qvl = { version = "0.6.3", path = "../" }
 hex = "0.4.3"
 ring = "0.17"
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }

--- a/dcap-qvl-js/package-lock.json
+++ b/dcap-qvl-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/dcap-qvl",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.3.13",

--- a/dcap-qvl-js/package.json
+++ b/dcap-qvl-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dcap-qvl",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pure JavaScript implementation of DCAP Quote Verification Library",
   "type": "commonjs",
   "main": "src/index.js",

--- a/dcap-qvl-mobile/Cargo.toml
+++ b/dcap-qvl-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-qvl-mobile"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 description = "UniFFI-powered Kotlin and Swift bindings for dcap-qvl"


### PR DESCRIPTION
Release 0.6.3.

## Changes since v0.6.2

- `feat(collateral)`: let callers choose the TCB evaluation data set
  (`TcbEvaluationDataSet::{Standard,Early,Number}` +
  `CollateralClient::with_evaluation_data_set`) (#223)
- `fix(ci)`: bump maturin to 1.15 so the Linux aarch64 Python wheels link again (#224)

Purely additive API surface, no breaking changes, so this is a patch bump.